### PR TITLE
Add missing volumes mounts for node wiper

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -363,11 +363,12 @@
 
 [[projects]]
   branch = "release-6.0"
-  digest = "1:84c69696ab84712ce74b813dc1222fc1206e49be015a8ecaa4b05f0fd07b3c0c"
+  digest = "1:84bdb388ad5babcefc31f5e553ff8e2e8f3dc4b0453e382da0e36b2f010f6400"
   name = "github.com/libopenstorage/openstorage"
   packages = [
     "api",
     "pkg/auth",
+    "pkg/dbg",
     "pkg/grpcserver",
     "pkg/util",
     "volume",
@@ -1370,11 +1371,13 @@
     "github.com/google/shlex",
     "github.com/hashicorp/go-version",
     "github.com/libopenstorage/openstorage/api",
+    "github.com/libopenstorage/openstorage/pkg/dbg",
     "github.com/libopenstorage/openstorage/pkg/grpcserver",
     "github.com/portworx/kvdb",
     "github.com/portworx/kvdb/consul",
     "github.com/portworx/kvdb/etcd/v2",
     "github.com/portworx/kvdb/etcd/v3",
+    "github.com/portworx/kvdb/mem",
     "github.com/portworx/sched-ops/k8s",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
@@ -1384,7 +1387,6 @@
     "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/reflection",
     "k8s.io/api/apps/v1",
-    "k8s.io/api/apps/v1beta2",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/api/rbac/v1",

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -2,13 +2,10 @@ package portworx
 
 import (
 	"context"
-	"io/ioutil"
-	"path"
 	"testing"
 
 	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
 	"github.com/portworx/sched-ops/k8s"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -16,13 +13,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakek8sclient "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -1950,105 +1945,4 @@ func TestDisableCSI(t *testing.T) {
 	statefulSet = &appsv1.StatefulSet{}
 	err = get(k8sClient, statefulSet, csiStatefulSetName, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-}
-
-func list(k8sClient client.Client, obj runtime.Object) error {
-	return k8sClient.List(context.TODO(), &client.ListOptions{}, obj)
-}
-
-func get(k8sClient client.Client, obj runtime.Object, name, namespace string) error {
-	return k8sClient.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		},
-		obj,
-	)
-}
-
-func deleteObj(k8sClient client.Client, obj runtime.Object) error {
-	return k8sClient.Delete(context.TODO(), obj)
-}
-
-func getExpectedClusterRole(t *testing.T, fileName string) *rbacv1.ClusterRole {
-	obj := getKubernetesObject(t, fileName)
-	clusterRole, ok := obj.(*rbacv1.ClusterRole)
-	assert.True(t, ok, "Expected ClusterRole object")
-	return clusterRole
-}
-
-func getExpectedClusterRoleBinding(t *testing.T, fileName string) *rbacv1.ClusterRoleBinding {
-	obj := getKubernetesObject(t, fileName)
-	crb, ok := obj.(*rbacv1.ClusterRoleBinding)
-	assert.True(t, ok, "Expected ClusterRoleBinding object")
-	return crb
-}
-
-func getExpectedRole(t *testing.T, fileName string) *rbacv1.Role {
-	obj := getKubernetesObject(t, fileName)
-	role, ok := obj.(*rbacv1.Role)
-	assert.True(t, ok, "Expected Role object")
-	return role
-}
-
-func getExpectedRoleBinding(t *testing.T, fileName string) *rbacv1.RoleBinding {
-	obj := getKubernetesObject(t, fileName)
-	roleBinding, ok := obj.(*rbacv1.RoleBinding)
-	assert.True(t, ok, "Expected RoleBinding object")
-	return roleBinding
-}
-
-func getExpectedService(t *testing.T, fileName string) *v1.Service {
-	obj := getKubernetesObject(t, fileName)
-	service, ok := obj.(*v1.Service)
-	assert.True(t, ok, "Expected Service object")
-	return service
-}
-
-func getExpectedDeployment(t *testing.T, fileName string) *appsv1.Deployment {
-	obj := getKubernetesObject(t, fileName)
-	deployment, ok := obj.(*appsv1.Deployment)
-	assert.True(t, ok, "Expected Deployment object")
-	return deployment
-}
-
-func getExpectedStatefulSet(t *testing.T, fileName string) *appsv1.StatefulSet {
-	obj := getKubernetesObject(t, fileName)
-	statefulSet, ok := obj.(*appsv1.StatefulSet)
-	assert.True(t, ok, "Expected StatefulSet object")
-	return statefulSet
-}
-
-func getExpectedDaemonSet(t *testing.T, fileName string) *appsv1.DaemonSet {
-	obj := getKubernetesObject(t, fileName)
-	daemonSet, ok := obj.(*appsv1.DaemonSet)
-	assert.True(t, ok, "Expected DaemonSet object")
-	return daemonSet
-}
-
-func getKubernetesObject(t *testing.T, fileName string) runtime.Object {
-	json, err := ioutil.ReadFile(path.Join("testspec", fileName))
-	assert.NoError(t, err)
-	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode([]byte(json), nil, nil)
-	assert.NoError(t, err)
-	return obj
-}
-
-func getImageForContainer(deployment *appsv1.Deployment, containerName string) string {
-	for _, c := range deployment.Spec.Template.Spec.Containers {
-		if c.Name == containerName {
-			return c.Image
-		}
-	}
-	return ""
-}
-
-func getPullPolicyForContainer(deployment *appsv1.Deployment, containerName string) v1.PullPolicy {
-	for _, c := range deployment.Spec.Template.Spec.Containers {
-		if c.Name == containerName {
-			return c.ImagePullPolicy
-		}
-	}
-	return ""
 }

--- a/drivers/storage/portworx/testspec/nodeWiper.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiper.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: px-node-wiper
+  namespace: kube-test
+  labels:
+    name: px-node-wiper
+spec:
+  selector:
+    matchLabels:
+      name: px-node-wiper
+  template:
+    metadata:
+      labels:
+        name: px-node-wiper
+    spec:
+      containers:
+      - name: px-node-wiper
+        image: portworx/px-node-wiper:2.1.2-rc1
+        imagePullPolicy: Always
+        args:
+        - -w
+        securityContext:
+          privileged: true
+        readinessProbe:
+          initialDelaySeconds: 30
+          exec:
+            command:
+            - cat
+            - /tmp/px-node-wipe-done
+        volumeMounts:
+        - name: etcpwx
+          mountPath: /etc/pwx
+        - name: hostproc
+          mountPath: /hostproc
+        - name: optpwx
+          mountPath: /opt/pwx
+        - name: dbus
+          mountPath: /var/run/dbus
+        - name: sysdmount
+          mountPath: /etc/systemd/system
+        - name: dev
+          mountPath: /dev
+        - name: lvm
+          mountPath: /run/lvm
+        - name: etc-multipath
+          mountPath: /etc/multipath
+        - name: run-udev-data
+          mountPath: /run/udev/data
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+      restartPolicy: Always
+      serviceAccountName: portworx
+      volumes:
+      - name: etcpwx
+        hostPath:
+          path: /etc/pwx
+      - name: hostproc
+        hostPath:
+          path: /proc
+      - name: optpwx
+        hostPath:
+          path: /opt/pwx
+      - name: dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: sysdmount
+        hostPath:
+          path: /etc/systemd/system
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: etc-multipath
+        hostPath:
+          path: /etc/multipath
+          type: DirectoryOrCreate
+      - name: lvm
+        hostPath:
+          path: /run/lvm
+          type: DirectoryOrCreate
+      - name: run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: sys
+        hostPath:
+          path: /sys

--- a/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: px-node-wiper
+  namespace: kube-test
+  labels:
+    name: px-node-wiper
+spec:
+  selector:
+    matchLabels:
+      name: px-node-wiper
+  template:
+    metadata:
+      labels:
+        name: px-node-wiper
+    spec:
+      containers:
+      - name: px-node-wiper
+        image: portworx/px-node-wiper:2.1.2-rc1
+        imagePullPolicy: Always
+        args:
+        - -w
+        securityContext:
+          privileged: true
+        readinessProbe:
+          initialDelaySeconds: 30
+          exec:
+            command:
+            - cat
+            - /tmp/px-node-wipe-done
+        volumeMounts:
+        - name: etcpwx
+          mountPath: /etc/pwx
+        - name: hostproc
+          mountPath: /hostproc
+        - name: optpwx
+          mountPath: /opt/pwx
+        - name: dbus
+          mountPath: /var/run/dbus
+        - name: sysdmount
+          mountPath: /etc/systemd/system
+        - name: dev
+          mountPath: /dev
+        - name: lvm
+          mountPath: /run/lvm
+        - name: etc-multipath
+          mountPath: /etc/multipath
+        - name: run-udev-data
+          mountPath: /run/udev/data
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+      restartPolicy: Always
+      serviceAccountName: portworx
+      volumes:
+      - name: etcpwx
+        hostPath:
+          path: /var/vcap/store/etc/pwx
+      - name: hostproc
+        hostPath:
+          path: /proc
+      - name: optpwx
+        hostPath:
+          path: /var/vcap/store/opt/pwx
+      - name: dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: sysdmount
+        hostPath:
+          path: /etc/systemd/system
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: etc-multipath
+        hostPath:
+          path: /etc/multipath
+          type: DirectoryOrCreate
+      - name: lvm
+        hostPath:
+          path: /run/lvm
+          type: DirectoryOrCreate
+      - name: run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: sys
+        hostPath:
+          path: /sys

--- a/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: px-node-wiper
+  namespace: kube-test
+  labels:
+    name: px-node-wiper
+spec:
+  selector:
+    matchLabels:
+      name: px-node-wiper
+  template:
+    metadata:
+      labels:
+        name: px-node-wiper
+    spec:
+      containers:
+      - name: px-node-wiper
+        image: portworx/px-node-wiper:2.1.2-rc1
+        imagePullPolicy: Always
+        args:
+        - -w
+        - -r
+        securityContext:
+          privileged: true
+        readinessProbe:
+          initialDelaySeconds: 30
+          exec:
+            command:
+            - cat
+            - /tmp/px-node-wipe-done
+        volumeMounts:
+        - name: etcpwx
+          mountPath: /etc/pwx
+        - name: hostproc
+          mountPath: /hostproc
+        - name: optpwx
+          mountPath: /opt/pwx
+        - name: dbus
+          mountPath: /var/run/dbus
+        - name: sysdmount
+          mountPath: /etc/systemd/system
+        - name: dev
+          mountPath: /dev
+        - name: lvm
+          mountPath: /run/lvm
+        - name: etc-multipath
+          mountPath: /etc/multipath
+        - name: run-udev-data
+          mountPath: /run/udev/data
+          readOnly: true
+        - name: sys
+          mountPath: /sys
+      restartPolicy: Always
+      serviceAccountName: portworx
+      volumes:
+      - name: etcpwx
+        hostPath:
+          path: /etc/pwx
+      - name: hostproc
+        hostPath:
+          path: /proc
+      - name: optpwx
+        hostPath:
+          path: /opt/pwx
+      - name: dbus
+        hostPath:
+          path: /var/run/dbus
+      - name: sysdmount
+        hostPath:
+          path: /etc/systemd/system
+      - name: dev
+        hostPath:
+          path: /dev
+      - name: etc-multipath
+        hostPath:
+          path: /etc/multipath
+          type: DirectoryOrCreate
+      - name: lvm
+        hostPath:
+          path: /run/lvm
+          type: DirectoryOrCreate
+      - name: run-udev-data
+        hostPath:
+          path: /run/udev/data
+      - name: sys
+        hostPath:
+          path: /sys

--- a/drivers/storage/portworx/testutils.go
+++ b/drivers/storage/portworx/testutils.go
@@ -1,0 +1,126 @@
+package portworx
+
+import (
+	"context"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func get(k8sClient client.Client, obj runtime.Object, name, namespace string) error {
+	return k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+		obj,
+	)
+}
+
+func list(k8sClient client.Client, obj runtime.Object) error {
+	return k8sClient.List(context.TODO(), &client.ListOptions{}, obj)
+}
+
+func deleteObj(k8sClient client.Client, obj runtime.Object) error {
+	return k8sClient.Delete(context.TODO(), obj)
+}
+
+func getExpectedClusterRole(t *testing.T, fileName string) *rbacv1.ClusterRole {
+	obj := getKubernetesObject(t, fileName)
+	clusterRole, ok := obj.(*rbacv1.ClusterRole)
+	assert.True(t, ok, "Expected ClusterRole object")
+	return clusterRole
+}
+
+func getExpectedClusterRoleBinding(t *testing.T, fileName string) *rbacv1.ClusterRoleBinding {
+	obj := getKubernetesObject(t, fileName)
+	crb, ok := obj.(*rbacv1.ClusterRoleBinding)
+	assert.True(t, ok, "Expected ClusterRoleBinding object")
+	return crb
+}
+
+func getExpectedRole(t *testing.T, fileName string) *rbacv1.Role {
+	obj := getKubernetesObject(t, fileName)
+	role, ok := obj.(*rbacv1.Role)
+	assert.True(t, ok, "Expected Role object")
+	return role
+}
+
+func getExpectedRoleBinding(t *testing.T, fileName string) *rbacv1.RoleBinding {
+	obj := getKubernetesObject(t, fileName)
+	roleBinding, ok := obj.(*rbacv1.RoleBinding)
+	assert.True(t, ok, "Expected RoleBinding object")
+	return roleBinding
+}
+
+func getExpectedService(t *testing.T, fileName string) *v1.Service {
+	obj := getKubernetesObject(t, fileName)
+	service, ok := obj.(*v1.Service)
+	assert.True(t, ok, "Expected Service object")
+	return service
+}
+
+func getExpectedDeployment(t *testing.T, fileName string) *appsv1.Deployment {
+	obj := getKubernetesObject(t, fileName)
+	deployment, ok := obj.(*appsv1.Deployment)
+	assert.True(t, ok, "Expected Deployment object")
+	return deployment
+}
+
+func getExpectedStatefulSet(t *testing.T, fileName string) *appsv1.StatefulSet {
+	obj := getKubernetesObject(t, fileName)
+	statefulSet, ok := obj.(*appsv1.StatefulSet)
+	assert.True(t, ok, "Expected StatefulSet object")
+	return statefulSet
+}
+
+func getExpectedDaemonSet(t *testing.T, fileName string) *appsv1.DaemonSet {
+	obj := getKubernetesObject(t, fileName)
+	daemonSet, ok := obj.(*appsv1.DaemonSet)
+	assert.True(t, ok, "Expected DaemonSet object")
+	return daemonSet
+}
+
+func getKubernetesObject(t *testing.T, fileName string) runtime.Object {
+	json, err := ioutil.ReadFile(path.Join("testspec", fileName))
+	assert.NoError(t, err)
+	obj, _, err := scheme.Codecs.UniversalDeserializer().Decode([]byte(json), nil, nil)
+	assert.NoError(t, err)
+	return obj
+}
+
+func getImageForContainer(deployment *appsv1.Deployment, containerName string) string {
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		if c.Name == containerName {
+			return c.Image
+		}
+	}
+	return ""
+}
+
+func getPullPolicyForContainer(deployment *appsv1.Deployment, containerName string) v1.PullPolicy {
+	for _, c := range deployment.Spec.Template.Spec.Containers {
+		if c.Name == containerName {
+			return c.ImagePullPolicy
+		}
+	}
+	return ""
+}
+
+func fakeK8sClient(initObjects ...runtime.Object) client.Client {
+	s := scheme.Scheme
+	corev1alpha1.AddToScheme(s)
+	return fake.NewFakeClientWithScheme(s, initObjects...)
+}

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -348,7 +348,7 @@ func (c *Controller) deleteStorageCluster(
 			toDelete.Status.Conditions[foundIndex] = *deleteClusterCondition
 		}
 
-		if err := c.client.Status().Update(context.TODO(), toDelete); err != nil {
+		if err := c.client.Status().Update(context.TODO(), toDelete); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("error updating delete status for StorageCluster %v/%v: %v",
 				toDelete.Namespace, toDelete.Name, err)
 		}

--- a/vendor/github.com/libopenstorage/openstorage/pkg/dbg/log.go
+++ b/vendor/github.com/libopenstorage/openstorage/pkg/dbg/log.go
@@ -1,0 +1,25 @@
+package dbg
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Panicf outputs error message, dumps threads and exits.
+func Panicf(format string, args ...interface{}) {
+	logrus.Warnf(format, args...)
+	err := DumpGoProfile()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	DumpHeap()
+	os.Exit(6)
+}
+
+// Assert Panicf's if the condition evaluates to false.
+func Assert(condition bool, format string, args ...interface{}) {
+	if !condition {
+		Panicf(format, args...)
+	}
+}

--- a/vendor/github.com/libopenstorage/openstorage/pkg/dbg/profile_dump.go
+++ b/vendor/github.com/libopenstorage/openstorage/pkg/dbg/profile_dump.go
@@ -1,0 +1,45 @@
+package dbg
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	path     = "/var/cores/"
+	fnameFmt = "2006-01-02T15:04:05.999999-0700MST"
+)
+
+// DumpGoMemoryTrace output memory profile to logs.
+func DumpGoMemoryTrace() {
+	m := &runtime.MemStats{}
+	runtime.ReadMemStats(m)
+	res := fmt.Sprintf("%#v", m)
+	logrus.Infof("==== Dumping Memory Profile ===")
+	logrus.Infof(res)
+}
+
+// DumpGoProfile output goroutines to file.
+func DumpGoProfile() error {
+	trace := make([]byte, 5120*1024)
+	len := runtime.Stack(trace, true)
+	return ioutil.WriteFile(path+time.Now().Format(fnameFmt)+".stack", trace[:len], 0644)
+}
+
+func DumpHeap() {
+	f, err := os.Create(path + time.Now().Format(fnameFmt) + ".heap")
+	if err != nil {
+		logrus.Errorf("could not create memory profile: %v", err)
+		return
+	}
+	defer f.Close()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		logrus.Errorf("could not write memory profile: %v", err)
+	}
+}


### PR DESCRIPTION
- Wipe metadata only if UninstallAndWipe strategy is selected
- Use k8s client for controller-runtime instead of sched ops in uninstall.go
- Do not error out in storagecluster controller if cluster object is already deleted
- Add unit tests for uninstall/delete workflows in portworx driver

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>