### PR TITLE
Should allow changing service type to cluster ip

### DIFF
--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -493,6 +493,10 @@ func CreateOrUpdateService(
 		toUpdate.Port = newPort.Port
 		toUpdate.TargetPort = newPort.TargetPort
 		toUpdate.Protocol = newPort.Protocol
+		if service.Spec.Type != v1.ServiceTypeLoadBalancer &&
+			service.Spec.Type != v1.ServiceTypeNodePort {
+			toUpdate.NodePort = int32(0)
+		}
 		servicePorts = append(servicePorts, *toUpdate)
 		delete(portMapping, newPort.Name)
 	}


### PR DESCRIPTION
The service update breaks if the service had node ports before and the
type was changed to ClusterIP

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>