### PR TITLE
Detect cloud provider and zone/instances information in controller loop.

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -51,6 +51,8 @@ type portworx struct {
 	lhDeploymentCreated               bool
 	csiStatefulSetCreated             bool
 	sdkConn                           *grpc.ClientConn
+	zoneToInstancesMap                map[string]int
+	cloudProvider                     string
 }
 
 func (p *portworx) String() string {
@@ -66,6 +68,12 @@ func (p *portworx) Init(k8sClient client.Client, recorder record.EventRecorder) 
 		return fmt.Errorf("event recorder cannot be nil")
 	}
 	p.recorder = recorder
+	return nil
+}
+
+func (p *portworx) UpdateDriver(info *storage.UpdateDriverInfo) error {
+	p.zoneToInstancesMap = info.ZoneToInstancesMap
+	p.cloudProvider = info.CloudProvider
 	return nil
 }
 

--- a/drivers/storage/storage.go
+++ b/drivers/storage/storage.go
@@ -9,6 +9,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// UpdateDriverInfo consists of information that the controller
+// wants to convey to the Driver with regards to the cluster and node state.
+type UpdateDriverInfo struct {
+	// ZoneToInstancesMap is a map of zone to number of instances in that zone
+	ZoneToInstancesMap map[string]int
+	// CloudProvider cloud provider where this cluster is running
+	CloudProvider string
+}
+
 // Driver defines an external storage driver interface.
 // Any driver that wants to be used with openstorage operator needs
 // to implement these interfaces.
@@ -17,6 +26,10 @@ type Driver interface {
 	Init(client.Client, record.EventRecorder) error
 	// String returns the string name of the driver
 	String() string
+	// UpdateDriver updates the driver with the current cluster and node conditions.
+	// This API can be extended to provide information other than the StorageCluster
+	// to the drivers from the controller reconcile loop.
+	UpdateDriver(*UpdateDriverInfo) error
 	// ClusterPluginInterface interface to manage storage cluster
 	ClusterPluginInterface
 	// StorkInterface interface to manage Stork related operations

--- a/pkg/mock/storagedriver.mock.go
+++ b/pkg/mock/storagedriver.mock.go
@@ -8,6 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	storage "github.com/libopenstorage/operator/drivers/storage"
 	v1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	record "k8s.io/client-go/tools/record"
@@ -143,6 +144,18 @@ func (m *MockDriver) String() string {
 // String indicates an expected call of String
 func (mr *MockDriverMockRecorder) String() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "String", reflect.TypeOf((*MockDriver)(nil).String))
+}
+
+// UpdateDriver mocks base method
+func (m *MockDriver) UpdateDriver(arg0 *storage.UpdateDriverInfo) error {
+	ret := m.ctrl.Call(m, "UpdateDriver", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDriver indicates an expected call of UpdateDriver
+func (mr *MockDriverMockRecorder) UpdateDriver(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDriver", reflect.TypeOf((*MockDriver)(nil).UpdateDriver), arg0)
 }
 
 // UpdateStorageClusterStatus mocks base method


### PR DESCRIPTION
- Pass on this information to the driver through the new UpdateDriver API.

- The UpdateDriver API can be used to keep updating the Driver with information that the controller has. 