### PR TITLE
Handle CapacitySpecs in Portworx Driver

### DIFF
--- a/drivers/storage/portworx/cloud_storage_test.go
+++ b/drivers/storage/portworx/cloud_storage_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	testProviderType = "mock"
+	testProviderType = cloudops.ProviderType("mock")
 	testNamespace    = "test-ns"
 )
 
@@ -117,13 +117,13 @@ func TestGetStorageNodeConfigValidConfigMap(t *testing.T) {
 		},
 	)
 	p := &portworxCloudStorage{
-		cloudProvider: testProviderType,
-		namespace:     testNamespace,
-		zoneCount:     3,
-		k8sClient:     k8sClient,
+		cloudProvider:      testProviderType,
+		namespace:          testNamespace,
+		zoneToInstancesMap: map[string]int{"a": 3, "b": 3, "c": 3},
+		k8sClient:          k8sClient,
 	}
 
-	inputSpecs := []*corev1alpha1.CloudStorageCapacitySpec{
+	inputSpecs := []corev1alpha1.CloudStorageCapacitySpec{
 		{
 			MinIOPS:          uint32(100),
 			MinCapacityInGiB: uint64(100),
@@ -141,7 +141,7 @@ func TestGetStorageNodeConfigValidConfigMap(t *testing.T) {
 
 	mockStorageManager.EXPECT().
 		GetStorageDistribution(&cloudops.StorageDistributionRequest{
-			ZoneCount:        p.zoneCount,
+			ZoneCount:        len(p.zoneToInstancesMap),
 			InstancesPerZone: inputInstancesPerZone,
 			UserStorageSpec: []*cloudops.StorageSpec{
 				{
@@ -216,13 +216,13 @@ func TestGetStorageNodeConfigDifferentInstancesPerZone(t *testing.T) {
 		},
 	)
 	p := &portworxCloudStorage{
-		cloudProvider: testProviderType,
-		namespace:     testNamespace,
-		zoneCount:     3,
-		k8sClient:     k8sClient,
+		cloudProvider:      testProviderType,
+		namespace:          testNamespace,
+		zoneToInstancesMap: map[string]int{"a": 3, "b": 3, "c": 3},
+		k8sClient:          k8sClient,
 	}
 
-	inputSpecs := []*corev1alpha1.CloudStorageCapacitySpec{
+	inputSpecs := []corev1alpha1.CloudStorageCapacitySpec{
 		{
 			MinIOPS:          uint32(100),
 			MinCapacityInGiB: uint64(100),
@@ -242,7 +242,7 @@ func TestGetStorageNodeConfigDifferentInstancesPerZone(t *testing.T) {
 
 	mockStorageManager.EXPECT().
 		GetStorageDistribution(&cloudops.StorageDistributionRequest{
-			ZoneCount:        p.zoneCount,
+			ZoneCount:        len(p.zoneToInstancesMap),
 			InstancesPerZone: inputInstancesPerZone,
 			UserStorageSpec: []*cloudops.StorageSpec{
 				{
@@ -318,13 +318,13 @@ func TestGetStorageNodeConfigMultipleDriveCounts(t *testing.T) {
 		},
 	)
 	p := &portworxCloudStorage{
-		cloudProvider: testProviderType,
-		namespace:     testNamespace,
-		zoneCount:     3,
-		k8sClient:     k8sClient,
+		cloudProvider:      testProviderType,
+		namespace:          testNamespace,
+		zoneToInstancesMap: map[string]int{"a": 3, "b": 3, "c": 3},
+		k8sClient:          k8sClient,
 	}
 
-	inputSpecs := []*corev1alpha1.CloudStorageCapacitySpec{
+	inputSpecs := []corev1alpha1.CloudStorageCapacitySpec{
 		{
 			MinIOPS:          uint32(100),
 			MinCapacityInGiB: uint64(100),
@@ -342,7 +342,7 @@ func TestGetStorageNodeConfigMultipleDriveCounts(t *testing.T) {
 
 	mockStorageManager.EXPECT().
 		GetStorageDistribution(&cloudops.StorageDistributionRequest{
-			ZoneCount:        p.zoneCount,
+			ZoneCount:        len(p.zoneToInstancesMap),
 			InstancesPerZone: inputInstancesPerZone,
 			UserStorageSpec: []*cloudops.StorageSpec{
 				{
@@ -436,13 +436,13 @@ func TestGetStorageNodeConfigSpecCountMismatch(t *testing.T) {
 		},
 	)
 	p := &portworxCloudStorage{
-		cloudProvider: testProviderType,
-		namespace:     testNamespace,
-		zoneCount:     3,
-		k8sClient:     k8sClient,
+		cloudProvider:      testProviderType,
+		namespace:          testNamespace,
+		zoneToInstancesMap: map[string]int{"a": 3, "b": 3, "c": 3},
+		k8sClient:          k8sClient,
 	}
 
-	inputSpecs := []*corev1alpha1.CloudStorageCapacitySpec{
+	inputSpecs := []corev1alpha1.CloudStorageCapacitySpec{
 		{
 			MinIOPS:          uint32(100),
 			MinCapacityInGiB: uint64(100),
@@ -460,7 +460,7 @@ func TestGetStorageNodeConfigSpecCountMismatch(t *testing.T) {
 
 	mockStorageManager.EXPECT().
 		GetStorageDistribution(&cloudops.StorageDistributionRequest{
-			ZoneCount:        p.zoneCount,
+			ZoneCount:        len(p.zoneToInstancesMap),
 			InstancesPerZone: inputInstancesPerZone,
 			UserStorageSpec: []*cloudops.StorageSpec{
 				{

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -575,8 +575,8 @@ func (t *template) getArguments() []string {
 	} else if t.cluster.Spec.CloudStorage != nil {
 		if t.cloudConfig != nil && len(t.cloudConfig.CloudStorage) > 0 {
 			// CapacitySpecs have higher preference over DeviceSpecs
-			for _, cloudNodeSpec := range t.cloudConfig.CloudStorage {
-				args = append(args, "-s", t.getCloudStorageArguments(cloudNodeSpec))
+			for _, cloudDriveSpec := range t.cloudConfig.CloudStorage {
+				args = append(args, "-s", t.getCloudStorageArguments(cloudDriveSpec))
 			}
 		} else if t.cluster.Spec.CloudStorage.DeviceSpecs != nil {
 			for _, dev := range *t.cluster.Spec.CloudStorage.DeviceSpecs {
@@ -599,6 +599,12 @@ func (t *template) getArguments() []string {
 		if t.cloudConfig != nil && t.cloudConfig.StorageInstancesPerZone > 0 {
 			args = append(args, "-max_storage_nodes_per_zone",
 				strconv.Itoa(t.cloudConfig.StorageInstancesPerZone))
+		} else if t.cluster.Spec.CloudStorage.MaxStorageNodesPerZone != nil &&
+			// cloudConfig is not generated use the max storage nodes per zone
+			// provided by the user
+			*t.cluster.Spec.CloudStorage.MaxStorageNodesPerZone > 0 {
+			args = append(args, "-max_storage_nodes_per_zone",
+				strconv.Itoa(int(*t.cluster.Spec.CloudStorage.MaxStorageNodesPerZone)))
 		}
 	}
 

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -8,11 +8,14 @@ import (
 
 	"github.com/google/shlex"
 	version "github.com/hashicorp/go-version"
+
+	"github.com/libopenstorage/cloudops"
 	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
+	"github.com/libopenstorage/operator/pkg/cloudstorage"
 	"github.com/libopenstorage/operator/pkg/util"
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -186,9 +189,12 @@ type template struct {
 	k8sVersion         *version.Version
 	csiVersions        csiVersions
 	kvdb               map[string]string
+	cloudConfig        *cloudstorage.Config
 }
 
-func newTemplate(cluster *corev1alpha1.StorageCluster) (*template, error) {
+func newTemplate(
+	cluster *corev1alpha1.StorageCluster,
+) (*template, error) {
 	if cluster == nil {
 		return nil, fmt.Errorf("storage cluster cannot be empty")
 	}
@@ -271,11 +277,47 @@ func newTemplate(cluster *corev1alpha1.StorageCluster) (*template, error) {
 	return t, nil
 }
 
+func (p *portworx) generateCloudStorageSpecs(
+	cluster *corev1alpha1.StorageCluster,
+) (*cloudstorage.Config, error) {
+	cloudStorageManager := &portworxCloudStorage{
+		p.zoneToInstancesMap,
+		cloudops.ProviderType(p.cloudProvider),
+		cluster.Namespace,
+		p.k8sClient,
+	}
+
+	instancesPerZone := 0
+	if cluster.Spec.CloudStorage.MaxStorageNodesPerZone != nil {
+		instancesPerZone = int(*cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+	}
+	cloudConfig, err := cloudStorageManager.GetStorageNodeConfig(
+		cluster.Spec.CloudStorage.CapacitySpecs,
+		instancesPerZone,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cloud storage node config: %v", err)
+	}
+
+	return cloudConfig, nil
+}
+
 // TODO [Imp] Validate the cluster spec and return errors in the configuration
-func (p *portworx) GetStoragePodSpec(cluster *corev1alpha1.StorageCluster) v1.PodSpec {
+func (p *portworx) GetStoragePodSpec(
+	cluster *corev1alpha1.StorageCluster,
+) (v1.PodSpec, error) {
 	t, err := newTemplate(cluster)
 	if err != nil {
-		return v1.PodSpec{}
+		return v1.PodSpec{}, err
+	}
+
+	if cluster.Spec.CloudStorage != nil && len(cluster.Spec.CloudStorage.CapacitySpecs) > 0 {
+		// Cloud Environment
+		cloudConfig, err := p.generateCloudStorageSpecs(cluster)
+		if err != nil {
+			return v1.PodSpec{}, err
+		}
+		t.cloudConfig = cloudConfig
 	}
 
 	podSpec := v1.PodSpec{
@@ -308,7 +350,7 @@ func (p *portworx) GetStoragePodSpec(cluster *corev1alpha1.StorageCluster) v1.Po
 		)
 	}
 
-	return podSpec
+	return podSpec, nil
 }
 
 func (t *template) portworxContainer() v1.Container {
@@ -440,6 +482,27 @@ func (t *template) getSelectorRequirements() []v1.NodeSelectorRequirement {
 	return selectorRequirements
 }
 
+func (t *template) getCloudStorageArguments(cloudDeviceSpec cloudstorage.CloudDriveConfig) string {
+	devSpec := strings.Join(
+		[]string{
+			"type=" + cloudDeviceSpec.Type,
+			"size=" + strconv.FormatUint(cloudDeviceSpec.SizeInGiB, 10),
+			"iops=" + strconv.FormatUint(uint64(cloudDeviceSpec.IOPS), 10)},
+		",",
+	)
+	for k, v := range cloudDeviceSpec.Options {
+		devSpec = strings.Join(
+			[]string{
+				devSpec,
+				k + "=" + v,
+			},
+			",",
+		)
+	}
+	return devSpec
+
+}
+
 func (t *template) getArguments() []string {
 	args := []string{
 		"-c", t.cluster.Name,
@@ -510,26 +573,32 @@ func (t *template) getArguments() []string {
 		}
 
 	} else if t.cluster.Spec.CloudStorage != nil {
-		if t.cluster.Spec.CloudStorage.DeviceSpecs != nil {
+		if t.cloudConfig != nil && len(t.cloudConfig.CloudStorage) > 0 {
+			// CapacitySpecs have higher preference over DeviceSpecs
+			for _, cloudNodeSpec := range t.cloudConfig.CloudStorage {
+				args = append(args, "-s", t.getCloudStorageArguments(cloudNodeSpec))
+			}
+		} else if t.cluster.Spec.CloudStorage.DeviceSpecs != nil {
 			for _, dev := range *t.cluster.Spec.CloudStorage.DeviceSpecs {
 				args = append(args, "-s", dev)
 			}
 		}
 		if t.cluster.Spec.CloudStorage.JournalDeviceSpec != nil &&
-			*t.cluster.Spec.CloudStorage.JournalDeviceSpec != "" {
+			len(*t.cluster.Spec.CloudStorage.JournalDeviceSpec) > 0 {
 			args = append(args, "-j", *t.cluster.Spec.CloudStorage.JournalDeviceSpec)
 		}
 		if t.cluster.Spec.CloudStorage.SystemMdDeviceSpec != nil &&
-			*t.cluster.Spec.CloudStorage.SystemMdDeviceSpec != "" {
+			len(*t.cluster.Spec.CloudStorage.SystemMdDeviceSpec) > 0 {
 			args = append(args, "-metadata", *t.cluster.Spec.CloudStorage.SystemMdDeviceSpec)
 		}
-		if t.cluster.Spec.CloudStorage.MaxStorageNodes != nil {
+		if t.cluster.Spec.CloudStorage.MaxStorageNodes != nil &&
+			*t.cluster.Spec.CloudStorage.MaxStorageNodes > 0 {
 			args = append(args, "-max_drive_set_count",
 				strconv.Itoa(int(*t.cluster.Spec.CloudStorage.MaxStorageNodes)))
 		}
-		if t.cluster.Spec.CloudStorage.MaxStorageNodesPerZone != nil {
+		if t.cloudConfig != nil && t.cloudConfig.StorageInstancesPerZone > 0 {
 			args = append(args, "-max_storage_nodes_per_zone",
-				strconv.Itoa(int(*t.cluster.Spec.CloudStorage.MaxStorageNodesPerZone)))
+				strconv.Itoa(t.cloudConfig.StorageInstancesPerZone))
 		}
 	}
 

--- a/drivers/storage/storage.go
+++ b/drivers/storage/storage.go
@@ -50,8 +50,8 @@ type ClusterPluginInterface interface {
 	// start to make sure the cluster comes up correctly. This should be
 	// idempotent and subsequent calls should result in the same result.
 	PreInstall(*corev1alpha1.StorageCluster) error
-	// GetStoragePodSpec given the storage cluster spec it returns the pod spec
-	GetStoragePodSpec(*corev1alpha1.StorageCluster) v1.PodSpec
+	// GetStoragePodSpec given the storage cluster spec it returns the pod spec for a node
+	GetStoragePodSpec(*corev1alpha1.StorageCluster) (v1.PodSpec, error)
 	// GetSelectorLabels returns driver specific labels that are applied on the pods
 	GetSelectorLabels() map[string]string
 	// SetDefaultsOnStorageCluster sets the driver specific defaults on the storage

--- a/pkg/apis/core/v1alpha1/storagecluster.go
+++ b/pkg/apis/core/v1alpha1/storagecluster.go
@@ -252,6 +252,8 @@ type CloudStorageSpec struct {
 	// be created for every spec in the DeviceSpecs list. Currently,
 	// CloudStorageSpec is only at the cluster level, so the below specs
 	// be applied to all storage nodes in the cluster.
+	// (Deprecated) DeviceSpecs will be removed from StorageCluster in v1alpha2.
+	// Use CapacitySpecs instead
 	DeviceSpecs *[]string `json:"deviceSpecs,omitempty"`
 
 	// CapacitySpecs list of cluster wide storage types and their capacities.
@@ -260,7 +262,7 @@ type CloudStorageSpec struct {
 	// capacity will get divided amongst the nodes. The nodes bearing storage
 	// themselves will get uniformly distributed across all the zones.
 	// CapacitySpecs is slated to replace DeviceSpecs in v1alpha2 version of StorageCluster.
-	// CapacitySpecs []CloudStorageCapacitySpec `json:"capacitySpecs,omitempty"`
+	CapacitySpecs []CloudStorageCapacitySpec `json:"capacitySpecs,omitempty"`
 
 	// JournalDeviceSpec spec for the journal device
 	JournalDeviceSpec *string `json:"journalDeviceSpec,omitempty"`

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -62,6 +62,13 @@ func (in *CloudStorageSpec) DeepCopyInto(out *CloudStorageSpec) {
 			copy(*out, *in)
 		}
 	}
+	if in.CapacitySpecs != nil {
+		in, out := &in.CapacitySpecs, &out.CapacitySpecs
+		*out = make([]CloudStorageCapacitySpec, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.JournalDeviceSpec != nil {
 		in, out := &in.JournalDeviceSpec, &out.JournalDeviceSpec
 		*out = new(string)

--- a/pkg/cloudstorage/manager.go
+++ b/pkg/cloudstorage/manager.go
@@ -31,5 +31,5 @@ type Config struct {
 type Manager interface {
 	// GetStorageNodeConfig based on the cloud provider will return
 	// the storage configuration for a single node
-	GetStorageNodeConfig([]*corev1alpha1.CloudStorageCapacitySpec, int) (*Config, error)
+	GetStorageNodeConfig([]corev1alpha1.CloudStorageCapacitySpec, int) (*Config, error)
 }

--- a/pkg/mock/storagedriver.mock.go
+++ b/pkg/mock/storagedriver.mock.go
@@ -64,10 +64,11 @@ func (mr *MockDriverMockRecorder) GetSelectorLabels() *gomock.Call {
 }
 
 // GetStoragePodSpec mocks base method
-func (m *MockDriver) GetStoragePodSpec(arg0 *v1alpha1.StorageCluster) v1.PodSpec {
+func (m *MockDriver) GetStoragePodSpec(arg0 *v1alpha1.StorageCluster) (v1.PodSpec, error) {
 	ret := m.ctrl.Call(m, "GetStoragePodSpec", arg0)
 	ret0, _ := ret[0].(v1.PodSpec)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetStoragePodSpec indicates an expected call of GetStoragePodSpec


### PR DESCRIPTION
- Update StorageCluster CRD to include CapacitySpecs in CloudStorageSpec. …
- Regenerate code.
- Change the Portworx driver to handle CapacitySpecs.
- Invoke the CloudStorage API to get per node drive config.
- Parse the storage distribution returned by cloudops into arguments.
- UTs for CapacitySpecs