### PR TITLE
Package storage distribution yamls

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -363,15 +363,16 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:169f1e45aa87c8d2ccf7c34802806ba77985c99876e1a63cb8cf56f6af8ef57f"
+  digest = "1:957b7b7f17e0e00d5fcb9a2a117d58b842bec3de4960aef0791ca1e92a591824"
   name = "github.com/libopenstorage/cloudops"
   packages = [
     ".",
     "mock",
     "pkg/parser",
+    "specs/decisionmatrix",
   ]
   pruneopts = "UT"
-  revision = "098cedcd38281fdaa1a85c7e4b8834e214e40f8f"
+  revision = "b5029744a578ca1738fafd3ce1e67a643cab0216"
 
 [[projects]]
   branch = "release-6.0"
@@ -1413,6 +1414,7 @@
     "github.com/libopenstorage/cloudops",
     "github.com/libopenstorage/cloudops/mock",
     "github.com/libopenstorage/cloudops/pkg/parser",
+    "github.com/libopenstorage/cloudops/specs/decisionmatrix",
     "github.com/libopenstorage/openstorage/api",
     "github.com/libopenstorage/openstorage/pkg/dbg",
     "github.com/libopenstorage/openstorage/pkg/grpcserver",

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,4 +11,6 @@ WORKDIR /
 
 COPY licenses /licenses
 
+COPY vendor/github.com/libopenstorage/cloudops/specs /specs
+
 COPY ./bin/operator /

--- a/drivers/storage/portworx/cloud_storage.go
+++ b/drivers/storage/portworx/cloud_storage.go
@@ -31,6 +31,7 @@ type portworxCloudStorage struct {
 	cloudProvider      cloudops.ProviderType
 	namespace          string
 	k8sClient          client.Client
+	ownerRef           *metav1.OwnerReference
 }
 
 func (p *portworxCloudStorage) GetStorageNodeConfig(
@@ -132,8 +133,9 @@ func (p *portworxCloudStorage) CreateStorageDistributionMatrix() error {
 
 	decisionMatrixCM := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      storageDecisionMatrixCMName,
-			Namespace: p.namespace,
+			Name:            storageDecisionMatrixCMName,
+			Namespace:       p.namespace,
+			OwnerReferences: []metav1.OwnerReference{*p.ownerRef},
 		},
 		Data: map[string]string{
 			storageDecisionMatrixCMKey: string(yamlBytes),

--- a/drivers/storage/portworx/cloud_storage_test.go
+++ b/drivers/storage/portworx/cloud_storage_test.go
@@ -529,6 +529,7 @@ func TestCreateStorageDistributionMatrixSupportedProvider(t *testing.T) {
 		cloudProvider: cloudops.Azure,
 		namespace:     testNamespace,
 		k8sClient:     k8sClient,
+		ownerRef:      &metav1.OwnerReference{},
 	}
 	err := p.CreateStorageDistributionMatrix()
 	require.NoError(t, err, "Unexpected error on CreateStorageDistributionMatrix")

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -16,6 +16,7 @@ import (
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -285,6 +286,7 @@ func (p *portworx) generateCloudStorageSpecs(
 		cloudops.ProviderType(p.cloudProvider),
 		cluster.Namespace,
 		p.k8sClient,
+		metav1.NewControllerRef(cluster, controllerKind),
 	}
 
 	if err := cloudStorageManager.CreateStorageDistributionMatrix(); err != nil {

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -287,6 +287,10 @@ func (p *portworx) generateCloudStorageSpecs(
 		p.k8sClient,
 	}
 
+	if err := cloudStorageManager.CreateStorageDistributionMatrix(); err != nil {
+		logrus.Warnf("Failed to generate storage distribution matrix config map: %v", err)
+	}
+
 	instancesPerZone := 0
 	if cluster.Spec.CloudStorage.MaxStorageNodesPerZone != nil {
 		instancesPerZone = int(*cluster.Spec.CloudStorage.MaxStorageNodesPerZone)

--- a/pkg/cloudstorage/manager.go
+++ b/pkg/cloudstorage/manager.go
@@ -29,6 +29,9 @@ type Config struct {
 // provisioner. It is an abstraction layer to interact with the APIs in
 // libopenstorage/cloudops repository
 type Manager interface {
+	// CreateStorageDistributionMatrix creates a config map which contains
+	// the cloud specific storage distribution matrix
+	CreateStorageDistributionMatrix() error
 	// GetStorageNodeConfig based on the cloud provider will return
 	// the storage configuration for a single node
 	GetStorageNodeConfig([]corev1alpha1.CloudStorageCapacitySpec, int) (*Config, error)

--- a/vendor/github.com/libopenstorage/cloudops/specs/decisionmatrix/azure.yaml
+++ b/vendor/github.com/libopenstorage/cloudops/specs/decisionmatrix/azure.yaml
@@ -1,0 +1,111 @@
+rows:
+        - iops: 1100
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 256
+          max_size: 8192
+          priority: 0
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - iops: 2300
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 512
+          max_size: 8192
+          priority: 0
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - iops: 5000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 1024
+          max_size: 8192
+          priority: 0
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - iops: 7500
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 2048
+          max_size: 8192
+          priority: 0
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - iops: 16000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 8192
+          max_size: 8192
+          priority: 1
+          thin_provisioning: false
+          drive_type: "Premium_LRS"
+        - iops: 500
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 256
+          max_size: 4096
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
+        - iops: 2000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 8192
+          max_size: 8192
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
+        - iops: 4000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 16384
+          max_size: 16384
+          priority: 1
+          thin_provisioning: false
+          drive_type: "StandardSSD_LRS"
+        - iops: 500
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 256
+          max_size: 4096
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Standard_LRS"
+        - iops: 1300
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 8192
+          max_size: 8192
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Standard_LRS"
+        - iops: 2000
+          instance_type: "*"
+          instance_max_drives: 8
+          instance_min_drives: 1
+          region: "*"
+          min_size: 16384
+          max_size: 16384
+          priority: 2
+          thin_provisioning: false
+          drive_type: "Standard_LRS"

--- a/vendor/github.com/libopenstorage/cloudops/specs/decisionmatrix/doc.go
+++ b/vendor/github.com/libopenstorage/cloudops/specs/decisionmatrix/doc.go
@@ -1,0 +1,3 @@
+// Package decisionmatrix includes cloud provider specific decision matrices in the
+// form of yamls.
+package decisionmatrix


### PR DESCRIPTION
- Package libopenstorage/cloudop's storage distribution yamls into operator container.

- Added a new API CreateStorageDecisionMatrix in CloudManager.
- Read the cloud provider specific yamls packaged in the operator
  and create a config map if it does not exist.
- Added UTs for the new API.