### PR TITLE
Add a new CloudProvider interface.

### DIFF
--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -1,0 +1,45 @@
+package cloudprovider
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	azureName = "azure"
+)
+
+type azure struct{}
+
+func (a *azure) Name() string {
+	return azureName
+}
+
+func (a *azure) GetZone(node *v1.Node) (string, error) {
+	if node == nil {
+		return "", fmt.Errorf("node cannot be nil")
+	}
+	// if region is empty we want isAvailabilityZone to be false
+	region, ok := node.Labels[failureDomainRegionKey]
+	if !ok {
+		logrus.Warnf("Failed to get azure region info for node %v", node.Name)
+	}
+	zone, ok := node.Labels[failureDomainZoneKey]
+	if !ok {
+		logrus.Warnf("Failed to get azure zone info for node %v", node.Name)
+	}
+
+	if a.isAvailabilityZone(zone, region) {
+		return zone, nil
+	}
+	return "", nil
+}
+
+// isAvailabilityZone returns true if the zone is in format of <region>-<zone-id>.
+// This is done to differentiate between availability sets and availability zones
+func (a *azure) isAvailabilityZone(zone string, region string) bool {
+	return strings.HasPrefix(zone, fmt.Sprintf("%s-", region))
+}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -1,0 +1,62 @@
+package cloudprovider
+
+import (
+	"fmt"
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	failureDomainZoneKey   = "failure-domain.beta.kubernetes.io/zone"
+	failureDomainRegionKey = "failure-domain.beta.kubernetes.io/region"
+)
+
+var (
+	providerRegistry     map[string]Ops
+	providerRegistryLock sync.Mutex
+)
+
+// Ops is a list of APIs to fetch information about cloudprovider and its nodes
+type Ops interface {
+	// Name returns the name of the cloud provider
+	Name() string
+
+	// GetZone returns the zone of the provided node
+	GetZone(*v1.Node) (string, error)
+}
+
+// New returns a new implementation of the cloud provider
+func New(name string) Ops {
+	providerRegistryLock.Lock()
+	defer providerRegistryLock.Unlock()
+
+	ops, ok := providerRegistry[name]
+	if !ok {
+		return &defaultProvider{name}
+	}
+	return ops
+}
+
+type defaultProvider struct {
+	name string
+}
+
+func (d *defaultProvider) Name() string {
+	return d.name
+}
+
+func (d *defaultProvider) GetZone(node *v1.Node) (string, error) {
+	if node == nil {
+		return "", fmt.Errorf("node cannot be nil")
+	}
+	return node.Labels[failureDomainZoneKey], nil
+}
+
+func init() {
+	providerRegistryLock.Lock()
+	defer providerRegistryLock.Unlock()
+
+	providerRegistry = make(map[string]Ops)
+	providerRegistry[azureName] = &azure{}
+}

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -1,0 +1,101 @@
+package cloudprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNew(t *testing.T) {
+	cp := New("foo")
+	require.NotNil(t, cp, "Unexpected error on New")
+	require.Equal(t, "foo", cp.Name(), "Unexpected name of default provider")
+
+	cp = New(azureName)
+	require.NotNil(t, cp, "Unexpected error on New")
+	require.Equal(t, azureName, cp.Name(), "Unexpected name of default provider")
+}
+
+func TestDefaultGetZoneNodeNil(t *testing.T) {
+	cp := New("default")
+	require.NotNil(t, cp, "Unexpected error on New")
+
+	zone, err := cp.GetZone(nil)
+	require.Error(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "", zone, "Unexpected zone returned")
+}
+
+func TestDefaultGetZone(t *testing.T) {
+	cp := New("default")
+	require.NotNil(t, cp, "Unexpected error on New")
+
+	zone, err := cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "node1",
+			Labels: map[string]string{failureDomainZoneKey: "bar"},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "bar", zone, "Unexpected zone returned")
+}
+
+func TestAzureGetZoneNodeNil(t *testing.T) {
+	cp := New(azureName)
+	require.NotNil(t, cp, "Unexpected error on New")
+
+	zone, err := cp.GetZone(nil)
+	require.Error(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "", zone, "Unexpected zone returned")
+}
+
+func TestAzureGetZoneAvailabilityZone(t *testing.T) {
+	cp := New(azureName)
+	require.NotNil(t, cp, "Unexpected error on New")
+
+	zone, err := cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				failureDomainZoneKey:   "region-0",
+				failureDomainRegionKey: "region",
+			},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "region-0", zone, "Unexpected zone returned")
+}
+
+func TestAzureGetZoneAvailabilitySet(t *testing.T) {
+	cp := New(azureName)
+	require.NotNil(t, cp, "Unexpected error on New")
+
+	zone, err := cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				failureDomainZoneKey:   "0",
+				failureDomainRegionKey: "region",
+			},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "", zone, "Unexpected zone returned")
+}
+
+func TestAzureGetZoneNoRegion(t *testing.T) {
+	cp := New(azureName)
+	require.NotNil(t, cp, "Unexpected error on New")
+
+	zone, err := cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				failureDomainZoneKey: "region-0",
+			},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "", zone, "Unexpected zone returned")
+}


### PR DESCRIPTION
- Contains only one API GetZones for now.
- Add a default implementation to fetch zone information from kubernetes nodes.
- Add an azure specific implementation that differentiates between availability zones and sets.
- Add UTs for both defaul and azure implementation.