### PR TITLE
Use release manifest to group component versions

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,4 +12,5 @@ WORKDIR /
 COPY licenses /licenses
 COPY vendor/github.com/libopenstorage/cloudops/specs /specs
 COPY deploy/crds /crds
+COPY manifests /manifests
 COPY ./bin/operator /

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -1,0 +1,136 @@
+package manifest
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"sort"
+
+	version "github.com/hashicorp/go-version"
+	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+	// ManifestDir directory where release manifest is stored
+	ManifestDir = "manifests"
+	// ReleasesFilename name of the release manifest file
+	ReleasesFilename = "portworx-releases.yaml"
+)
+
+var (
+	// ErrEmptyReleases when releases list is empty
+	ErrEmptyReleases = errors.New("releases cannot be empty")
+	// ErrReleaseNotFound when given release is not found
+	ErrReleaseNotFound = errors.New("release not found")
+	// ErrInvalidDefaultRelease when the default release is invalid
+	ErrInvalidDefaultRelease = errors.New("invalid default release")
+	loadReleaseManifest      = readManifestFile
+)
+
+// ReleaseManifest defines the Portworx release manifest
+type ReleaseManifest struct {
+	DefaultRelease string             `yaml:"defaultRelease,omitempty"`
+	Releases       map[string]Release `yaml:"releases,omitempty"`
+}
+
+// Release is a single release object with images for different components
+type Release struct {
+	Stork      string `yaml:"stork,omitempty"`
+	Lighthouse string `yaml:"lighthouse,omitempty"`
+}
+
+// NewReleaseManifest returns a release manifest object from the portworx releases file
+func NewReleaseManifest() (*ReleaseManifest, error) {
+	data, err := loadReleaseManifest()
+	if err != nil {
+		return nil, err
+	}
+	manifest := &ReleaseManifest{}
+	err = yaml.Unmarshal([]byte(data), manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(manifest.Releases) == 0 {
+		return nil, ErrEmptyReleases
+	}
+	if len(manifest.DefaultRelease) == 0 {
+		manifest.DefaultRelease = manifest.getLatest()
+	} else if _, exists := manifest.Releases[manifest.DefaultRelease]; !exists {
+		return nil, ErrInvalidDefaultRelease
+	}
+	return manifest, nil
+}
+
+// Get returns a release object for given string version
+func (m *ReleaseManifest) Get(target string) (*Release, error) {
+	if release, exists := m.Releases[target]; exists {
+		targetRelease := release
+		return &targetRelease, nil
+	}
+	targetVersion, err := version.NewSemver(target)
+	if err != nil {
+		return nil, fmt.Errorf("invalid version %s: %v", target, err)
+	}
+	return m.GetFromVersion(targetVersion)
+}
+
+// GetFromVersion returns a release object for given version
+func (m *ReleaseManifest) GetFromVersion(target *version.Version) (*Release, error) {
+	if target == nil {
+		return nil, ErrReleaseNotFound
+	}
+	for release := range m.Releases {
+		curr, err := version.NewSemver(release)
+		if err == nil && curr.Equal(target) {
+			targetRelease := m.Releases[release]
+			return &targetRelease, nil
+		}
+	}
+	return nil, ErrReleaseNotFound
+}
+
+// GetDefault returns a release object for the default release
+func (m *ReleaseManifest) GetDefault() (*Release, error) {
+	return m.Get(m.DefaultRelease)
+}
+
+func (m *ReleaseManifest) getLatest() string {
+	versions := make([]string, 0)
+	for version := range m.Releases {
+		versions = append(versions, version)
+	}
+
+	sort.Sort(semver(versions))
+	return versions[len(versions)-1]
+}
+
+func readManifestFile() ([]byte, error) {
+	return ioutil.ReadFile(path.Join(ManifestDir, ReleasesFilename))
+}
+
+type semver []string
+
+func (s semver) Len() int {
+	return len(s)
+}
+
+func (s semver) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// The versions are compared on follow criteria:
+// - if both are semver, return semver comparision result
+// - if both are not semver, return lexicographic comparison result
+// - if one is semver and other is not, then semver is considered smaller
+func (s semver) Less(i, j int) bool {
+	version1, err1 := version.NewSemver(s[i])
+	version2, err2 := version.NewSemver(s[j])
+	if err1 == nil && err2 == nil {
+		return version1.LessThan(version2)
+	} else if err1 != nil && err2 != nil {
+		return s[i] < s[j]
+	}
+	return err1 == nil
+}

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -1,0 +1,253 @@
+package manifest
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorWhenReadingManifest(t *testing.T) {
+	// Error reading manifest file
+	loadReleaseManifest = func() ([]byte, error) {
+		return nil, fmt.Errorf("file read error")
+	}
+	r, err := NewReleaseManifest()
+	require.EqualError(t, err, "file read error")
+	require.Nil(t, r)
+
+	// Error parsing manifest file
+	defer unmaskLoadManifest()
+	maskLoadManifest("invalid-yaml")
+	r, err = NewReleaseManifest()
+	require.Error(t, err)
+	require.Nil(t, r)
+}
+
+func TestManifestWithoutReleases(t *testing.T) {
+	// Emtpy manifest file
+	defer unmaskLoadManifest()
+	maskLoadManifest("")
+	r, err := NewReleaseManifest()
+	require.Equal(t, ErrEmptyReleases, err)
+	require.Nil(t, r)
+
+	// No releases section
+	maskLoadManifest(`
+defaultRelease: 1.2.3
+`)
+	r, err = NewReleaseManifest()
+	require.Equal(t, ErrEmptyReleases, err)
+	require.Nil(t, r)
+
+	// Empty releases list
+	maskLoadManifest(`
+defaultRelease: 1.2.3
+releases:
+`)
+	r, err = NewReleaseManifest()
+	require.Equal(t, ErrEmptyReleases, err)
+	require.Nil(t, r)
+}
+
+func TestInvalidDefaultRelease(t *testing.T) {
+	defer unmaskLoadManifest()
+	maskLoadManifest(`
+defaultRelease: master
+releases:
+  1.2.3:
+    stork: stork/image
+    lighthouse: lighthouse/image
+`)
+	r, err := NewReleaseManifest()
+	require.Equal(t, ErrInvalidDefaultRelease, err)
+	require.Nil(t, r)
+}
+
+func TestValidManifest(t *testing.T) {
+	defer unmaskLoadManifest()
+	maskLoadManifest(`
+defaultRelease: 1.2.3
+releases:
+  1.2.3:
+    stork: stork/image:1.2.3
+    lighthouse: lighthouse/image:1.2.3
+  1.2.4:
+    stork: stork/image:1.2.4
+    lighthouse: lighthouse/image:1.2.4
+`)
+
+	r, err := NewReleaseManifest()
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3", r.DefaultRelease)
+	require.Len(t, r.Releases, 2)
+	require.Equal(t, "stork/image:1.2.3", r.Releases["1.2.3"].Stork)
+	require.Equal(t, "lighthouse/image:1.2.3", r.Releases["1.2.3"].Lighthouse)
+	require.Equal(t, "stork/image:1.2.4", r.Releases["1.2.4"].Stork)
+	require.Equal(t, "lighthouse/image:1.2.4", r.Releases["1.2.4"].Lighthouse)
+}
+
+func TestMissingDefaultShouldMakeLatestAsDefault(t *testing.T) {
+	defer unmaskLoadManifest()
+	// Choose the latest version as default if absent
+	maskLoadManifest(`
+releases:
+  1.2.3:
+    stork: stork/image:1.2.3
+    lighthouse: lighthouse/image:1.2.3
+  1.2.4:
+    stork: stork/image:1.2.4
+    lighthouse: lighthouse/image:1.2.4
+  1.2.4-rc1:
+    stork: stork/image:1.2.4-rc1
+    lighthouse: lighthouse/image:1.2.4-rc1
+`)
+
+	r, err := NewReleaseManifest()
+	require.NoError(t, err)
+	require.Len(t, r.Releases, 3)
+	require.Equal(t, "1.2.4", r.DefaultRelease)
+
+	release, err := r.GetDefault()
+	require.NoError(t, err)
+	require.Equal(t, "stork/image:1.2.4", release.Stork)
+	require.Equal(t, "lighthouse/image:1.2.4", release.Lighthouse)
+
+	// Non-semvar versions are considered newer than semvar versions.
+	// Non-semvar versions are sorted amongst themselves lexicographically.
+	maskLoadManifest(`
+releases:
+  test1:
+    stork: stork/image:test1
+    lighthouse: lighthouse/image:test1
+  1.2.3:
+    stork: stork/image:1.2.3
+    lighthouse: lighthouse/image:1.2.3
+  test3:
+    stork: stork/image:test3
+    lighthouse: lighthouse/image:test3
+  test2:
+    stork: stork/image:test2
+    lighthouse: lighthouse/image:test2
+`)
+
+	r, err = NewReleaseManifest()
+	require.NoError(t, err)
+	require.Len(t, r.Releases, 4)
+	require.Equal(t, "test3", r.DefaultRelease)
+
+	release, err = r.GetDefault()
+	require.NoError(t, err)
+	require.Equal(t, "stork/image:test3", release.Stork)
+	require.Equal(t, "lighthouse/image:test3", release.Lighthouse)
+}
+
+func TestGetOnReleaseManifest(t *testing.T) {
+	defer unmaskLoadManifest()
+	maskLoadManifest(`
+releases:
+  master:
+    stork: stork/image:master
+    lighthouse: lighthouse/image:master
+  1.2.3:
+    stork: stork/image:1.2.3
+    lighthouse: lighthouse/image:1.2.3
+`)
+
+	r, err := NewReleaseManifest()
+	require.NoError(t, err)
+
+	// Should return the release if found
+	release, err := r.Get("master")
+	require.NoError(t, err)
+	require.Equal(t, "stork/image:master", release.Stork)
+	require.Equal(t, "lighthouse/image:master", release.Lighthouse)
+
+	// Should return a matching semver release if not found directly
+	release, err = r.Get("1.2.3.0")
+	require.NoError(t, err)
+	require.Equal(t, "stork/image:1.2.3", release.Stork)
+	require.Equal(t, "lighthouse/image:1.2.3", release.Lighthouse)
+
+	// Should return error if not found
+	release, err = r.Get("1.2.3.1")
+	require.Equal(t, ErrReleaseNotFound, err)
+	require.Nil(t, release)
+
+	// Should return error if not found directly and is invalid semver
+	release, err = r.Get("latest")
+	require.Contains(t, err.Error(), "invalid version")
+	require.Nil(t, release)
+}
+
+func TestGetFromVersionOnReleaseManifest(t *testing.T) {
+	defer unmaskLoadManifest()
+	maskLoadManifest(`
+releases:
+  master:
+    stork: stork/image:master
+    lighthouse: lighthouse/image:master
+  1.2.3.0:
+    stork: stork/image:1.2.3.0
+    lighthouse: lighthouse/image:1.2.3.0
+`)
+
+	r, err := NewReleaseManifest()
+	require.NoError(t, err)
+
+	// Should return err if nil version passed
+	release, err := r.GetFromVersion(nil)
+	require.Equal(t, ErrReleaseNotFound, err)
+	require.Nil(t, release)
+
+	// Should return a matching version found
+	v, _ := version.NewSemver("1.2.3.0")
+	release, err = r.GetFromVersion(v)
+	require.NoError(t, err)
+	require.Equal(t, "stork/image:1.2.3.0", release.Stork)
+	require.Equal(t, "lighthouse/image:1.2.3.0", release.Lighthouse)
+
+	// Should return even if a matching semver version found
+	v, _ = version.NewSemver("1.2.3")
+	release, err = r.GetFromVersion(v)
+	require.NoError(t, err)
+	require.Equal(t, "stork/image:1.2.3.0", release.Stork)
+	require.Equal(t, "lighthouse/image:1.2.3.0", release.Lighthouse)
+
+	// Should return err if not found
+	v, _ = version.NewSemver("1.2.3.1")
+	release, err = r.GetFromVersion(v)
+	require.Equal(t, ErrReleaseNotFound, err)
+	require.Nil(t, release)
+}
+
+func TestReadingManifestFile(t *testing.T) {
+	os.RemoveAll(ManifestDir)
+	linkPath := path.Join(
+		os.Getenv("GOPATH"),
+		"src/github.com/libopenstorage/operator/drivers/storage/portworx/manifest/testspec",
+	)
+	os.Symlink(linkPath, ManifestDir)
+
+	r, err := NewReleaseManifest()
+	require.NoError(t, err)
+	require.Equal(t, "2.1.5", r.DefaultRelease)
+	require.Len(t, r.Releases, 1)
+	require.Equal(t, "openstorage/stork:2.2.4", r.Releases["2.1.5"].Stork)
+	require.Equal(t, "portworx/px-lighthouse:2.0.4", r.Releases["2.1.5"].Lighthouse)
+
+	os.RemoveAll(ManifestDir)
+}
+
+func maskLoadManifest(manifest string) {
+	loadReleaseManifest = func() ([]byte, error) {
+		return []byte(manifest), nil
+	}
+}
+
+func unmaskLoadManifest() {
+	loadReleaseManifest = readManifestFile
+}

--- a/drivers/storage/portworx/manifest/testspec/portworx-releases.yaml
+++ b/drivers/storage/portworx/manifest/testspec/portworx-releases.yaml
@@ -1,0 +1,5 @@
+defaultRelease: 2.1.5
+releases:
+  2.1.5:
+    stork: openstorage/stork:2.2.4
+    lighthouse: portworx/px-lighthouse:2.0.4

--- a/drivers/storage/portworx/testspec/portworx-releases.yaml
+++ b/drivers/storage/portworx/testspec/portworx-releases.yaml
@@ -1,0 +1,6 @@
+defaultRelease: 2.1.5
+releases:
+  2.1.4:
+  2.1.5:
+    stork: openstorage/stork:2.3.4
+    lighthouse: portworx/px-lighthouse:2.3.4

--- a/manifests/portworx-releases.yaml
+++ b/manifests/portworx-releases.yaml
@@ -1,0 +1,17 @@
+defaultRelease: 2.1.5
+releases:
+  2.1.2:
+    stork: openstorage/stork:2.2.5
+    lighthouse: portworx/px-lighthouse:2.0.4
+  2.1.3:
+    stork: openstorage/stork:2.2.5
+    lighthouse: portworx/px-lighthouse:2.0.4
+  2.1.4:
+    stork: openstorage/stork:2.2.5
+    lighthouse: portworx/px-lighthouse:2.0.4
+  2.1.5:
+    stork: openstorage/stork:2.2.5
+    lighthouse: portworx/px-lighthouse:2.0.4
+  2.2.0:
+    stork: openstorage/stork:2.3-dev
+    lighthouse: portworx/px-lighthouse:2.0.4

--- a/pkg/apis/core/v1alpha1/storagecluster.go
+++ b/pkg/apis/core/v1alpha1/storagecluster.go
@@ -291,6 +291,10 @@ type UserInterfaceSpec struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Image is the docker image of the user interface container
 	Image string `json:"image,omitempty"`
+	// LockImage is a boolean indicating if the user interface image needs to be locked
+	// to the given image. If the image is not locked, it can be updated by the driver
+	// during upgrades.
+	LockImage bool `json:"lockImage,omitempty"`
 	// Env is a list of environment variables used by UI component
 	Env []v1.EnvVar `json:"env,omitempty"`
 }
@@ -301,6 +305,10 @@ type StorkSpec struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Image is docker image of the STORK container
 	Image string `json:"image,omitempty"`
+	// LockImage is a boolean indicating if the stork image needs to be locked
+	// to the given image. If the image is not locked, it can be updated by the
+	// driver during upgrades.
+	LockImage bool `json:"lockImage,omitempty"`
 	// Args is a map of arguments given to STORK
 	Args map[string]string `json:"args,omitempty"`
 	// Env is a list of environment variables used by stork

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	CoreV1alpha1() corev1alpha1.CoreV1alpha1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Core() corev1alpha1.CoreV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // CoreV1alpha1 retrieves the CoreV1alpha1Client
 func (c *Clientset) CoreV1alpha1() corev1alpha1.CoreV1alpha1Interface {
-	return c.coreV1alpha1
-}
-
-// Deprecated: Core retrieves the default version of CoreClient.
-// Please explicitly pick a version.
-func (c *Clientset) Core() corev1alpha1.CoreV1alpha1Interface {
 	return c.coreV1alpha1
 }
 

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) CoreV1alpha1() corev1alpha1.CoreV1alpha1Interface {
 	return &fakecorev1alpha1.FakeCoreV1alpha1{Fake: &c.Fake}
 }
-
-// Core retrieves the CoreV1alpha1Client
-func (c *Clientset) Core() corev1alpha1.CoreV1alpha1Interface {
-	return &fakecorev1alpha1.FakeCoreV1alpha1{Fake: &c.Fake}
-}

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/core_client.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
+	v1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
 	"github.com/libopenstorage/operator/pkg/client/clientset/versioned/scheme"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/rest"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	rest "k8s.io/client-go/rest"
 )
 
 type CoreV1alpha1Interface interface {

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/fake/fake_core_client.go
@@ -19,9 +19,9 @@ limitations under the License.
 package fake
 
 import (
-	"github.com/libopenstorage/operator/pkg/client/clientset/versioned/typed/core/v1alpha1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/testing"
+	v1alpha1 "github.com/libopenstorage/operator/pkg/client/clientset/versioned/typed/core/v1alpha1"
+	rest "k8s.io/client-go/rest"
+	testing "k8s.io/client-go/testing"
 )
 
 type FakeCoreV1alpha1 struct {

--- a/pkg/client/clientset/versioned/typed/core/v1alpha1/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/core/v1alpha1/generated_expansion.go
@@ -18,8 +18,6 @@ limitations under the License.
 
 package v1alpha1
 
-type ClusterOperationExpansion interface{}
-
 type StorageClusterExpansion interface{}
 
 type StorageNodeExpansion interface{}

--- a/pkg/client/informers/externalversions/core/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/core/v1alpha1/interface.go
@@ -24,8 +24,6 @@ import (
 
 // Interface provides access to all the informers in this group version.
 type Interface interface {
-	// ClusterOperations returns a ClusterOperationInformer.
-	ClusterOperations() ClusterOperationInformer
 	// StorageClusters returns a StorageClusterInformer.
 	StorageClusters() StorageClusterInformer
 	// StorageNodes returns a StorageNodeInformer.
@@ -41,11 +39,6 @@ type version struct {
 // New returns a new Interface.
 func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakListOptions internalinterfaces.TweakListOptionsFunc) Interface {
 	return &version{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
-}
-
-// ClusterOperations returns a ClusterOperationInformer.
-func (v *version) ClusterOperations() ClusterOperationInformer {
-	return &clusterOperationInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
 // StorageClusters returns a StorageClusterInformer.

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -53,8 +53,6 @@ func (f *genericInformer) Lister() cache.GenericLister {
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
 	// Group=core.libopenstorage.org, Version=v1alpha1
-	case v1alpha1.SchemeGroupVersion.WithResource("clusteroperations"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().V1alpha1().ClusterOperations().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("storageclusters"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().V1alpha1().StorageClusters().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("storagenodes"):

--- a/pkg/client/listers/core/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/core/v1alpha1/expansion_generated.go
@@ -18,14 +18,6 @@ limitations under the License.
 
 package v1alpha1
 
-// ClusterOperationListerExpansion allows custom methods to be added to
-// ClusterOperationLister.
-type ClusterOperationListerExpansion interface{}
-
-// ClusterOperationNamespaceListerExpansion allows custom methods to be added to
-// ClusterOperationNamespaceLister.
-type ClusterOperationNamespaceListerExpansion interface{}
-
 // StorageClusterListerExpansion allows custom methods to be added to
 // StorageClusterLister.
 type StorageClusterListerExpansion interface{}

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -813,21 +813,6 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1alpha1.StorageClus
 		toUpdate.Spec.ImagePullPolicy = v1.PullAlways
 	}
 
-	partitions := strings.Split(toUpdate.Spec.Image, ":")
-	if len(partitions) > 1 {
-		toUpdate.Spec.Version = partitions[len(partitions)-1]
-	}
-
-	// Enable stork by default
-	if toUpdate.Spec.Stork == nil {
-		toUpdate.Spec.Stork = &corev1alpha1.StorkSpec{
-			Enabled: true,
-			Image:   defaultStorkImage,
-		}
-	} else if toUpdate.Spec.Stork.Enabled && len(strings.TrimSpace(toUpdate.Spec.Stork.Image)) == 0 {
-		toUpdate.Spec.Stork.Image = defaultStorkImage
-	}
-
 	foundDeleteFinalizer := false
 	for _, finalizer := range toUpdate.Finalizers {
 		if finalizer == deleteFinalizerName {

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -26,7 +26,6 @@ import (
 )
 
 const (
-	defaultStorkImage                = "openstorage/stork:2.2.4"
 	storkConfigMapName               = "stork-config"
 	storkServiceAccountName          = "stork"
 	storkClusterRoleName             = "stork"


### PR DESCRIPTION
- Introduce a hardcoded portworx release manifest with related component versions to go with different portworx versions. In future we will have an online manifest that we can pull before using the hardcoded one. Will make Manifest an interface then.
- By default if portworx image version is changed, other component versions also change based on the release manifest. 
- Introduced `LockImage` boolean in all component specs to disallow default image override from manifest. 
- Release manifest will look something like this - 
```
defaultRelease: 2.1.3
releases:
  2.1.2:
    stork: openstorage/stork:2.2.5
    lighthouse: portworx/px-lighthouse:2.0.4
  2.1.3:
    stork: openstorage/stork:2.2.5
    lighthouse: portworx/px-lighthouse:2.0.4
```
- The portworx version is determined from the tag of `spec.image`. If `PX_IMAGE` env is present then it's tag take precedence over `spec.image`. For dev/testing, if custom tags are used in `spec.image` and/or `PX_IMAGE`, then we look at the annotation for version `portworx.io/px-version` which directly can have version (eg. 2.1.5) as it's value.
- If no matching tag is found in the release manifest, we pick up the default version from the release manifest to deploy.