### PR TITLE
Add default storage classes for portworx

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1591,6 +1591,7 @@
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/fields",

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1,8 +1,8 @@
 package portworx
 
 import (
+	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"math"
 	"path"
 	"strconv"
@@ -17,8 +17,8 @@ import (
 	"github.com/libopenstorage/operator/pkg/util"
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/drivers/storage/portworx/testspec/storageClassDb.yaml
+++ b/drivers/storage/portworx/testspec/storageClassDb.yaml
@@ -1,0 +1,20 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-db
+  annotations:
+    params/docs: "https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html"
+    params/fs: "Filesystem to be laid out: none|xfs|ext4"
+    params/block_size: "Block size"
+    params/repl: "Replication factor for the volume: 1|2|3"
+    params/secure: "Flag to create an encrypted volume: true|false"
+    params/shared: "Flag to create a globally shared namespace volume which can be used by multiple pods: true|false"
+    params/priority_io: "IO Priority: low|medium|high"
+    params/io_profile: "IO Profile can be used to override the I/O algorithm Portworx uses for the volumes: db|sequential|random|cms"
+    params/aggregation_level: "Specifies the number of replication sets the volume can be aggregated from"
+    params/sticky: "Flag to create sticky volumes that cannot be deleted until the flag is disabled"
+    params/journal: "Flag to indicate if you want to use journal device for the volume's metadata. This will use the journal device that you used when installing Portworx. It is recommended to use a journal device to absorb PX metadata writes"
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  io_profile: "db"

--- a/drivers/storage/portworx/testspec/storageClassDbCloudSnapshot.yaml
+++ b/drivers/storage/portworx/testspec/storageClassDbCloudSnapshot.yaml
@@ -1,0 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-db-cloud-snapshot
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  snapshotschedule.stork.libopenstorage.org/daily-schedule: |
+    schedulePolicyName: default-daily-policy
+    annotations:
+      portworx/snapshot-type: cloud

--- a/drivers/storage/portworx/testspec/storageClassDbCloudSnapshotEncrypted.yaml
+++ b/drivers/storage/portworx/testspec/storageClassDbCloudSnapshotEncrypted.yaml
@@ -1,0 +1,12 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-db-cloud-snapshot-encrypted
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  secure: "true"
+  snapshotschedule.stork.libopenstorage.org/daily-schedule: |
+    schedulePolicyName: default-daily-policy
+    annotations:
+      portworx/snapshot-type: cloud

--- a/drivers/storage/portworx/testspec/storageClassDbEncrypted.yaml
+++ b/drivers/storage/portworx/testspec/storageClassDbEncrypted.yaml
@@ -1,0 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-db-encrypted
+  annotations:
+    params/note: "Ensure that you have a cluster-wide secret created in the configured secrets provider"
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  secure: "true"
+  io_profile: "db"

--- a/drivers/storage/portworx/testspec/storageClassDbLocalSnapshot.yaml
+++ b/drivers/storage/portworx/testspec/storageClassDbLocalSnapshot.yaml
@@ -1,0 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-db-local-snapshot
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  snapshotschedule.stork.libopenstorage.org/daily-schedule: |
+    schedulePolicyName: default-daily-policy
+    annotations:
+      portworx/snapshot-type: local

--- a/drivers/storage/portworx/testspec/storageClassDbLocalSnapshotEncrypted.yaml
+++ b/drivers/storage/portworx/testspec/storageClassDbLocalSnapshotEncrypted.yaml
@@ -1,0 +1,12 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-db-local-snapshot-encrypted
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  secure: "true"
+  snapshotschedule.stork.libopenstorage.org/daily-schedule: |
+    schedulePolicyName: default-daily-policy
+    annotations:
+      portworx/snapshot-type: local

--- a/drivers/storage/portworx/testspec/storageClassReplicated.yaml
+++ b/drivers/storage/portworx/testspec/storageClassReplicated.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-replicated
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "2"

--- a/drivers/storage/portworx/testspec/storageClassReplicatedEncrypted.yaml
+++ b/drivers/storage/portworx/testspec/storageClassReplicatedEncrypted.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: px-replicated-encrypted
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "2"
+  secure: "true"

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -199,7 +199,7 @@ func (c *Controller) createStorkConfigMap(
 func (c *Controller) createStorkSnapshotStorageClass(
 	ownerRef *metav1.OwnerReference,
 ) error {
-	return k8sutil.CreateOrUpdateStorageClass(
+	return k8sutil.CreateStorageClass(
 		c.client,
 		&storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
@@ -208,7 +208,6 @@ func (c *Controller) createStorkSnapshotStorageClass(
 			},
 			Provisioner: "stork-snapshot",
 		},
-		ownerRef,
 	)
 }
 

--- a/pkg/util/k8s/k8s_test.go
+++ b/pkg/util/k8s/k8s_test.go
@@ -395,6 +395,35 @@ func TestDeleteClusterRoleBinding(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 }
 
+func TestCreateStorageClass(t *testing.T) {
+	k8sClient := fake.NewFakeClient()
+	expectedStorageClass := &storagev1.StorageClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Provisioner: "foo",
+	}
+
+	err := CreateStorageClass(k8sClient, expectedStorageClass)
+	require.NoError(t, err)
+
+	actualStorageClass := &storagev1.StorageClass{}
+	err = testutil.Get(k8sClient, actualStorageClass, "test", "")
+	require.NoError(t, err)
+	require.Equal(t, "foo", actualStorageClass.Provisioner)
+
+	// Trying to create again will not create again and not return an error
+	expectedStorageClass.Provisioner = "bar"
+
+	err = CreateStorageClass(k8sClient, expectedStorageClass)
+	require.NoError(t, err)
+
+	actualStorageClass = &storagev1.StorageClass{}
+	err = testutil.Get(k8sClient, actualStorageClass, "test", "")
+	require.NoError(t, err)
+	require.Equal(t, "foo", actualStorageClass.Provisioner)
+}
+
 func TestDeleteStorageClass(t *testing.T) {
 	name := "test"
 	expected := &storagev1.StorageClass{


### PR DESCRIPTION
- Adding 4 default storage classes that get installed with portworx and removed when the StorageCluster spec is removed.
- We may not be able to delete these storage classes from operator in the future as they could be used. Also we will not be able to update most of the values as they are immutable.
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: px-db
  annotations:
    params/docs: "https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html"
    params/fs: "Filesystem to be laid out: none|xfs|ext4"
    params/block_size: "Block size"
    params/repl: "Replication factor for the volume: 1|2|3"
    params/secure: "Flag to create an encrypted volume: true|false"
    params/shared: "Flag to create a globally shared namespace volume which can be used by multiple pods: true|false"
    params/priority_io: "IO Priority: low|medium|high"
    params/io_profile: "IO Profile can be used to override the I/O algorithm Portworx uses for the volumes: db|sequential|random|cms"
    params/aggregation_level: "Specifies the number of replication sets the volume can be aggregated from"
    params/sticky: "Flag to create sticky volumes that cannot be deleted until the flag is disabled"
    params/journal: "Flag to indicate if you want to use journal device for the volume's metadata. This will use the journal device that you used when installing Portworx. It is recommended to use a journal device to absorb PX metadata writes"
provisioner: kubernetes.io/portworx-volume
parameters:
  repl: "3"
  io_profile: "db"
```
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: px-db-encrypted
  annotations:
    params/note: "Ensure that you have a cluster-wide secret created in the configured secrets provider"
provisioner: kubernetes.io/portworx-volume
parameters:
  repl: "3"
  secure: "true"
  io_profile: "db"
```
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: px-db-cloud-snapshot
provisioner: kubernetes.io/portworx-volume
parameters:
  repl: "3"
  snapshotschedule.stork.libopenstorage.org/daily-schedule: |
    schedulePolicyName: default-daily-policy
    annotations:
      portworx/snapshot-type: cloud
```
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: px-db-cloud-snapshot-encrypted
provisioner: kubernetes.io/portworx-volume
parameters:
  repl: "3"
  secure: "true"
  snapshotschedule.stork.libopenstorage.org/daily-schedule: |
    schedulePolicyName: default-daily-policy
    annotations:
      portworx/snapshot-type: cloud
```
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: px-db-local-snapshot
provisioner: kubernetes.io/portworx-volume
parameters:
  repl: "3"
  snapshotschedule.stork.libopenstorage.org/daily-schedule: |
    schedulePolicyName: default-daily-policy
    annotations:
      portworx/snapshot-type: local
```
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: px-db-local-snapshot-encrypted
provisioner: kubernetes.io/portworx-volume
parameters:
  repl: "3"
  secure: "true"
  snapshotschedule.stork.libopenstorage.org/daily-schedule: |
    schedulePolicyName: default-daily-policy
    annotations:
      portworx/snapshot-type: local
```
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: px-replicated
provisioner: kubernetes.io/portworx-volume
parameters:
  repl: "2"
```
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: px-replicated-encrypted
provisioner: kubernetes.io/portworx-volume
parameters:
  repl: "2"
  secure: "true"
```
