### PR TITLE
Use default storage if nothing present

### DIFF
--- a/deploy/olm-catalog/portworx/portworxoperator.v1.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/portworxoperator.v1.1.0.clusterserviceversion.yaml
@@ -26,16 +26,8 @@ metadata:
           },
           "spec": {
             "image": "registry.connect.redhat.com/portworx/px-monitor:2.1.5",
-            "stork": {
-              "enabled": true,
-              "image": "openstorage/stork:2.2.5"
-            },
             "userInterface": {
-              "enabled": true,
-              "image": "portworx/px-lighthouse:2.0.4"
-            },
-            "storage": {
-              "useAll": true
+              "enabled": true
             }
           }
         },
@@ -149,9 +141,9 @@ spec:
   - type: SingleNamespace
     supported: true
   - type: MultiNamespace
-    supported: false
+    supported: true
   - type: AllNamespaces
-    supported: false
+    supported: true
   install:
     spec:
       clusterPermissions:
@@ -262,17 +254,11 @@ spec:
         description: The docker image name and version of Portworx Enterprise.
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
-      - path: imagePullPolicy
-        displayName: Image Pull Policy
-        description: It is the pull policy for the image. Takes one of Always, Never,
-          IfNotPresent. Defaults to Always.
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:imagePullPolicy'
-        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:image'
       - path: imagePullSecret
-        displayName: Image Pull Secret
-        description: It is a reference to secret in the kube-system namespace which
-          is used for pulling images used by this storage cluster.
+        displayName: Private Registry Image Pull Secret
+        description: It is a reference to a secret in the same namespace as the
+          StorageCluster. This secret is used to pull images from a private
+          registry.
         x-descriptors:
         - 'urn:alm:descriptor:io.kubernetes:Secret'
         - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:image'
@@ -285,42 +271,48 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
         - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:image'
-      - path: stork.enabled
-        displayName: Enable Stork
-        description: 'Enable Stork'
+      - description: The secrets provider which will contain secrets that are needed by
+          Portworx for features like volume encryption, cloudsnaps, etc.
+        displayName: Secrets Provider
+        path: secretsProvider
         x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
-        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:stork'
-      - path: stork.image
-        displayName: Stork Image
-        description: The docker image name and version of Stork.
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:text'
-        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:stork'
-      - path: userInterface.enabled
-        displayName: Enable Lighthouse
-        description: 'Enable Lighthouse'
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
-        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:lighthouse'
-      - path: userInterface.image
-        displayName: Lighthouse Image
-        description: The docker image name and version of Lighthouse.
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:text'
-        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:lighthouse'
-      - path: monitoring.enableMetrics
-        displayName: Enable Metrics
-        description: 'Expose Portworx metrics to Prometheus'
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
-        - 'urn:alm:descriptor:com.tectonic.ui:fieldGroup:monitoring'
-      - path: featureGates.CSI
-        displayName: Enable CSI
-        description: 'Enable CSI'
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
         - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - 'urn:alm:descriptor:com.tectonic.ui:select:k8s'
+        - 'urn:alm:descriptor:com.tectonic.ui:select:vault'
+        - 'urn:alm:descriptor:com.tectonic.ui:select:aws-kms'
+        - 'urn:alm:descriptor:com.tectonic.ui:select:azure-kv'
+        - 'urn:alm:descriptor:com.tectonic.ui:select:ibm-kp'
+      - description: This controls the delete strategy of the Portworx cluster.
+        displayName: DeleteStrategy
+        path: deleteStrategy.type
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:advanced'
+        - 'urn:alm:descriptor:com.tectonic.ui:select:Uninstall'
+        - 'urn:alm:descriptor:com.tectonic.ui:select:UninstallAndWipe'
+      - description: It is the pull policy for the image. Accepts one of Always, Never,
+          IfNotPresent. Defaults to Always.
+        displayName: Image Pull Policy
+        path: imagePullPolicy
+      - description: Expose Portworx metrics to Prometheus.
+        displayName: Enable Metrics
+        path: monitoring.enableMetrics
+      - description: The network interface to be used by Portworx for data traffic.
+        displayName: Data Interface
+        path: network.dataInterface
+      - description: The network interface to be used by Portworx for management
+          traffic.
+        displayName: Management Interface
+        path: network.mgmtInterface
+      - description: It is the starting port in the range of ports used by Portworx.
+        displayName: Start Port
+        path: startPort
+      - description: Revision history limit is the number of old histories to retain.
+        displayName: Revision History Limit
+        path: revisionHistoryLimit
+      - description: Version is a read-only field. It contains the current version of
+          Portworx.
+        displayName: Version
+        path: version
       statusDescriptors:
       - path: conditions
         displayName: Cluster Conditions

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -136,6 +136,18 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1alpha1.StorageClu
 	startPort := uint32(t.startPort)
 	toUpdate.Spec.StartPort = &startPort
 
+	// If no storage spec is provided, initialize one where Portworx takes all available drives
+	if toUpdate.Spec.CloudStorage == nil && toUpdate.Spec.Storage == nil {
+		toUpdate.Spec.Storage = &corev1alpha1.StorageSpec{}
+	}
+	if toUpdate.Spec.Storage != nil {
+		if toUpdate.Spec.Storage.Devices == nil &&
+			(toUpdate.Spec.Storage.UseAllWithPartitions == nil || !*toUpdate.Spec.Storage.UseAllWithPartitions) &&
+			toUpdate.Spec.Storage.UseAll == nil {
+			toUpdate.Spec.Storage.UseAll = boolPtr(true)
+		}
+	}
+
 	if toUpdate.Spec.Placement == nil || toUpdate.Spec.Placement.NodeAffinity == nil {
 		toUpdate.Spec.Placement = &corev1alpha1.PlacementSpec{
 			NodeAffinity: &v1.NodeAffinity{

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -957,6 +957,28 @@ func CreateOrUpdateDaemonSet(
 	return k8sClient.Update(context.TODO(), existingDS)
 }
 
+// UpdateStorageClusterStatus updates the status of given StorageCluster object
+// on the latest copy
+func UpdateStorageClusterStatus(
+	k8sClient client.Client,
+	cluster *corev1alpha1.StorageCluster,
+) error {
+	existingCluster := &corev1alpha1.StorageCluster{}
+	if err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+		existingCluster,
+	); err != nil {
+		return err
+	}
+
+	cluster.ResourceVersion = existingCluster.ResourceVersion
+	return k8sClient.Status().Update(context.TODO(), cluster)
+}
+
 // CreateOrUpdateStorageNode creates a StorageNode if not present, else updates it
 func CreateOrUpdateStorageNode(
 	k8sClient client.Client,


### PR DESCRIPTION
- Add status for deleting stages
- Allow all installation modes for the operator to support previous releases
- Remove the defaults from the example spec to keep the StorageCluster spec simple.