### PR TITLE
Heterogenous storage configuration using node specs

### DIFF
--- a/deploy/crds/core_v1alpha1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1alpha1_storagecluster_crd.yaml
@@ -611,6 +611,83 @@ spec:
                             type: string
                           optional:
                             type: boolean
+            nodes:
+              type: array
+              description: Node level configurations that will override the configuration at cluster level.
+                These configurations can be for individual nodes or can be grouped to override configuration
+                of multiple nodes based on label selectors.
+              items:
+                type: object
+                properties:
+                  selector:
+                    type: object
+                    description: Configuration in this node block is applied to nodes based on this selector.
+                      Use either nodeName of labelSelector, not both. If nodeName is used, labelSelector will
+                      be ignored.
+                    properties:
+                      nodeName:
+                        type: string
+                        description: Name of the Kubernetes node that is to be selected. If present then the
+                          labelSelector is ignored even if the node with the given name is absent and the
+                          labelSelector matches another node.
+                      labelSelector:
+                        type: object
+                        description: It is a label query over all the nodes. The result of matchLabels and
+                          matchExpressions is ANDed. An empty label selector matches all nodes. A null
+                          label selector matches no objects.
+                        properties:
+                          matchLabels:
+                            type: object
+                            description: It is a map of key-value pairs. A single key-value in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          matchExpressions:
+                            type: array
+                            description: It is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              type: object
+                              properties:
+                                key:
+                                  type: string
+                                  description: It is the label key that the selector applies to.
+                                operator:
+                                  type: string
+                                  description: "It represents a key's relationship to a set of values. Valid operators
+                                    are In, NotIn, Exists and DoesNotExist."
+                                values:
+                                  type: array
+                                  description: It is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty.
+                                  items:
+                                    type: string
+                  storage:
+                    type: object
+                    description: Details of the storage used by the storage driver.
+                    properties:
+                      useAll:
+                        type: boolean
+                        description: Use all available, unformatted, unpartitioned devices. This will be
+                          ignored if spec.storage.devices is not empty.
+                      useAllWithPartitions:
+                        type: boolean
+                        description: Use all available unformatted devices. This will be
+                          ignored if spec.storage.devices is not empty.
+                      forceUseDisks:
+                        type: boolean
+                        description: Flag indicating to use the devices even if there is file system present
+                          on it. Note that the devices may be wiped before using.
+                      devices:
+                        type: array
+                        description: List of devices to be used by the storage driver.
+                        items:
+                          type: string
+                      journalDevice:
+                        type: string
+                        description: Device used for journaling.
+                      systemMetadataDevice:
+                        type: string
+                        description: Device that will be used to store system metadata by the driver.
         status:
           type: object
           description: Most recently observed status of the storage cluster. This data may not be up to date.

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -14,6 +14,7 @@ import (
 	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
 	"github.com/libopenstorage/operator/pkg/cloudstorage"
 	"github.com/libopenstorage/operator/pkg/util"
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -317,7 +318,6 @@ func (p *portworx) GetStoragePodSpec(
 	}
 
 	if cluster.Spec.CloudStorage != nil && len(cluster.Spec.CloudStorage.CapacitySpecs) > 0 {
-
 		nodes, err := p.storageNodesList(cluster)
 		if err != nil {
 			return v1.PodSpec{}, err
@@ -388,7 +388,7 @@ func (p *portworx) createStorageNode(cluster *corev1alpha1.StorageCluster, nodeN
 	configureStorageNodeSpec(storageNode, cloudConfig)
 	if cluster.Status.Storage.StorageNodesPerZone != cloudConfig.StorageInstancesPerZone {
 		cluster.Status.Storage.StorageNodesPerZone = cloudConfig.StorageInstancesPerZone
-		err := p.k8sClient.Status().Update(context.TODO(), cluster)
+		err := k8sutil.UpdateStorageClusterStatus(p.k8sClient, cluster)
 		if err != nil {
 			return err
 		}

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -665,18 +665,29 @@ func setNodeSpecDefaults(toUpdate *corev1alpha1.StorageCluster) {
 		if nodeSpec.Storage == nil {
 			nodeSpecCopy.Storage = toUpdate.Spec.Storage.DeepCopy()
 		} else if toUpdate.Spec.Storage != nil {
-			if nodeSpecCopy.Storage.UseAll == nil && toUpdate.Spec.Storage.UseAll != nil {
-				nodeSpecCopy.Storage.UseAll = boolPtr(*toUpdate.Spec.Storage.UseAll)
+			// Devices, UseAll and UseAllWithPartitions should be set exclusive of each other, if not already
+			// set by the user in the node spec.
+			if nodeSpecCopy.Storage.Devices == nil &&
+				(nodeSpecCopy.Storage.UseAll == nil || !*nodeSpecCopy.Storage.UseAll) &&
+				(nodeSpecCopy.Storage.UseAllWithPartitions == nil || !*nodeSpecCopy.Storage.UseAllWithPartitions) &&
+				toUpdate.Spec.Storage.Devices != nil {
+				devices := append(make([]string, 0), *toUpdate.Spec.Storage.Devices...)
+				nodeSpecCopy.Storage.Devices = &devices
 			}
-			if nodeSpecCopy.Storage.UseAllWithPartitions == nil && toUpdate.Spec.Storage.UseAllWithPartitions != nil {
+			if nodeSpecCopy.Storage.UseAllWithPartitions == nil &&
+				(nodeSpecCopy.Storage.UseAll == nil || !*nodeSpecCopy.Storage.UseAll) &&
+				nodeSpecCopy.Storage.Devices == nil &&
+				toUpdate.Spec.Storage.UseAllWithPartitions != nil {
 				nodeSpecCopy.Storage.UseAllWithPartitions = boolPtr(*toUpdate.Spec.Storage.UseAllWithPartitions)
+			}
+			if nodeSpecCopy.Storage.UseAll == nil &&
+				(nodeSpecCopy.Storage.UseAllWithPartitions == nil || !*nodeSpecCopy.Storage.UseAllWithPartitions) &&
+				nodeSpecCopy.Storage.Devices == nil &&
+				toUpdate.Spec.Storage.UseAll != nil {
+				nodeSpecCopy.Storage.UseAll = boolPtr(*toUpdate.Spec.Storage.UseAll)
 			}
 			if nodeSpecCopy.Storage.ForceUseDisks == nil && toUpdate.Spec.Storage.ForceUseDisks != nil {
 				nodeSpecCopy.Storage.ForceUseDisks = boolPtr(*toUpdate.Spec.Storage.ForceUseDisks)
-			}
-			if nodeSpecCopy.Storage.Devices == nil && toUpdate.Spec.Storage.Devices != nil {
-				devices := append(make([]string, 0), *toUpdate.Spec.Storage.Devices...)
-				nodeSpecCopy.Storage.Devices = &devices
 			}
 			if nodeSpecCopy.Storage.JournalDevice == nil && toUpdate.Spec.Storage.JournalDevice != nil {
 				nodeSpecCopy.Storage.JournalDevice = stringPtr(*toUpdate.Spec.Storage.JournalDevice)

--- a/pkg/apis/core/v1alpha1/storagecluster.go
+++ b/pkg/apis/core/v1alpha1/storagecluster.go
@@ -90,7 +90,7 @@ type StorageClusterSpec struct {
 	Monitoring *MonitoringSpec `json:"monitoring,omitempty"`
 	// Nodes node level configurations that will override the ones at cluster
 	// level. These configurations can be grouped based on label selectors.
-	// Nodes []NodeSpec `json:"nodes"`
+	Nodes []NodeSpec `json:"nodes,omitempty"`
 }
 
 // NodeSpec is the spec used to define node level configuration. Values
@@ -100,10 +100,8 @@ type NodeSpec struct {
 	// Selector rest of the attributes are applied to a node that matches
 	// the selector
 	Selector NodeSelector `json:"selector,omitempty"`
-	// Geo is topology information for the node
-	Geo *Geography `json:"geography,omitempty"`
-	// CommonConfig that is present at both cluster and node level
-	CommonConfig
+	// Storage details of storage used by the driver
+	Storage *StorageSpec `json:"storage,omitempty"`
 }
 
 // CommonConfig are common configurations that are exposed at both

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -354,12 +354,11 @@ func (in *NodeSelector) DeepCopy() *NodeSelector {
 func (in *NodeSpec) DeepCopyInto(out *NodeSpec) {
 	*out = *in
 	in.Selector.DeepCopyInto(&out.Selector)
-	if in.Geo != nil {
-		in, out := &in.Geo, &out.Geo
-		*out = new(Geography)
-		**out = **in
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		*out = new(StorageSpec)
+		(*in).DeepCopyInto(*out)
 	}
-	in.CommonConfig.DeepCopyInto(&out.CommonConfig)
 	return
 }
 
@@ -602,6 +601,13 @@ func (in *StorageClusterSpec) DeepCopyInto(out *StorageClusterSpec) {
 		in, out := &in.Monitoring, &out.Monitoring
 		*out = new(MonitoringSpec)
 		**out = **in
+	}
+	if in.Nodes != nil {
+		in, out := &in.Nodes, &out.Nodes
+		*out = make([]NodeSpec, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }

--- a/pkg/controller/storagecluster/util.go
+++ b/pkg/controller/storagecluster/util.go
@@ -15,11 +15,11 @@ import (
 )
 
 // TODO: make the storage cluster pod a critical pod to guarantee scheduling
-func addOrUpdateStoragePodTolerations(pod *v1.Pod) {
+func addOrUpdateStoragePodTolerations(podSpec *v1.PodSpec) {
 	// StorageCluster pods shouldn't be deleted by NodeController in case of node problems.
 	// Add infinite toleration for taint notReady:NoExecute here to survive taint-based
 	// eviction enforced by NodeController when node turns not ready.
-	v1helper.AddOrUpdateTolerationInPod(pod, &v1.Toleration{
+	v1helper.AddOrUpdateTolerationInPodSpec(podSpec, &v1.Toleration{
 		Key:      schedapi.TaintNodeNotReady,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoExecute,
@@ -28,7 +28,7 @@ func addOrUpdateStoragePodTolerations(pod *v1.Pod) {
 	// StorageCluster pods shouldn't be deleted by NodeController in case of node problems.
 	// Add infinite toleration for taint unreachable:NoExecute here to survive taint-based
 	// eviction enforced by NodeController when node turns unreachable.
-	v1helper.AddOrUpdateTolerationInPod(pod, &v1.Toleration{
+	v1helper.AddOrUpdateTolerationInPodSpec(podSpec, &v1.Toleration{
 		Key:      schedapi.TaintNodeUnreachable,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoExecute,
@@ -36,31 +36,31 @@ func addOrUpdateStoragePodTolerations(pod *v1.Pod) {
 
 	// All StorageCluster pods should tolerate MemoryPressure, DiskPressure, Unschedulable
 	// and NetworkUnavailable and OutOfDisk taints.
-	v1helper.AddOrUpdateTolerationInPod(pod, &v1.Toleration{
+	v1helper.AddOrUpdateTolerationInPodSpec(podSpec, &v1.Toleration{
 		Key:      schedapi.TaintNodeDiskPressure,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoSchedule,
 	})
 
-	v1helper.AddOrUpdateTolerationInPod(pod, &v1.Toleration{
+	v1helper.AddOrUpdateTolerationInPodSpec(podSpec, &v1.Toleration{
 		Key:      schedapi.TaintNodeMemoryPressure,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoSchedule,
 	})
 
-	v1helper.AddOrUpdateTolerationInPod(pod, &v1.Toleration{
+	v1helper.AddOrUpdateTolerationInPodSpec(podSpec, &v1.Toleration{
 		Key:      schedapi.TaintNodePIDPressure,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoSchedule,
 	})
 
-	v1helper.AddOrUpdateTolerationInPod(pod, &v1.Toleration{
+	v1helper.AddOrUpdateTolerationInPodSpec(podSpec, &v1.Toleration{
 		Key:      schedapi.TaintNodeUnschedulable,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoSchedule,
 	})
 
-	v1helper.AddOrUpdateTolerationInPod(pod, &v1.Toleration{
+	v1helper.AddOrUpdateTolerationInPodSpec(podSpec, &v1.Toleration{
 		Key:      schedapi.TaintNodeNetworkUnavailable,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoSchedule,


### PR DESCRIPTION
- If the selector in node specs matches a k8s node, use the storage
   configuration from the matching node spec.
- If a partial storage config is used in node spec, populate the rest
   of the fields from cluster storage configuration.

A sample list of node specs will look something like below:
```
spec:
  storage:
    devices:
    - /dev/sda
    - /dev/sdb

  nodes:
  - selector:
      nodeName: k8s-node-1
    storage:
      useAll: true

  - selector:
      labelSelector:
        matchExpressions:
        - key: drive-type
          operator: In
          values:
          - ssd
          - hdd
    storage:
      devices:
      - /dev/xvdf

  - selector:
      labelSelector:
        matchLabels:
          storageless: "true"
    storage:
      devices: {}
```