### PR TITLE
Allow disabling of storage pods

### DIFF
--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -57,6 +57,14 @@ func (c *portworxAPI) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 }
 
 func (c *portworxAPI) Delete(cluster *corev1alpha1.StorageCluster) error {
+	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	if err := k8sutil.DeleteService(c.k8sClient, PxAPIServiceName, cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteDaemonSet(c.k8sClient, PxAPIDaemonSetName, cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
+	c.isCreated = false
 	return nil
 }
 

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -39,7 +39,7 @@ func (c *portworxAPI) Initialize(
 }
 
 func (c *portworxAPI) IsEnabled(cluster *corev1alpha1.StorageCluster) bool {
-	return true
+	return pxutil.IsPortworxEnabled(cluster)
 }
 
 func (c *portworxAPI) Reconcile(cluster *corev1alpha1.StorageCluster) error {

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -37,7 +37,7 @@ func (c *portworxBasic) Initialize(
 }
 
 func (c *portworxBasic) IsEnabled(cluster *corev1alpha1.StorageCluster) bool {
-	return true
+	return pxutil.IsPortworxEnabled(cluster)
 }
 
 func (c *portworxBasic) Reconcile(cluster *corev1alpha1.StorageCluster) error {

--- a/drivers/storage/portworx/component/portworx_crd.go
+++ b/drivers/storage/portworx/component/portworx_crd.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/sirupsen/logrus"
@@ -35,7 +36,7 @@ func (c *portworxCRD) Initialize(
 }
 
 func (c *portworxCRD) IsEnabled(cluster *corev1alpha1.StorageCluster) bool {
-	return true
+	return pxutil.IsPortworxEnabled(cluster)
 }
 
 func (c *portworxCRD) Reconcile(cluster *corev1alpha1.StorageCluster) error {

--- a/drivers/storage/portworx/component/portworx_sc.go
+++ b/drivers/storage/portworx/component/portworx_sc.go
@@ -53,7 +53,7 @@ func (c *portworxStorageClass) Initialize(
 }
 
 func (c *portworxStorageClass) IsEnabled(cluster *corev1alpha1.StorageCluster) bool {
-	return true
+	return pxutil.IsPortworxEnabled(cluster)
 }
 
 func (c *portworxStorageClass) Reconcile(cluster *corev1alpha1.StorageCluster) error {

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -61,6 +61,11 @@ func (c *pvcController) IsEnabled(cluster *corev1alpha1.StorageCluster) bool {
 		return enabled
 	}
 
+	// If portworx is disabled, then do not run pvc controller unless explicitly told to.
+	if !pxutil.IsPortworxEnabled(cluster) {
+		return false
+	}
+
 	// Enable PVC controller for managed kubernetes services. Also enable it for openshift,
 	// only if Portworx service is not deployed in kube-system namespace.
 	if pxutil.IsPKS(cluster) || pxutil.IsEKS(cluster) ||

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
+	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -72,6 +73,12 @@ var (
 	// variable for testing. DO NOT change the value of the function unless for testing.
 	SpecsBaseDir = getSpecsBaseDir
 )
+
+// IsPortworxEnabled returns true if portworx is not explicitly disabled using the annotation
+func IsPortworxEnabled(cluster *corev1alpha1.StorageCluster) bool {
+	disabled, err := strconv.ParseBool(cluster.Annotations[storagecluster.AnnotationDisableStorage])
+	return err != nil || !disabled
+}
 
 // IsPKS returns true if the annotation has a PKS annotation and is true value
 func IsPKS(cluster *corev1alpha1.StorageCluster) bool {

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -68,7 +68,7 @@ const (
 	ControllerName = "storagecluster-controller"
 	// AnnotationDisableStorage annotation to disable the storage pods from running.
 	// Defaults to false value.
-	AnnotationDisableStorage            = operatorPrefix + "/disable-storage-pods"
+	AnnotationDisableStorage            = operatorPrefix + "/disable-storage"
 	slowStartInitialBatchSize           = 1
 	validateCRDInterval                 = 5 * time.Second
 	validateCRDTimeout                  = 1 * time.Minute

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-version"
-	_ "github.com/libopenstorage/operator/drivers/storage/portworx"
 	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
 	"github.com/libopenstorage/operator/pkg/util"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"


### PR DESCRIPTION
- If portworx is disabled, then do not deploy
  portworx pods, portworx RBAC, API pods, portworx service, storage classes
- Do not update storage cluster status or create storage node objects
- Do not allow deleting the portworx with any delete strategy
- We should still be able to deploy components using the StorageCluster

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>