### PR TITLE
Check portworx service in any namespace for metrics

### DIFF
--- a/drivers/storage/portworx/component/monitoring.go
+++ b/drivers/storage/portworx/component/monitoring.go
@@ -105,7 +105,7 @@ func (c *monitoring) createServiceMonitor(
 				},
 			},
 			NamespaceSelector: monitoringv1.NamespaceSelector{
-				MatchNames: []string{cluster.Namespace},
+				Any: true,
 			},
 			Selector: metav1.LabelSelector{
 				MatchLabels: pxutil.SelectorLabels(),

--- a/drivers/storage/portworx/testspec/prometheusServiceMonitor.yaml
+++ b/drivers/storage/portworx/testspec/prometheusServiceMonitor.yaml
@@ -10,7 +10,6 @@ spec:
     matchLabels:
       name: portworx
   namespaceSelector:
-    matchNames:
-    - kube-test
+    any: true
   endpoints:
   - port: px-api

--- a/drivers/storage/portworx/testspec/prometheusServiceMonitorWithInternalKvdb.yaml
+++ b/drivers/storage/portworx/testspec/prometheusServiceMonitorWithInternalKvdb.yaml
@@ -10,8 +10,7 @@ spec:
     matchLabels:
       name: portworx
   namespaceSelector:
-    matchNames:
-    - kube-test
+    any: true
   endpoints:
   - port: px-api
   - port: px-kvdb


### PR DESCRIPTION
This is useful when px central like components deploy their
own prometheus stack in their own namespace.

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>