### PR TITLE
prometheus operator version change

### DIFF
--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -14,7 +14,7 @@ import (
 	"github.com/portworx/sched-ops/k8s"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metaerrors "k8s.io/apimachinery/pkg/api/meta"
@@ -50,7 +50,7 @@ const (
 	// PrometheusInstanceName name of the prometheus instance
 	PrometheusInstanceName = "px-prometheus"
 	// DefaultPrometheusOperatorImage is the default prometheus operator image
-	DefaultPrometheusOperatorImage = "quay.io/coreos/prometheus-operator:v0.29.0"
+	DefaultPrometheusOperatorImage = "quay.io/coreos/prometheus-operator:v0.35.0"
 )
 
 type prometheus struct {
@@ -226,6 +226,7 @@ func (c *prometheus) createOperatorClusterRole(ownerRef *metav1.OwnerReference) 
 						"prometheuses/finalizers",
 						"servicemonitors",
 						"prometheusrules",
+						"podmonitors",
 					},
 					Verbs: []string{"*"},
 				},

--- a/drivers/storage/portworx/testspec/prometheusOperatorClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/prometheusOperatorClusterRole.yaml
@@ -22,6 +22,7 @@ rules:
       - prometheuses/finalizers
       - servicemonitors
       - prometheusrules
+      - podmonitors
     verbs: ["*"]
   - apiGroups:
       - apps

--- a/drivers/storage/portworx/testspec/prometheusOperatorDeployment.yaml
+++ b/drivers/storage/portworx/testspec/prometheusOperatorDeployment.yaml
@@ -19,7 +19,7 @@ spec:
         - args:
             - --kubelet-service=kube-test/kubelet
             - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-          image: quay.io/coreos/prometheus-operator:v0.29.0
+          image: quay.io/coreos/prometheus-operator:v0.35.0
           imagePullPolicy: Always
           name: px-prometheus-operator
           ports:


### PR DESCRIPTION
- Changed Prometheus operator version from 0.29.0 to 0.35.0(latest stable)
- Added `podmonitors` permissions into Prometheus operator cluster role