### PR TITLE
Annotation to disable default portworx storage classes

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7-atomic:7.6
+FROM registry.access.redhat.com/rhel7-atomic:7.7
 
 LABEL name="OpenStorage Operator" \
       vendor="openstorage.org" \

--- a/drivers/storage/portworx/component/portworx_sc.go
+++ b/drivers/storage/portworx/component/portworx_sc.go
@@ -53,7 +53,7 @@ func (c *portworxStorageClass) Initialize(
 }
 
 func (c *portworxStorageClass) IsEnabled(cluster *corev1alpha1.StorageCluster) bool {
-	return pxutil.IsPortworxEnabled(cluster)
+	return pxutil.IsPortworxEnabled(cluster) && pxutil.StorageClassEnabled(cluster)
 }
 
 func (c *portworxStorageClass) Reconcile(cluster *corev1alpha1.StorageCluster) error {
@@ -195,6 +195,31 @@ annotations:
 }
 
 func (c *portworxStorageClass) Delete(cluster *corev1alpha1.StorageCluster) error {
+	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbStorageClass, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxReplicatedStorageClass, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbLocalSnapshotStorageClass, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbCloudSnapshotStorageClass, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbEncryptedStorageClass, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxReplicatedEncryptedStorageClass, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbLocalSnapshotEncryptedStorageClass, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbCloudSnapshotEncryptedStorageClass, *ownerRef); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -197,6 +197,11 @@ func (c *pvcController) createClusterRole(ownerRef *metav1.OwnerReference) error
 				},
 				{
 					APIGroups: []string{""},
+					Resources: []string{"serviceaccounts/token"},
+					Verbs:     []string{"create"},
+				},
+				{
+					APIGroups: []string{""},
 					Resources: []string{"configmaps"},
 					Verbs:     []string{"get", "create", "update"},
 				},

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -42,7 +42,7 @@ const (
 	defaultStorkImage                 = "openstorage/stork:2.3.1"
 	defaultSDKPort                    = 9020
 	defaultSecretsProvider            = "k8s"
-	defaultNodeWiperImage             = "portworx/px-node-wiper:2.1.2-rc1"
+	defaultNodeWiperImage             = "portworx/px-node-wiper:2.1.4"
 	envKeyNodeWiperImage              = "PX_NODE_WIPER_IMAGE"
 	envKeyPortworxEnableTLS           = "PX_ENABLE_TLS"
 	storageClusterDeleteMsg           = "Portworx service NOT removed. Portworx drives and data NOT wiped."

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -2533,10 +2534,12 @@ func TestDeleteClusterWithCustomRepoRegistry(t *testing.T) {
 	_, err := driver.DeleteStorage(cluster)
 	require.NoError(t, err)
 
+	parts := strings.Split(defaultNodeWiperImage, "/")
+	expectedNodeWiperImage := parts[len(parts)-1]
 	wiperDS := &appsv1.DaemonSet{}
 	err = testutil.Get(k8sClient, wiperDS, pxNodeWiperDaemonSetName, cluster.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, customRepo+"/px-node-wiper:2.1.2-rc1",
+	require.Equal(t, customRepo+"/"+expectedNodeWiperImage,
 		wiperDS.Spec.Template.Spec.Containers[0].Image,
 	)
 }
@@ -2566,7 +2569,7 @@ func TestDeleteClusterWithCustomRegistry(t *testing.T) {
 	wiperDS := &appsv1.DaemonSet{}
 	err = testutil.Get(k8sClient, wiperDS, pxNodeWiperDaemonSetName, cluster.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, customRegistry+"/portworx/px-node-wiper:2.1.2-rc1",
+	require.Equal(t, customRegistry+"/"+defaultNodeWiperImage,
 		wiperDS.Spec.Template.Spec.Containers[0].Image,
 	)
 }

--- a/drivers/storage/portworx/testspec/nodeWiper.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiper.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: px-node-wiper
-        image: portworx/px-node-wiper:2.1.2-rc1
+        image: portworx/px-node-wiper:2.1.4
         imagePullPolicy: Always
         args:
         - -w

--- a/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: px-node-wiper
-        image: portworx/px-node-wiper:2.1.2-rc1
+        image: portworx/px-node-wiper:2.1.4
         imagePullPolicy: Always
         args:
         - -w

--- a/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: px-node-wiper
-        image: portworx/px-node-wiper:2.1.2-rc1
+        image: portworx/px-node-wiper:2.1.4
         imagePullPolicy: Always
         args:
         - -w

--- a/drivers/storage/portworx/testspec/openshift_runc.yaml
+++ b/drivers/storage/portworx/testspec/openshift_runc.yaml
@@ -37,7 +37,7 @@ spec:
           imagePullPolicy: Always
           args:
             ["-c", "px-cluster", "-a", "-secret_type", "k8s", "-b",
-             "-r", "9011", "-x", "kubernetes"]
+             "-r", "17001", "-x", "kubernetes"]
           env:
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-system"
@@ -51,13 +51,13 @@ spec:
             httpGet:
               host: 127.0.0.1
               path: /status
-              port: 9011
+              port: 17001
           readinessProbe:
             periodSeconds: 10
             httpGet:
               host: 127.0.0.1
               path: /health
-              port: 9025
+              port: 17015
           terminationMessagePath: "/tmp/px-termination-log"
           securityContext:
             privileged: true

--- a/drivers/storage/portworx/testspec/pvcControllerClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerClusterRole.yaml
@@ -37,5 +37,8 @@ rules:
   resources: ["serviceaccounts"]
   verbs: ["get", "create"]
 - apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
+- apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "create", "update"]

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -19,7 +19,7 @@ const (
 	// DefaultStartPort is the default start port for Portworx
 	DefaultStartPort = 9001
 	// DefaultOpenshiftStartPort is the default start port for Portworx on OpenShift
-	DefaultOpenshiftStartPort = 9011
+	DefaultOpenshiftStartPort = 17001
 	// PortworxSpecsDir is the directory where all the Portworx specs are stored
 	PortworxSpecsDir = "/configs"
 

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -56,6 +56,9 @@ const (
 	AnnotationServiceType = pxAnnotationPrefix + "/service-type"
 	// AnnotationPXVersion annotation indicating the portworx semantic version
 	AnnotationPXVersion = pxAnnotationPrefix + "/px-version"
+	// AnnotationDisableStorageClass annotation to disable installing default portworx
+	// storage classes
+	AnnotationDisableStorageClass = pxAnnotationPrefix + "/disable-storage-class"
 
 	// EnvKeyPXImage key for the environment variable that specifies Portworx image
 	EnvKeyPXImage = "PX_IMAGE"
@@ -110,6 +113,12 @@ func IsEKS(cluster *corev1alpha1.StorageCluster) bool {
 func IsOpenshift(cluster *corev1alpha1.StorageCluster) bool {
 	enabled, err := strconv.ParseBool(cluster.Annotations[AnnotationIsOpenshift])
 	return err == nil && enabled
+}
+
+// StorageClassEnabled returns true if default portworx storage classes are disabled
+func StorageClassEnabled(cluster *corev1alpha1.StorageCluster) bool {
+	disabled, err := strconv.ParseBool(cluster.Annotations[AnnotationDisableStorageClass])
+	return err != nil || !disabled
 }
 
 // ServiceType returns the k8s service type from cluster annotations if present

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -189,7 +189,7 @@ func TestRegisterCRDShouldRemoveNodeStatusCRD(t *testing.T) {
 func TestKubernetesVersionValidation(t *testing.T) {
 	fakeClient := fakek8sclient.NewSimpleClientset()
 	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &kversion.Info{
-		GitVersion: "v1.10.99",
+		GitVersion: "v1.11.99",
 	}
 	k8s.Instance().SetBaseClient(fakeClient)
 
@@ -253,7 +253,7 @@ func TestSingleClusterValidation(t *testing.T) {
 		},
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	k8sClient := testutil.FakeK8sClient(existingCluster, cluster)
 	recorder := record.NewFakeRecorder(10)
 	controller := Controller{
@@ -514,7 +514,7 @@ func TestFailureDuringStorkInstallation(t *testing.T) {
 	cluster.Annotations = map[string]string{
 		annotationStorkCPU: "invalid-cpu",
 	}
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -558,7 +558,7 @@ func TestFailureDuringDriverPreInstall(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -607,7 +607,7 @@ func TestStoragePodsShouldNotBeScheduledIfDisabled(t *testing.T) {
 	// Kubernetes node with resources to create a pod
 	k8sNode := createK8sNode("k8s-node-1", 10)
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster, k8sNode)
 	podControl := &k8scontroller.FakePodControl{}
@@ -662,7 +662,7 @@ func TestStoragePodGetsScheduled(t *testing.T) {
 	k8sNode1 := createK8sNode("k8s-node-1", 1)
 	k8sNode2 := createK8sNode("k8s-node-2", 1)
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster, k8sNode1, k8sNode2)
 	podControl := &k8scontroller.FakePodControl{}
@@ -917,7 +917,7 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 	}
 	k8sNode3 := createK8sNode("k8s-node-3", 1)
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster, k8sNode1, k8sNode2, k8sNode3)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1043,7 +1043,7 @@ func TestFailedStoragePodsGetRemoved(t *testing.T) {
 		labelKeyDriverName: driverName,
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1130,7 +1130,7 @@ func TestExtraStoragePodsGetRemoved(t *testing.T) {
 		labelKeyDriverName: driverName,
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1239,7 +1239,7 @@ func TestStoragePodsAreRemovedIfDisabled(t *testing.T) {
 		labelKeyDriverName: driverName,
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1301,7 +1301,7 @@ func TestStoragePodFailureDueToInsufficientResources(t *testing.T) {
 		labelKeyDriverName: driverName,
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1397,7 +1397,7 @@ func TestStoragePodFailureDueToNodeSelectorNotMatch(t *testing.T) {
 		labelKeyDriverName: driverName,
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1482,7 +1482,7 @@ func TestFailureDuringPodTemplateCreation(t *testing.T) {
 	k8sNode1 := createK8sNode("k8s-node-1", 1)
 	k8sNode2 := createK8sNode("k8s-node-2", 1)
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster, k8sNode1, k8sNode2)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1555,7 +1555,7 @@ func TestFailureDuringCreateDeletePods(t *testing.T) {
 		labelKeyDriverName: driverName,
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{
@@ -1623,7 +1623,7 @@ func TestTimeoutFailureDuringCreatePods(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	recorder := record.NewFakeRecorder(10)
@@ -1671,7 +1671,7 @@ func TestUpdateClusterStatusFromDriver(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1720,7 +1720,7 @@ func TestUpdateClusterStatusErrorFromDriver(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1771,7 +1771,7 @@ func TestFailedPreInstallFromDriver(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1820,7 +1820,7 @@ func TestUpdateDriverWithInstanceInformation(t *testing.T) {
 	k8sNode3 := createK8sNode("k8s-node-3", 1)
 	k8sNode3.Labels = map[string]string{failureDomainZoneKey: "z2"}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster, k8sNode1, k8sNode2, k8sNode3)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1897,7 +1897,7 @@ func TestDeleteStorageClusterWithoutFinalizers(t *testing.T) {
 		labelKeyDriverName: driverName,
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -1970,7 +1970,7 @@ func TestDeleteStorageClusterWithFinalizers(t *testing.T) {
 		labelKeyDriverName: driverName,
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -2107,7 +2107,7 @@ func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -2229,7 +2229,7 @@ func TestUpdateStorageClusterShouldNotExceedMaxUnavailable(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -2415,7 +2415,7 @@ func TestUpdateStorageClusterWithPercentageMaxUnavailable(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -2561,7 +2561,7 @@ func TestUpdateStorageClusterWithInvalidMaxUnavailableValue(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -2613,7 +2613,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItDoesNotHaveAnyHash(t *testing.T
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -2669,7 +2669,7 @@ func TestUpdateStorageClusterKvdbSpec(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -2773,7 +2773,7 @@ func TestUpdateStorageClusterCloudStorageSpec(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -2928,7 +2928,7 @@ func TestUpdateStorageClusterStorageSpec(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -3069,7 +3069,7 @@ func TestUpdateStorageClusterNetworkSpec(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -3152,7 +3152,7 @@ func TestUpdateStorageClusterEnvVariables(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -3237,7 +3237,7 @@ func TestUpdateStorageClusterRuntimeOptions(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -3319,7 +3319,7 @@ func TestUpdateStorageClusterSecretsProvider(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -3400,7 +3400,7 @@ func TestUpdateStorageClusterStartPort(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -3481,7 +3481,7 @@ func TestUpdateStorageClusterFeatureGates(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -3573,7 +3573,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 			Value: "cluster_value",
 		},
 	}
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -3952,7 +3952,7 @@ func TestUpdateStorageClusterK8sNodeChanges(t *testing.T) {
 			},
 		},
 	}
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -4039,7 +4039,7 @@ func TestUpdateStorageClusterShouldNotRestartPodsForSomeOptions(t *testing.T) {
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -4212,7 +4212,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItsHistoryHasInvalidSpec(t *testi
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	storageLabels := map[string]string{
 		labelKeyName:       cluster.Name,
@@ -4290,7 +4290,7 @@ func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
 	cluster.Spec.Image = "test/image:v1"
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -4416,7 +4416,7 @@ func TestUpdateClusterShouldHandleHashCollisions(t *testing.T) {
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
 	cluster.Spec.Image = "image/v1"
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -4567,7 +4567,7 @@ func TestUpdateClusterShouldDedupRevisionsAnywhereInHistory(t *testing.T) {
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
 	cluster.Spec.Image = "test/image:v1"
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}
@@ -4697,7 +4697,7 @@ func TestHistoryCleanup(t *testing.T) {
 	revisionLimit := int32(1)
 	cluster.Spec.RevisionHistoryLimit = &revisionLimit
 	cluster.Spec.Image = "test/image:v1"
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	podControl := &k8scontroller.FakePodControl{}

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -86,7 +86,7 @@ const (
 	crdBasePath                         = "/crds"
 	storageClusterCRDFile               = "core_v1alpha1_storagecluster_crd.yaml"
 	storageNodeCRDFile                  = "core_v1alpha1_storagenode_crd.yaml"
-	minSupportedK8sVersion              = "1.11.0"
+	minSupportedK8sVersion              = "1.12.0"
 )
 
 var _ reconcile.Reconciler = &Controller{}

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -60,7 +60,7 @@ func TestStorkInstallation(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -260,7 +260,7 @@ func TestStorkWithoutImage(t *testing.T) {
 		},
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	recorder := record.NewFakeRecorder(10)
 	controller := Controller{
@@ -308,7 +308,7 @@ func TestStorkImageChange(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -362,7 +362,7 @@ func TestStorkArgumentsChange(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -432,7 +432,7 @@ func TestStorkEnvVarsChange(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -499,7 +499,7 @@ func TestStorkCPUChange(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -556,7 +556,7 @@ func TestStorkSchedulerCPUChange(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -615,7 +615,7 @@ func TestStorkInvalidCPU(t *testing.T) {
 		},
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	recorder := record.NewFakeRecorder(10)
@@ -659,7 +659,7 @@ func TestStorkSchedulerInvalidCPU(t *testing.T) {
 		},
 	}
 
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	recorder := record.NewFakeRecorder(10)
@@ -704,7 +704,7 @@ func TestStorkSchedulerRollbackImageChange(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -725,7 +725,7 @@ func TestStorkSchedulerRollbackImageChange(t *testing.T) {
 	err = testutil.Get(k8sClient, deployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		"gcr.io/google_containers/kube-scheduler-amd64:v1.11.0",
+		"gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
 		deployment.Spec.Template.Spec.Containers[0].Image,
 	)
 
@@ -740,7 +740,7 @@ func TestStorkSchedulerRollbackImageChange(t *testing.T) {
 	err = testutil.Get(k8sClient, deployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		"gcr.io/google_containers/kube-scheduler-amd64:v1.11.0",
+		"gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
 		deployment.Spec.Template.Spec.Containers[0].Image,
 	)
 }
@@ -766,7 +766,7 @@ func TestStorkSchedulerRollbackCommandChange(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -824,7 +824,7 @@ func TestStorkInstallWithCustomRepoRegistry(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -853,7 +853,7 @@ func TestStorkInstallWithCustomRepoRegistry(t *testing.T) {
 	err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		customRepo+"/kube-scheduler-amd64:v1.11.0",
+		customRepo+"/kube-scheduler-amd64:v"+k8sVersion.String(),
 		schedDeployment.Spec.Template.Spec.Containers[0].Image,
 	)
 }
@@ -879,7 +879,7 @@ func TestStorkInstallWithCustomRegistry(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -912,7 +912,7 @@ func TestStorkInstallWithCustomRegistry(t *testing.T) {
 	err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		customRegistry+"/gcr.io/google_containers/kube-scheduler-amd64:v1.11.0",
+		customRegistry+"/gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
 		schedDeployment.Spec.Template.Spec.Containers[0].Image,
 	)
 	require.Equal(t,
@@ -941,7 +941,7 @@ func TestStorkInstallWithImagePullSecret(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -995,7 +995,7 @@ func TestDisableStork(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -1125,7 +1125,7 @@ func TestRemoveStork(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{
@@ -1255,7 +1255,7 @@ func TestStorkDriverNotImplemented(t *testing.T) {
 	}
 
 	k8s.Instance().SetBaseClient(fakek8sclient.NewSimpleClientset())
-	k8sVersion, _ := version.NewVersion("1.11.0")
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
 	controller := Controller{

--- a/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
@@ -29,7 +29,7 @@ spec:
         - --policy-configmap=stork-config
         - --policy-configmap-namespace=kube-test
         - --lock-object-name=stork-scheduler
-        image: gcr.io/google_containers/kube-scheduler-amd64:v1.11.0
+        image: gcr.io/google_containers/kube-scheduler-amd64:v1.12.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Changes included in this PR
- Add a new annotation to allow disabling default portworx storage classes
- Change the default start port for portworx in openshift to 17001
- Change minimum supported k8s version to 1.12
- Change operator's base image to rhel-atomic:7.7
- Update the portworx node-wiper image to 2.1.4