### PR TITLE
Fix node wiper security context constraints

### DIFF
--- a/deploy/olm-catalog/portworx/portworxoperator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/portworxoperator.v1.3.0.clusterserviceversion.yaml
@@ -163,36 +163,6 @@ spec:
           resources:
           - securitycontextconstraints
           resourceNames:
-          - privileged
-          verbs:
-          - use
-      - serviceAccountName: portworx
-        rules:
-        - apiGroups:
-          - security.openshift.io
-          resources:
-          - securitycontextconstraints
-          resourceNames:
-          - privileged
-          verbs:
-          - use
-      - serviceAccountName: portworx-pvc-controller
-        rules:
-        - apiGroups:
-          - security.openshift.io
-          resources:
-          - securitycontextconstraints
-          resourceNames:
-          - privileged
-          verbs:
-          - use
-      - serviceAccountName: px-lighthouse
-        rules:
-        - apiGroups:
-          - security.openshift.io
-          resources:
-          - securitycontextconstraints
-          resourceNames:
           - anyuid
           - privileged
           verbs:

--- a/drivers/storage/portworx/component/lighthouse.go
+++ b/drivers/storage/portworx/component/lighthouse.go
@@ -189,6 +189,12 @@ func (c *lighthouse) createClusterRole(ownerRef *metav1.OwnerReference) error {
 					},
 					Verbs: []string{"*"},
 				},
+				{
+					APIGroups:     []string{"security.openshift.io"},
+					Resources:     []string{"securitycontextconstraints"},
+					ResourceNames: []string{"privileged", "anyuid"},
+					Verbs:         []string{"use"},
+				},
 			},
 		},
 		ownerRef,

--- a/drivers/storage/portworx/component/lighthouse.go
+++ b/drivers/storage/portworx/component/lighthouse.go
@@ -95,8 +95,9 @@ func (c *lighthouse) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 
 func (c *lighthouse) Delete(cluster *corev1alpha1.StorageCluster) error {
 	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
-	// We don't delete the service account for Lighthouse because it is part of CSV. If
-	// we disable Lighthouse then the CSV upgrades would fail as requirements are not met.
+	if err := k8sutil.DeleteServiceAccount(c.k8sClient, LhServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
 	if err := k8sutil.DeleteClusterRole(c.k8sClient, LhClusterRoleName, *ownerRef); err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -214,6 +214,12 @@ func (c *portworxBasic) createClusterRole(ownerRef *metav1.OwnerReference) error
 					Resources: []string{"events"},
 					Verbs:     []string{"create"},
 				},
+				{
+					APIGroups:     []string{"security.openshift.io"},
+					Resources:     []string{"securitycontextconstraints"},
+					ResourceNames: []string{"privileged"},
+					Verbs:         []string{"use"},
+				},
 			},
 		},
 		ownerRef,

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -205,6 +205,12 @@ func (c *pvcController) createClusterRole(ownerRef *metav1.OwnerReference) error
 					Resources: []string{"configmaps"},
 					Verbs:     []string{"get", "create", "update"},
 				},
+				{
+					APIGroups:     []string{"security.openshift.io"},
+					Resources:     []string{"securitycontextconstraints"},
+					ResourceNames: []string{"privileged"},
+					Verbs:         []string{"use"},
+				},
 			},
 		},
 		ownerRef,

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -95,8 +95,9 @@ func (c *pvcController) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 
 func (c *pvcController) Delete(cluster *corev1alpha1.StorageCluster) error {
 	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
-	// We don't delete the service account for PVC controller because it is part of CSV. If
-	// we disable PVC controller then the CSV upgrades would fail as requirements are not met.
+	if err := k8sutil.DeleteServiceAccount(c.k8sClient, PVCServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
 	if err := k8sutil.DeleteClusterRole(c.k8sClient, PVCClusterRoleName, *ownerRef); err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -66,11 +66,11 @@ func (c *pvcController) IsEnabled(cluster *corev1alpha1.StorageCluster) bool {
 		return false
 	}
 
-	// Enable PVC controller for managed kubernetes services. Also enable it for openshift,
-	// only if Portworx service is not deployed in kube-system namespace.
+	// Enable PVC controller for managed kubernetes services. Also enable it
+	// if Portworx is not deployed in kube-system namespace.
 	if pxutil.IsPKS(cluster) || pxutil.IsEKS(cluster) ||
 		pxutil.IsGKE(cluster) || pxutil.IsAKS(cluster) ||
-		(pxutil.IsOpenshift(cluster) && cluster.Namespace != "kube-system") {
+		cluster.Namespace != "kube-system" {
 		return true
 	}
 	return false

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3954,7 +3954,7 @@ func TestRemovePVCController(t *testing.T) {
 	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.PVCServiceAccountName, cluster.Namespace)
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	cr = &rbacv1.ClusterRole{}
 	err = testutil.Get(k8sClient, cr, component.PVCClusterRoleName, "")
@@ -4015,7 +4015,7 @@ func TestDisablePVCController(t *testing.T) {
 	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.PVCServiceAccountName, cluster.Namespace)
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	cr = &rbacv1.ClusterRole{}
 	err = testutil.Get(k8sClient, cr, component.PVCClusterRoleName, "")
@@ -4082,7 +4082,7 @@ func TestRemoveLighthouse(t *testing.T) {
 	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.LhServiceAccountName, cluster.Namespace)
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	cr = &rbacv1.ClusterRole{}
 	err = testutil.Get(k8sClient, cr, component.LhClusterRoleName, "")
@@ -4153,7 +4153,7 @@ func TestDisableLighthouse(t *testing.T) {
 	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.LhServiceAccountName, cluster.Namespace)
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	cr = &rbacv1.ClusterRole{}
 	err = testutil.Get(k8sClient, cr, component.LhClusterRoleName, "")

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -2510,6 +2511,27 @@ func TestDeleteClusterWithUninstallStrategy(t *testing.T) {
 	require.Len(t, sa.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, sa.OwnerReferences[0].Name)
 
+	// Check wiper cluster role
+	expectedCR := testutil.GetExpectedClusterRole(t, "nodeWiperClusterRole.yaml")
+	wiperCR := &rbacv1.ClusterRole{}
+	err = testutil.Get(k8sClient, wiperCR, pxNodeWiperClusterRoleName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedCR.Name, wiperCR.Name)
+	require.Len(t, wiperCR.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, wiperCR.OwnerReferences[0].Name)
+	require.ElementsMatch(t, expectedCR.Rules, wiperCR.Rules)
+
+	// Check wiper cluster role binding
+	expectedCRB := testutil.GetExpectedClusterRoleBinding(t, "nodeWiperClusterRoleBinding.yaml")
+	wiperCRB := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, wiperCRB, pxNodeWiperClusterRoleBindingName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedCRB.Name, wiperCRB.Name)
+	require.Len(t, wiperCRB.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, wiperCRB.OwnerReferences[0].Name)
+	require.ElementsMatch(t, expectedCRB.Subjects, wiperCRB.Subjects)
+	require.Equal(t, expectedCRB.RoleRef, wiperCRB.RoleRef)
+
 	// Check wiper daemonset
 	expectedDaemonSet := testutil.GetExpectedDaemonSet(t, "nodeWiper.yaml")
 	wiperDS := &appsv1.DaemonSet{}
@@ -2687,6 +2709,27 @@ func TestDeleteClusterWithUninstallStrategyForPKS(t *testing.T) {
 	require.Len(t, sa.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, sa.OwnerReferences[0].Name)
 
+	// Check wiper cluster role
+	expectedCR := testutil.GetExpectedClusterRole(t, "nodeWiperClusterRole.yaml")
+	wiperCR := &rbacv1.ClusterRole{}
+	err = testutil.Get(k8sClient, wiperCR, pxNodeWiperClusterRoleName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedCR.Name, wiperCR.Name)
+	require.Len(t, wiperCR.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, wiperCR.OwnerReferences[0].Name)
+	require.ElementsMatch(t, expectedCR.Rules, wiperCR.Rules)
+
+	// Check wiper cluster role binding
+	expectedCRB := testutil.GetExpectedClusterRoleBinding(t, "nodeWiperClusterRoleBinding.yaml")
+	wiperCRB := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, wiperCRB, pxNodeWiperClusterRoleBindingName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedCRB.Name, wiperCRB.Name)
+	require.Len(t, wiperCRB.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, wiperCRB.OwnerReferences[0].Name)
+	require.ElementsMatch(t, expectedCRB.Subjects, wiperCRB.Subjects)
+	require.Equal(t, expectedCRB.RoleRef, wiperCRB.RoleRef)
+
 	// Check wiper daemonset
 	expectedDaemonSet := testutil.GetExpectedDaemonSet(t, "nodeWiperPKS.yaml")
 	wiperDS := &appsv1.DaemonSet{}
@@ -2730,6 +2773,27 @@ func TestDeleteClusterWithUninstallAndWipeStrategy(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, sa.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, sa.OwnerReferences[0].Name)
+
+	// Check wiper cluster role
+	expectedCR := testutil.GetExpectedClusterRole(t, "nodeWiperClusterRole.yaml")
+	wiperCR := &rbacv1.ClusterRole{}
+	err = testutil.Get(k8sClient, wiperCR, pxNodeWiperClusterRoleName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedCR.Name, wiperCR.Name)
+	require.Len(t, wiperCR.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, wiperCR.OwnerReferences[0].Name)
+	require.ElementsMatch(t, expectedCR.Rules, wiperCR.Rules)
+
+	// Check wiper cluster role binding
+	expectedCRB := testutil.GetExpectedClusterRoleBinding(t, "nodeWiperClusterRoleBinding.yaml")
+	wiperCRB := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, wiperCRB, pxNodeWiperClusterRoleBindingName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedCRB.Name, wiperCRB.Name)
+	require.Len(t, wiperCRB.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, wiperCRB.OwnerReferences[0].Name)
+	require.ElementsMatch(t, expectedCRB.Subjects, wiperCRB.Subjects)
+	require.Equal(t, expectedCRB.RoleRef, wiperCRB.RoleRef)
 
 	// Check wiper daemonset
 	expectedDaemonSet := testutil.GetExpectedDaemonSet(t, "nodeWiperWithWipe.yaml")

--- a/drivers/storage/portworx/testspec/lighthouseClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/lighthouseClusterRole.yaml
@@ -28,3 +28,7 @@ rules:
   - apiGroups: ["monitoring.coreos.com"]
     resources: ["alertmanagers", "prometheuses", "prometheuses/finalizers", "servicemonitors", "prometheusrules"]
     verbs: ["*"]
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["privileged", "anyuid"]
+    verbs: ["use"]

--- a/drivers/storage/portworx/testspec/nodeWiperClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperClusterRole.yaml
@@ -1,0 +1,9 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+   name: px-node-wiper
+rules:
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["privileged"]
+  verbs: ["use"]

--- a/drivers/storage/portworx/testspec/nodeWiperClusterRoleBinding.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: px-node-wiper
+subjects:
+- kind: ServiceAccount
+  name: px-node-wiper
+  namespace: kube-test
+roleRef:
+  kind: ClusterRole
+  name: px-node-wiper
+  apiGroup: rbac.authorization.k8s.io

--- a/drivers/storage/portworx/testspec/portworxClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/portworxClusterRole.yaml
@@ -31,3 +31,7 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs: ["create"]
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["privileged"]
+  verbs: ["use"]

--- a/drivers/storage/portworx/testspec/pvcControllerClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerClusterRole.yaml
@@ -42,3 +42,7 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "create", "update"]
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  resourceNames: ["privileged"]
+  verbs: ["use"]

--- a/drivers/storage/portworx/testspec/pvcControllerClusterRoleBinding.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerClusterRoleBinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: portworx-pvc-controller
-  namespace: kube-test
+  namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: portworx-pvc-controller

--- a/drivers/storage/portworx/testspec/pvcControllerDeployment.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerDeployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     tier: control-plane
   name: portworx-pvc-controller
-  namespace: kube-test
+  namespace: kube-system
 spec:
   replicas: 3
   strategy:

--- a/drivers/storage/portworx/testspec/pvcControllerDeploymentOpenshift.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerDeploymentOpenshift.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     tier: control-plane
   name: portworx-pvc-controller
-  namespace: kube-test
+  namespace: kube-system
 spec:
   replicas: 3
   strategy:


### PR DESCRIPTION
- Earlier we used to register the SCC from the operator CSV spec. Changing that to register it from the code now.
- Also adding a cluster role for portworx node wipe and adding SCC to that.