### PR TITLE
Create proxy pod and service in kube-system namespace for Portworx volume provisioning

### DIFF
--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -258,8 +258,15 @@ func (c *portworxBasic) createPortworxService(
 	cluster *corev1alpha1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	labels := pxutil.SelectorLabels()
+	service := getPortworxServiceSpec(cluster, ownerRef)
+	return k8sutil.CreateOrUpdateService(c.k8sClient, service, ownerRef)
+}
 
+func getPortworxServiceSpec(
+	cluster *corev1alpha1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) *v1.Service {
+	labels := pxutil.SelectorLabels()
 	startPort := pxutil.StartPort(cluster)
 	kvdbTargetPort := 9019
 	sdkTargetPort := 9020
@@ -314,7 +321,7 @@ func (c *portworxBasic) createPortworxService(
 		newService.Spec.Type = serviceType
 	}
 
-	return k8sutil.CreateOrUpdateService(c.k8sClient, newService, ownerRef)
+	return newService
 }
 
 // RegisterPortworxBasicComponent registers the Portworx Basic component

--- a/drivers/storage/portworx/component/portworx_proxy.go
+++ b/drivers/storage/portworx/component/portworx_proxy.go
@@ -1,0 +1,203 @@
+package component
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-version"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// PortworxProxyComponent name of the Portworx Proxy component. This component
+	// runs in the kube-system namespace if the cluster is running outside. This
+	// ensures that k8s in-tree driver traffic gets routed the Portworx nodes.
+	PortworxProxyComponent = "Portworx Proxy"
+	// PxProxyServiceAccountName name of the Portworx proxy service account
+	PxProxyServiceAccountName = "portworx-proxy"
+	// PxProxyClusterRoleBindingName name of the Portworx proxy cluster role binding
+	PxProxyClusterRoleBindingName = "portworx-proxy"
+	// PxProxyDaemonSetName name of the Portworx proxy daemon set
+	PxProxyDaemonSetName = "portworx-proxy"
+
+	pxProxyContainerName = "portworx-proxy"
+)
+
+type portworxProxy struct {
+	isCreated bool
+	k8sClient client.Client
+}
+
+func (c *portworxProxy) Initialize(
+	k8sClient client.Client,
+	_ version.Version,
+	_ *runtime.Scheme,
+	_ record.EventRecorder,
+) {
+	c.k8sClient = k8sClient
+}
+
+func (c *portworxProxy) IsEnabled(cluster *corev1alpha1.StorageCluster) bool {
+	return cluster.Namespace != api.NamespaceSystem &&
+		pxutil.StartPort(cluster) != pxutil.DefaultStartPort &&
+		pxutil.IsPortworxEnabled(cluster)
+}
+
+func (c *portworxProxy) Reconcile(cluster *corev1alpha1.StorageCluster) error {
+	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	if err := c.createServiceAccount(ownerRef); err != nil {
+		return NewError(ErrCritical, err)
+	}
+	if err := c.createClusterRoleBinding(ownerRef); err != nil {
+		return NewError(ErrCritical, err)
+	}
+	if err := c.createPortworxService(cluster, ownerRef); err != nil {
+		return NewError(ErrCritical, err)
+	}
+	if err := c.createDaemonSet(cluster, ownerRef); err != nil {
+		return NewError(ErrCritical, err)
+	}
+	return nil
+}
+
+func (c *portworxProxy) Delete(cluster *corev1alpha1.StorageCluster) error {
+	if cluster.Namespace == api.NamespaceSystem {
+		// If the cluster namespace is kube-system, then there is nothing to delete.
+		// Also, we do not want to delete portworx-service if running in kube-system
+		return nil
+	}
+
+	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	if err := k8sutil.DeleteServiceAccount(c.k8sClient, PxProxyServiceAccountName, api.NamespaceSystem, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PxProxyClusterRoleBindingName, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteService(c.k8sClient, pxutil.PortworxServiceName, api.NamespaceSystem, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteDaemonSet(c.k8sClient, PxProxyDaemonSetName, api.NamespaceSystem, *ownerRef); err != nil {
+		return err
+	}
+	c.isCreated = false
+	return nil
+}
+
+func (c *portworxProxy) MarkDeleted() {}
+
+func (c *portworxProxy) createServiceAccount(
+	ownerRef *metav1.OwnerReference,
+) error {
+	return k8sutil.CreateOrUpdateServiceAccount(
+		c.k8sClient,
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            PxProxyServiceAccountName,
+				Namespace:       api.NamespaceSystem,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+		},
+		ownerRef,
+	)
+}
+
+func (c *portworxProxy) createClusterRoleBinding(
+	ownerRef *metav1.OwnerReference,
+) error {
+	return k8sutil.CreateOrUpdateClusterRoleBinding(
+		c.k8sClient,
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            PxProxyClusterRoleBindingName,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      PxProxyServiceAccountName,
+					Namespace: api.NamespaceSystem,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     PxClusterRoleName,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+		ownerRef,
+	)
+}
+
+func (c *portworxProxy) createPortworxService(
+	cluster *corev1alpha1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	service := getPortworxServiceSpec(cluster, ownerRef)
+	service.Namespace = api.NamespaceSystem
+	service.Labels = getPortworxProxyServiceLabels()
+	service.Spec.Selector = getPortworxProxyServiceLabels()
+
+	return k8sutil.CreateOrUpdateService(c.k8sClient, service, ownerRef)
+}
+
+func (c *portworxProxy) createDaemonSet(
+	cluster *corev1alpha1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	existingDaemonSet := &appsv1.DaemonSet{}
+	getErr := c.k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      PxProxyDaemonSetName,
+			Namespace: api.NamespaceSystem,
+		},
+		existingDaemonSet,
+	)
+	if getErr != nil && !errors.IsNotFound(getErr) {
+		return getErr
+	}
+
+	if !c.isCreated || errors.IsNotFound(getErr) {
+		daemonSet := getPortworxAPIDaemonSetSpec(cluster, ownerRef)
+
+		daemonSet.Name = PxProxyDaemonSetName
+		daemonSet.Namespace = api.NamespaceSystem
+		daemonSet.Spec.Selector.MatchLabels = getPortworxProxyServiceLabels()
+		daemonSet.Spec.Template.Labels = getPortworxProxyServiceLabels()
+		daemonSet.Spec.Template.Spec.ServiceAccountName = PxProxyServiceAccountName
+		daemonSet.Spec.Template.Spec.Containers[0].Name = pxProxyContainerName
+
+		if err := k8sutil.CreateOrUpdateDaemonSet(c.k8sClient, daemonSet, ownerRef); err != nil {
+			return err
+		}
+	}
+	c.isCreated = true
+	return nil
+}
+
+func getPortworxProxyServiceLabels() map[string]string {
+	return map[string]string{
+		"name": PxProxyDaemonSetName,
+	}
+}
+
+// RegisterPortworxProxyComponent registers the Portworx proxy component
+func RegisterPortworxProxyComponent() {
+	Register(PortworxProxyComponent, &portworxProxy{})
+}
+
+func init() {
+	RegisterPortworxProxyComponent()
+}

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -709,6 +709,10 @@ func (t *template) getArguments() []string {
 func (t *template) getEnvList() []v1.EnvVar {
 	envList := []v1.EnvVar{
 		{
+			Name:  pxutil.EnvKeyPortworxNamespace,
+			Value: t.cluster.Namespace,
+		},
+		{
 			Name:  "PX_SECRETS_NAMESPACE",
 			Value: t.cluster.Namespace,
 		},

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -120,8 +120,8 @@ func TestPodSpecWithImagePullSecrets(t *testing.T) {
 
 	assert.Len(t, actual.ImagePullSecrets, 1)
 	assert.Equal(t, expectedPullSecret, actual.ImagePullSecrets[0])
-	assert.Len(t, actual.Containers[0].Env, 4)
-	assert.Equal(t, expectedRegistryEnv, actual.Containers[0].Env[3])
+	assert.Len(t, actual.Containers[0].Env, 5)
+	assert.Equal(t, expectedRegistryEnv, actual.Containers[0].Env[4])
 }
 
 func TestPodSpecWithTolerations(t *testing.T) {

--- a/drivers/storage/portworx/testspec/openshift_runc.yaml
+++ b/drivers/storage/portworx/testspec/openshift_runc.yaml
@@ -39,6 +39,8 @@ spec:
             ["-c", "px-cluster", "-a", "-secret_type", "k8s", "-b",
              "-r", "17001", "-x", "kubernetes"]
           env:
+            - name: "PX_NAMESPACE"
+              value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-system"
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"

--- a/drivers/storage/portworx/testspec/pks.yaml
+++ b/drivers/storage/portworx/testspec/pks.yaml
@@ -37,6 +37,8 @@ spec:
             ["-c", "px-cluster", "-a", "-secret_type", "k8s", "-b", "--keep-px-up",
              "-x", "kubernetes"]
           env:
+            - name: "PX_NAMESPACE"
+              value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-system"
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"

--- a/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
@@ -31,6 +31,8 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "PX_NAMESPACE"
+              value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-system"
           livenessProbe:

--- a/drivers/storage/portworx/testspec/pxProxyClusterRoleBinding.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: portworx-proxy
+subjects:
+- kind: ServiceAccount
+  name: portworx-proxy
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: portworx
+  apiGroup: rbac.authorization.k8s.io

--- a/drivers/storage/portworx/testspec/pxProxyDaemonSet.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyDaemonSet.yaml
@@ -37,7 +37,7 @@ spec:
             periodSeconds: 10
             httpGet:
               host: 127.0.0.1
-              path: /status
-              port: 10001
+              path: /health
+              port: 10015
       restartPolicy: Always
       serviceAccountName: portworx-proxy

--- a/drivers/storage/portworx/testspec/pxProxyDaemonSet.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyDaemonSet.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: portworx-api
-  namespace: kube-test
+  name: portworx-proxy
+  namespace: kube-system
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -10,11 +10,11 @@ spec:
       maxUnavailable: 100%
   selector:
     matchLabels:
-      name: portworx-api
+      name: portworx-proxy
   template:
     metadata:
       labels:
-        name: portworx-api
+        name: portworx-proxy
     spec:
       affinity:
         nodeAffinity:
@@ -30,7 +30,7 @@ spec:
       hostNetwork: true
       hostPID: false
       containers:
-        - name: portworx-api
+        - name: portworx-proxy
           image: k8s.gcr.io/pause:3.1
           imagePullPolicy: Always
           readinessProbe:
@@ -40,4 +40,4 @@ spec:
               path: /status
               port: 10001
       restartPolicy: Always
-      serviceAccountName: portworx
+      serviceAccountName: portworx-proxy

--- a/drivers/storage/portworx/testspec/pxProxyService.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyService.yaml
@@ -1,0 +1,28 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-service
+  namespace: kube-system
+  labels:
+    name: portworx-proxy
+spec:
+  selector:
+    name: portworx-proxy
+  type: ClusterIP
+  ports:
+    - name: px-api
+      protocol: TCP
+      port: 9001
+      targetPort: 10001
+    - name: px-kvdb
+      protocol: TCP
+      port: 9019
+      targetPort: 10016
+    - name: px-sdk
+      protocol: TCP
+      port: 9020
+      targetPort: 10017
+    - name: px-rest-gateway
+      protocol: TCP
+      port: 9021
+      targetPort: 10018

--- a/drivers/storage/portworx/testspec/px_csi_0.3.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_0.3.yaml
@@ -26,6 +26,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "PX_NAMESPACE"
+              value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-system"
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"

--- a/drivers/storage/portworx/testspec/px_csi_1.0.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_1.0.yaml
@@ -26,6 +26,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "PX_NAMESPACE"
+              value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-system"
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"

--- a/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
@@ -28,6 +28,8 @@ spec:
             "-key", "/etc/pwx/kvdbcerts/kvdb.key",
              "-x", "kubernetes"]
           env:
+            - name: "PX_NAMESPACE"
+              value: "kube-test"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-test"
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
@@ -27,6 +27,8 @@ spec:
             "-key", "/etc/pwx/kvdbcerts/kvdb.key",
              "-x", "kubernetes"]
           env:
+            - name: "PX_NAMESPACE"
+              value: "kube-test"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-test"
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
@@ -26,6 +26,8 @@ spec:
             "-cert", "/etc/pwx/kvdbcerts/kvdb.crt",
              "-x", "kubernetes"]
           env:
+            - name: "PX_NAMESPACE"
+              value: "kube-test"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-test"
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"

--- a/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
@@ -24,6 +24,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "PX_NAMESPACE"
+              value: "kube-test"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-test"
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"

--- a/drivers/storage/portworx/testspec/runc.yaml
+++ b/drivers/storage/portworx/testspec/runc.yaml
@@ -41,6 +41,8 @@ spec:
             "-rt_opts", "op1=10",
              "-x", "kubernetes"]
           env:
+            - name: "PX_NAMESPACE"
+              value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"
               value: "kube-system"
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"


### PR DESCRIPTION
- If running outside kube-system namespace and not using 9001 port, we create a proxy service to redirect in-tree driver traffic to portworx nodes.
- Pass PX_NAMESPACE to portworx pods.