### PR TITLE
Remove extra kubelet path from px container when CSI is enabled

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -4250,7 +4250,7 @@ func TestCompleteInstallWithCustomRegistry(t *testing.T) {
 	err = testutil.Get(k8sClient, prometheusOperatorDeployment, component.PrometheusOperatorDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		customRegistry+"/"+component.DefaultPrometheusOperatorImage,
+		customRegistry+"/"+strings.TrimPrefix(component.DefaultPrometheusOperatorImage, "quay.io/"),
 		prometheusOperatorDeployment.Spec.Template.Spec.Containers[0].Image,
 	)
 
@@ -4259,15 +4259,15 @@ func TestCompleteInstallWithCustomRegistry(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, csiDeployment.Spec.Template.Spec.Containers, 3)
 	require.Equal(t,
-		customRegistry+"/quay.io/openstorage/csi-provisioner:v1.4.0-1",
+		customRegistry+"/openstorage/csi-provisioner:v1.4.0-1",
 		csiDeployment.Spec.Template.Spec.Containers[0].Image,
 	)
 	require.Equal(t,
-		customRegistry+"/quay.io/openstorage/csi-attacher:v1.2.1-1",
+		customRegistry+"/openstorage/csi-attacher:v1.2.1-1",
 		csiDeployment.Spec.Template.Spec.Containers[1].Image,
 	)
 	require.Equal(t,
-		customRegistry+"/quay.io/k8scsi/csi-snapshotter:v2.0.0",
+		customRegistry+"/k8scsi/csi-snapshotter:v2.0.0",
 		csiDeployment.Spec.Template.Spec.Containers[2].Image,
 	)
 
@@ -4285,7 +4285,7 @@ func TestCompleteInstallWithCustomRegistry(t *testing.T) {
 	err = testutil.Get(k8sClient, csiDeployment, component.CSIApplicationName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		customRegistry+"/quay.io/k8scsi/csi-resizer:v0.3.0",
+		customRegistry+"/k8scsi/csi-resizer:v0.3.0",
 		csiDeployment.Spec.Template.Spec.Containers[2].Image,
 	)
 
@@ -4304,11 +4304,11 @@ func TestCompleteInstallWithCustomRegistry(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, csiStatefulSet.Spec.Template.Spec.Containers, 2)
 	require.Equal(t,
-		customRegistry+"/quay.io/k8scsi/csi-provisioner:v0.4.3",
+		customRegistry+"/k8scsi/csi-provisioner:v0.4.3",
 		csiStatefulSet.Spec.Template.Spec.Containers[0].Image,
 	)
 	require.Equal(t,
-		customRegistry+"/quay.io/k8scsi/csi-attacher:v0.4.2",
+		customRegistry+"/k8scsi/csi-attacher:v0.4.2",
 		csiStatefulSet.Spec.Template.Spec.Containers[1].Image,
 	)
 }

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3292,7 +3292,7 @@ func TestCSI_1_0_ChangeImageVersions(t *testing.T) {
 		deployment.Spec.Template.Spec.Containers[0].Image)
 	require.Equal(t, "quay.io/openstorage/csi-attacher:v1.2.1-1",
 		deployment.Spec.Template.Spec.Containers[1].Image)
-	require.Equal(t, "quay.io/openstorage/csi-snapshotter:v2.0.0",
+	require.Equal(t, "quay.io/k8scsi/csi-snapshotter:v2.0.0",
 		deployment.Spec.Template.Spec.Containers[2].Image)
 
 	// Change provisioner image
@@ -3331,7 +3331,7 @@ func TestCSI_1_0_ChangeImageVersions(t *testing.T) {
 
 	err = testutil.Get(k8sClient, deployment, component.CSIApplicationName, cluster.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, "quay.io/openstorage/csi-snapshotter:v2.0.0",
+	require.Equal(t, "quay.io/k8scsi/csi-snapshotter:v2.0.0",
 		deployment.Spec.Template.Spec.Containers[2].Image)
 
 	// Enable resizer and the change it's image
@@ -3498,7 +3498,7 @@ func TestCSIChangeKubernetesVersions(t *testing.T) {
 		deployment.Spec.Template.Spec.Containers[1].Image)
 	require.Equal(t, "--leader-election-type=configmaps",
 		deployment.Spec.Template.Spec.Containers[1].Args[3])
-	require.Equal(t, "quay.io/openstorage/csi-snapshotter:v2.0.0",
+	require.Equal(t, "quay.io/k8scsi/csi-snapshotter:v2.0.0",
 		deployment.Spec.Template.Spec.Containers[2].Image)
 	require.Equal(t, "--leader-election-type=configmaps",
 		deployment.Spec.Template.Spec.Containers[2].Args[4])
@@ -3526,7 +3526,7 @@ func TestCSIChangeKubernetesVersions(t *testing.T) {
 		deployment.Spec.Template.Spec.Containers[0].Image)
 	require.Equal(t, "--leader-election-type=leases",
 		deployment.Spec.Template.Spec.Containers[0].Args[4])
-	require.Equal(t, "quay.io/openstorage/csi-snapshotter:v2.0.0",
+	require.Equal(t, "quay.io/k8scsi/csi-snapshotter:v2.0.0",
 		deployment.Spec.Template.Spec.Containers[1].Image)
 	require.Equal(t, "--leader-election-type=leases",
 		deployment.Spec.Template.Spec.Containers[1].Args[4])
@@ -4267,7 +4267,7 @@ func TestCompleteInstallWithCustomRegistry(t *testing.T) {
 		csiDeployment.Spec.Template.Spec.Containers[1].Image,
 	)
 	require.Equal(t,
-		customRegistry+"/quay.io/openstorage/csi-snapshotter:v2.0.0",
+		customRegistry+"/quay.io/k8scsi/csi-snapshotter:v2.0.0",
 		csiDeployment.Spec.Template.Spec.Containers[2].Image,
 	)
 

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -777,16 +777,7 @@ func (t *template) getEnvList() []v1.EnvVar {
 }
 
 func (t *template) getVolumeMounts() []v1.VolumeMount {
-	// TODO: Imp: add etcd certs to the volume mounts
 	volumeInfoList := append([]volumeInfo{}, defaultVolumeInfoList...)
-
-	if pxutil.FeatureCSI.IsEnabled(t.cluster.Spec.FeatureGates) {
-		volumeInfoList = append(volumeInfoList, volumeInfo{
-			name:      "csi-driver-path",
-			mountPath: t.csiConfig.DriverBasePath(),
-		})
-	}
-
 	volumeMounts := make([]v1.VolumeMount, 0)
 	for _, v := range volumeInfoList {
 		volMount := v1.VolumeMount{
@@ -815,7 +806,6 @@ func (t *template) getVolumeMounts() []v1.VolumeMount {
 }
 
 func (t *template) getVolumes() []v1.Volume {
-	// TODO: Imp: add etcd certs to the volume list
 	volumeInfoList := append([]volumeInfo{}, defaultVolumeInfoList...)
 
 	if pxutil.FeatureCSI.IsEnabled(t.cluster.Spec.FeatureGates) {

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
@@ -34,7 +34,7 @@ spec:
               mountPath: /csi
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-snapshotter:v2.0.0
+          image: quay.io/k8scsi/csi-snapshotter:v2.0.0
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
@@ -45,7 +45,7 @@ spec:
               mountPath: /csi
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-snapshotter:v2.0.0
+          image: quay.io/k8scsi/csi-snapshotter:v2.0.0
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
@@ -61,7 +61,7 @@ spec:
               mountPath: /csi
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-snapshotter:v2.0.0
+          image: quay.io/k8scsi/csi-snapshotter:v2.0.0
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"

--- a/drivers/storage/portworx/testspec/px_csi_0.3.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_0.3.yaml
@@ -67,8 +67,6 @@ spec:
               mountPath: /etc/crictl.yaml
             - name: etcpwx
               mountPath: /etc/pwx
-            - name: csi-driver-path
-              mountPath: /var/lib/kubelet/plugins/com.openstorage.pxd
             - name: optpwx
               mountPath: /opt/pwx
             - name: procmount

--- a/drivers/storage/portworx/testspec/px_csi_1.0.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_1.0.yaml
@@ -65,8 +65,6 @@ spec:
               mountPath: /etc/crictl.yaml
             - name: etcpwx
               mountPath: /etc/pwx
-            - name: csi-driver-path
-              mountPath: /var/lib/kubelet/plugins/com.openstorage.pxd
             - name: optpwx
               mountPath: /opt/pwx
             - name: procmount

--- a/drivers/storage/portworx/util/csi_generator.go
+++ b/drivers/storage/portworx/util/csi_generator.go
@@ -180,7 +180,7 @@ func (g *CSIGenerator) setSidecarContainerVersionsV1_0() *CSIConfiguration {
 		Attacher:      "quay.io/openstorage/csi-attacher:v1.2.1-1",
 		NodeRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
 		Provisioner:   "quay.io/openstorage/csi-provisioner:v1.4.0-1",
-		Snapshotter:   "quay.io/openstorage/csi-snapshotter:v2.0.0",
+		Snapshotter:   "quay.io/k8scsi/csi-snapshotter:v2.0.0",
 		Resizer:       "quay.io/k8scsi/csi-resizer:v0.3.0",
 		// Single registrar has been deprecated
 		Registrar: "",

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,6 +27,7 @@ var (
 	// commonDockerRegistries is a map of commonly used Docker registries
 	commonDockerRegistries = map[string]bool{
 		"docker.io":                   true,
+		"quay.io":                     true,
 		"index.docker.io":             true,
 		"registry-1.docker.io":        true,
 		"registry.connect.redhat.com": true,


### PR DESCRIPTION
- Fix the csi-snapshotter image path
- Add quay.io to common registries list, so that the it get's replaced with custom registry if specified

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>