### PR TITLE
Remove deprecated snapshotter arg from csi-snapshotter

### DIFF
--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
@@ -38,9 +38,7 @@ spec:
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
-            - "--snapshotter=com.openstorage.pxd"
             - "--leader-election=true"
-            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
@@ -49,9 +49,7 @@ spec:
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
-            - "--snapshotter=pxd.portworx.com"
             - "--leader-election=true"
-            - "--leader-election-type=leases"
           env:
             - name: ADDRESS
               value: /csi/csi.sock

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
@@ -61,11 +61,10 @@ spec:
               mountPath: /csi
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-snapshotter:v2.0.0
+          image: quay.io/openstorage/csi-snapshotter:v1.2.2-1
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
-            - "--snapshotter=com.openstorage.pxd"
             - "--leader-election=true"
             - "--leader-election-type=configmaps"
           env:

--- a/drivers/storage/portworx/util/csi_generator.go
+++ b/drivers/storage/portworx/util/csi_generator.go
@@ -111,6 +111,7 @@ func (g *CSIGenerator) GetCSIConfiguration() *CSIConfiguration {
 	if (g.kubeVersion.GreaterThan(k8sVer1_13) || g.kubeVersion.Equal(k8sVer1_13)) &&
 		g.kubeVersion.LessThan(k8sVer1_14) {
 		cv.IncludeEndpointsAndConfigMapsForLeases = true
+		cv.Snapshotter = "quay.io/openstorage/csi-snapshotter:v1.2.2-1"
 	}
 
 	// Enable resizer sidecar when PX >= 2.2 and k8s >= 1.14.0


### PR DESCRIPTION
Also use older csi-snapshotter image for 1.13.*

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>