### PR TITLE
Add support to specify kvdb device

### DIFF
--- a/deploy/crds/core_v1alpha1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1alpha1_storagecluster_crd.yaml
@@ -306,6 +306,9 @@ spec:
                 systemMetadataDevice:
                   type: string
                   description: Device that will be used to store system metadata by the driver.
+                kvdbDevice:
+                  type: string
+                  description: Device used for internal KVDB.
             cloudStorage:
               type: object
               description: Details of storage used in cloud environment.
@@ -367,6 +370,9 @@ spec:
                   type: string
                   description: Device spec for the metadata device. This device will be used to store
                     system metadata by the driver.
+                kvdbDeviceSpec:
+                  type: string
+                  description: Device spec for internal KVDB device.
             network:
               type: object
               description: Contains network information that is needed by the storage driver.
@@ -736,6 +742,9 @@ spec:
                       systemMetadataDevice:
                         type: string
                         description: Device that will be used to store system metadata by the driver.
+                      kvdbDevice:
+                        type: string
+                        description: Device used for internal KVDB.
                   network:
                     type: object
                     description: Contains network information that is needed by the storage driver.

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -620,6 +620,10 @@ func (t *template) getArguments() []string {
 			*t.cluster.Spec.Storage.SystemMdDevice != "" {
 			args = append(args, "-metadata", *t.cluster.Spec.Storage.SystemMdDevice)
 		}
+		if t.cluster.Spec.Storage.KvdbDevice != nil &&
+			*t.cluster.Spec.Storage.KvdbDevice != "" {
+			args = append(args, "-kvdb_dev", *t.cluster.Spec.Storage.KvdbDevice)
+		}
 
 	} else if t.cluster.Spec.CloudStorage != nil {
 		if t.cloudConfig != nil && len(t.cloudConfig.CloudStorage) > 0 {
@@ -639,6 +643,10 @@ func (t *template) getArguments() []string {
 		if t.cluster.Spec.CloudStorage.SystemMdDeviceSpec != nil &&
 			len(*t.cluster.Spec.CloudStorage.SystemMdDeviceSpec) > 0 {
 			args = append(args, "-metadata", *t.cluster.Spec.CloudStorage.SystemMdDeviceSpec)
+		}
+		if t.cluster.Spec.CloudStorage.KvdbDeviceSpec != nil &&
+			*t.cluster.Spec.CloudStorage.KvdbDeviceSpec != "" {
+			args = append(args, "-kvdb_dev", *t.cluster.Spec.CloudStorage.KvdbDeviceSpec)
 		}
 		if t.cluster.Spec.CloudStorage.MaxStorageNodes != nil &&
 			*t.cluster.Spec.CloudStorage.MaxStorageNodes > 0 {

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -476,6 +476,35 @@ func TestPodSpecWithStorageSpec(t *testing.T) {
 
 	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
 
+	// Kvdb device
+	cluster.Spec.Storage = &corev1alpha1.StorageSpec{
+		KvdbDevice: stringPtr("/dev/kvdb"),
+	}
+	expectedArgs = []string{
+		"-c", "px-cluster",
+		"-x", "kubernetes",
+		"-kvdb_dev", "/dev/kvdb",
+	}
+
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+
+	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
+
+	// No kvdb device if empty
+	cluster.Spec.Storage = &corev1alpha1.StorageSpec{
+		KvdbDevice: stringPtr(""),
+	}
+	expectedArgs = []string{
+		"-c", "px-cluster",
+		"-x", "kubernetes",
+	}
+
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+
+	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
+
 	// Storage devices
 	devices := []string{"/dev/one", "/dev/two", "/dev/three"}
 	cluster.Spec.Storage = &corev1alpha1.StorageSpec{
@@ -645,6 +674,32 @@ func TestPodSpecWithCloudStorageSpec(t *testing.T) {
 	// Empty metadata device
 	cluster.Spec.CloudStorage = &corev1alpha1.CloudStorageSpec{
 		SystemMdDeviceSpec: stringPtr(""),
+	}
+	expectedArgs = []string{
+		"-c", "px-cluster",
+		"-x", "kubernetes",
+	}
+
+	actual, _ = driver.GetStoragePodSpec(cluster, nodeName)
+
+	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
+
+	// Kvdb device
+	cluster.Spec.CloudStorage = &corev1alpha1.CloudStorageSpec{
+		KvdbDeviceSpec: stringPtr("type=kvdb"),
+	}
+	expectedArgs = []string{
+		"-c", "px-cluster",
+		"-x", "kubernetes",
+		"-kvdb_dev", "type=kvdb",
+	}
+
+	actual, _ = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
+
+	// Empty kvdb device
+	cluster.Spec.CloudStorage = &corev1alpha1.CloudStorageSpec{
+		KvdbDeviceSpec: stringPtr(""),
 	}
 	expectedArgs = []string{
 		"-c", "px-cluster",

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -784,6 +784,9 @@ func setNodeSpecDefaults(toUpdate *corev1alpha1.StorageCluster) {
 			if nodeSpecCopy.Storage.SystemMdDevice == nil && toUpdate.Spec.Storage.SystemMdDevice != nil {
 				nodeSpecCopy.Storage.SystemMdDevice = stringPtr(*toUpdate.Spec.Storage.SystemMdDevice)
 			}
+			if nodeSpecCopy.Storage.KvdbDevice == nil && toUpdate.Spec.Storage.KvdbDevice != nil {
+				nodeSpecCopy.Storage.KvdbDevice = stringPtr(*toUpdate.Spec.Storage.KvdbDevice)
+			}
 		}
 		updatedNodeSpecs = append(updatedNodeSpecs, *nodeSpecCopy)
 	}

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -1,18 +1,10 @@
 package portworx
 
 import (
-	"context"
-	"crypto/x509"
 	"fmt"
-	"os"
-	"reflect"
-	"strconv"
 	"strings"
-	"time"
 
 	version "github.com/hashicorp/go-version"
-	"github.com/libopenstorage/openstorage/api"
-	"github.com/libopenstorage/openstorage/pkg/grpcserver"
 	"github.com/libopenstorage/operator/drivers/storage"
 	"github.com/libopenstorage/operator/drivers/storage/portworx/component"
 	"github.com/libopenstorage/operator/drivers/storage/portworx/manifest"
@@ -21,17 +13,11 @@ import (
 	"github.com/libopenstorage/operator/pkg/cloudstorage"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
-	coreops "github.com/portworx/sched-ops/k8s/core"
-	operatorops "github.com/portworx/sched-ops/k8s/operator"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -253,279 +239,6 @@ func (p *portworx) markComponentsAsDeleted() {
 	}
 }
 
-func (p *portworx) UpdateStorageClusterStatus(
-	cluster *corev1alpha1.StorageCluster,
-) error {
-	if cluster.Status.Phase == "" {
-		cluster.Status.ClusterName = cluster.Name
-		cluster.Status.Phase = string(corev1alpha1.ClusterInit)
-		return nil
-	}
-
-	if !pxutil.IsPortworxEnabled(cluster) {
-		cluster.Status.Phase = string(corev1alpha1.ClusterOnline)
-		return nil
-	}
-
-	clientConn, err := p.getPortworxClient(cluster)
-	if err != nil {
-		p.updateRemainingStorageNodesWithoutError(cluster, nil)
-		return err
-	}
-
-	clusterClient := api.NewOpenStorageClusterClient(clientConn)
-	pxCluster, err := clusterClient.InspectCurrent(context.TODO(), &api.SdkClusterInspectCurrentRequest{})
-	if err != nil {
-		if closeErr := p.sdkConn.Close(); closeErr != nil {
-			logrus.Warnf("Failed to close grpc connection. %v", closeErr)
-		}
-		p.sdkConn = nil
-		p.updateRemainingStorageNodesWithoutError(cluster, nil)
-		return fmt.Errorf("failed to inspect cluster: %v", err)
-	} else if pxCluster.Cluster == nil {
-		p.updateRemainingStorageNodesWithoutError(cluster, nil)
-		return fmt.Errorf("empty ClusterInspect response")
-	}
-
-	cluster.Status.Phase = string(mapClusterStatus(pxCluster.Cluster.Status))
-	cluster.Status.ClusterName = pxCluster.Cluster.Name
-	cluster.Status.ClusterUID = pxCluster.Cluster.Id
-
-	return p.updateStorageNodes(clientConn, cluster)
-}
-
-func (p *portworx) updateStorageNodes(
-	clientConn *grpc.ClientConn,
-	cluster *corev1alpha1.StorageCluster,
-) error {
-	nodeClient := api.NewOpenStorageNodeClient(clientConn)
-	nodeEnumerateResponse, err := nodeClient.EnumerateWithFilters(
-		context.TODO(),
-		&api.SdkNodeEnumerateWithFiltersRequest{},
-	)
-	if err != nil {
-		p.updateRemainingStorageNodesWithoutError(cluster, nil)
-		return fmt.Errorf("failed to enumerate nodes: %v", err)
-	}
-
-	// Find all k8s nodes where Portworx is actually running
-	currentPxNodes := make(map[string]bool)
-	for _, node := range nodeEnumerateResponse.Nodes {
-		if node.SchedulerNodeName == "" {
-			k8sNode, err := coreops.Instance().SearchNodeByAddresses(
-				[]string{node.DataIp, node.MgmtIp, node.Hostname},
-			)
-			if err != nil {
-				logrus.Warnf("Unable to find kubernetes node name for nodeID %v: %v", node.Id, err)
-				continue
-			}
-			node.SchedulerNodeName = k8sNode.Name
-		}
-
-		currentPxNodes[node.SchedulerNodeName] = true
-
-		storageNode, err := p.updateStorageNodeSpec(cluster, node)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to update StorageNode for nodeID %v: %v", node.Id, err)
-			p.warningEvent(cluster, util.FailedSyncReason, msg)
-			continue
-		}
-
-		err = p.updateStorageNodeStatus(storageNode, node)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to update StorageNode status for nodeID %v: %v", node.Id, err)
-			p.warningEvent(cluster, util.FailedSyncReason, msg)
-		}
-	}
-
-	return p.updateRemainingStorageNodes(cluster, currentPxNodes)
-}
-
-func (p *portworx) updateRemainingStorageNodesWithoutError(
-	cluster *corev1alpha1.StorageCluster,
-	currentPxNodes map[string]bool,
-) {
-	if err := p.updateRemainingStorageNodes(cluster, nil); err != nil {
-		logrus.Warn(err)
-	}
-}
-
-func (p *portworx) updateRemainingStorageNodes(
-	cluster *corev1alpha1.StorageCluster,
-	currentPxNodes map[string]bool,
-) error {
-	// Find all k8s nodes where Portworx pods are running
-	pxLabels := p.GetSelectorLabels()
-	portworxPodList := &v1.PodList{}
-	err := p.k8sClient.List(
-		context.TODO(),
-		portworxPodList,
-		&client.ListOptions{
-			Namespace:     cluster.Namespace,
-			LabelSelector: labels.SelectorFromSet(pxLabels),
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("failed to get list of portworx pods. %v", err)
-	}
-
-	currentPxPodNodes := make(map[string]bool)
-	for _, pod := range portworxPodList.Items {
-		controllerRef := metav1.GetControllerOf(&pod)
-		if controllerRef != nil && controllerRef.UID == cluster.UID && len(pod.Spec.NodeName) != 0 {
-			currentPxPodNodes[pod.Spec.NodeName] = true
-		}
-	}
-
-	storageNodes := &corev1alpha1.StorageNodeList{}
-	if err = p.k8sClient.List(context.TODO(), storageNodes, &client.ListOptions{}); err != nil {
-		return fmt.Errorf("failed to get a list of StorageNode: %v", err)
-	}
-
-	for _, storageNode := range storageNodes.Items {
-		pxNodeExists := currentPxNodes[storageNode.Name]
-		pxPodExists := currentPxPodNodes[storageNode.Name]
-		if !pxNodeExists && !pxPodExists {
-			logrus.Debugf("Deleting orphan StorageNode %v/%v",
-				storageNode.Namespace, storageNode.Name)
-
-			err = p.k8sClient.Delete(context.TODO(), storageNode.DeepCopy())
-			if err != nil && !errors.IsNotFound(err) {
-				msg := fmt.Sprintf("Failed to delete StorageNode %v/%v: %v",
-					storageNode.Namespace, storageNode.Name, err)
-				p.warningEvent(cluster, util.FailedSyncReason, msg)
-			}
-		} else if !pxNodeExists && pxPodExists {
-			// If the portworx pod exists, but corresponding portworx node is missing in
-			// enumerate, then it's either still initializing, failed or removed from cluster.
-			// If it's not initializing or failed, then change the node phase to Unknown.
-			newPhase := getStorageNodePhase(&storageNode.Status)
-			if newPhase != string(corev1alpha1.NodeInitStatus) &&
-				newPhase != string(corev1alpha1.NodeFailedStatus) {
-				newPhase = string(corev1alpha1.NodeUnknownStatus)
-			}
-			if storageNode.Status.Phase != newPhase {
-				storageNodeCopy := storageNode.DeepCopy()
-				storageNodeCopy.Status.Phase = newPhase
-				logrus.Debugf("Updating StorageNode %v/%v status",
-					storageNode.Namespace, storageNode.Name)
-				err = p.k8sClient.Status().Update(context.TODO(), storageNodeCopy)
-				if err != nil && !errors.IsNotFound(err) {
-					msg := fmt.Sprintf("Failed to update StorageNode %v/%v: %v",
-						storageNode.Namespace, storageNode.Name, err)
-					p.warningEvent(cluster, util.FailedSyncReason, msg)
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func (p *portworx) updateStorageNodeSpec(
-	cluster *corev1alpha1.StorageCluster,
-	node *api.StorageNode,
-) (*corev1alpha1.StorageNode, error) {
-	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
-	storageNode := &corev1alpha1.StorageNode{}
-	getErr := p.k8sClient.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      node.SchedulerNodeName,
-			Namespace: cluster.Namespace,
-		},
-		storageNode,
-	)
-	if getErr != nil && !errors.IsNotFound(getErr) {
-		return nil, getErr
-	}
-
-	originalStorageNode := storageNode.DeepCopy()
-	storageNode.Name = node.SchedulerNodeName
-	storageNode.Namespace = cluster.Namespace
-	storageNode.OwnerReferences = []metav1.OwnerReference{*ownerRef}
-	storageNode.Labels = p.GetSelectorLabels()
-
-	if version, ok := node.NodeLabels[labelPortworxVersion]; ok {
-		storageNode.Spec.Version = version
-	} else {
-		partitions := strings.Split(cluster.Spec.Image, ":")
-		if len(partitions) > 1 {
-			storageNode.Spec.Version = partitions[len(partitions)-1]
-		}
-	}
-
-	var err error
-	if errors.IsNotFound(getErr) {
-		logrus.Debugf("Creating StorageNode %s/%s", storageNode.Namespace, storageNode.Name)
-		err = p.k8sClient.Create(context.TODO(), storageNode)
-	} else if !reflect.DeepEqual(originalStorageNode, storageNode) {
-		logrus.Debugf("Updating StorageNode %s/%s", storageNode.Namespace, storageNode.Name)
-		err = p.k8sClient.Update(context.TODO(), storageNode)
-	}
-	return storageNode, err
-}
-
-func (p *portworx) updateStorageNodeStatus(
-	storageNode *corev1alpha1.StorageNode,
-	node *api.StorageNode,
-) error {
-	originalStorageNodeStatus := storageNode.Status.DeepCopy()
-	storageNode.Status.NodeUID = node.Id
-	storageNode.Status.Network = corev1alpha1.NetworkStatus{
-		DataIP: node.DataIp,
-		MgmtIP: node.MgmtIp,
-	}
-	nodeStateCondition := &corev1alpha1.NodeCondition{
-		Type:   corev1alpha1.NodeStateCondition,
-		Status: mapNodeStatus(node.Status),
-	}
-	operatorops.Instance().UpdateStorageNodeCondition(&storageNode.Status, nodeStateCondition)
-	storageNode.Status.Phase = getStorageNodePhase(&storageNode.Status)
-
-	if !reflect.DeepEqual(originalStorageNodeStatus, &storageNode.Status) {
-		logrus.Debugf("Updating StorageNode %s/%s status",
-			storageNode.Namespace, storageNode.Name)
-		return p.k8sClient.Status().Update(context.TODO(), storageNode)
-	}
-	return nil
-}
-
-func (p *portworx) getPortworxClient(
-	cluster *corev1alpha1.StorageCluster,
-) (*grpc.ClientConn, error) {
-	if p.sdkConn != nil {
-		return p.sdkConn, nil
-	}
-
-	pxService := &v1.Service{}
-	err := p.k8sClient.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      pxutil.PortworxServiceName,
-			Namespace: cluster.Namespace,
-		},
-		pxService,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get k8s service spec: %v", err)
-	} else if len(pxService.Spec.ClusterIP) == 0 {
-		return nil, fmt.Errorf("failed to get endpoint for portworx volume driver")
-	}
-
-	endpoint := pxService.Spec.ClusterIP
-	sdkPort := defaultSDKPort
-
-	// Get the ports from service
-	for _, pxServicePort := range pxService.Spec.Ports {
-		if pxServicePort.Name == pxutil.PortworxSDKPortName && pxServicePort.Port != 0 {
-			sdkPort = int(pxServicePort.Port)
-		}
-	}
-
-	endpoint = fmt.Sprintf("%s:%d", endpoint, sdkPort)
-	return p.getGrpcConn(endpoint)
-}
-
 func (p *portworx) warningEvent(
 	cluster *corev1alpha1.StorageCluster,
 	reason, message string,
@@ -534,20 +247,7 @@ func (p *portworx) warningEvent(
 	p.recorder.Event(cluster, v1.EventTypeWarning, reason, message)
 }
 
-func (p *portworx) getGrpcConn(endpoint string) (*grpc.ClientConn, error) {
-	dialOptions, err := getDialOptions(isTLSEnabled())
-	if err != nil {
-		return nil, err
-	}
-	p.sdkConn, err = grpcserver.Connect(endpoint, dialOptions)
-	if err != nil {
-		return nil, fmt.Errorf("error connecting to GRPC server [%s]: %v", endpoint, err)
-	}
-	return p.sdkConn, nil
-}
-
 func (p *portworx) storageNodeToCloudSpec(storageNodes []*corev1alpha1.StorageNode, cluster *corev1alpha1.StorageCluster) *cloudstorage.Config {
-
 	res := &cloudstorage.Config{
 		CloudStorage:            []cloudstorage.CloudDriveConfig{},
 		StorageInstancesPerZone: cluster.Status.Storage.StorageNodesPerZone,
@@ -567,104 +267,6 @@ func (p *portworx) storageNodeToCloudSpec(storageNodes []*corev1alpha1.StorageNo
 		}
 	}
 	return nil
-}
-
-func getDialOptions(tls bool) ([]grpc.DialOption, error) {
-	if !tls {
-		return []grpc.DialOption{grpc.WithInsecure()}, nil
-	}
-	capool, err := x509.SystemCertPool()
-	if err != nil {
-		return nil, fmt.Errorf("failed to load CA system certs: %v", err)
-	}
-	return []grpc.DialOption{grpc.WithTransportCredentials(
-		credentials.NewClientTLSFromCert(capool, ""),
-	)}, nil
-}
-
-func mapClusterStatus(status api.Status) corev1alpha1.ClusterConditionStatus {
-	switch status {
-	case api.Status_STATUS_NONE:
-		fallthrough
-	case api.Status_STATUS_INIT:
-		fallthrough
-	case api.Status_STATUS_OFFLINE:
-		fallthrough
-	case api.Status_STATUS_ERROR:
-		return corev1alpha1.ClusterOffline
-
-	case api.Status_STATUS_NOT_IN_QUORUM:
-		fallthrough
-	case api.Status_STATUS_NOT_IN_QUORUM_NO_STORAGE:
-		return corev1alpha1.ClusterNotInQuorum
-
-	case api.Status_STATUS_OK:
-		fallthrough
-	case api.Status_STATUS_MAINTENANCE:
-		fallthrough
-	case api.Status_STATUS_NEEDS_REBOOT:
-		fallthrough
-	case api.Status_STATUS_STORAGE_DOWN:
-		fallthrough
-	case api.Status_STATUS_STORAGE_DEGRADED:
-		fallthrough
-	case api.Status_STATUS_STORAGE_REBALANCE:
-		fallthrough
-	case api.Status_STATUS_STORAGE_DRIVE_REPLACE:
-		return corev1alpha1.ClusterOnline
-
-	case api.Status_STATUS_DECOMMISSION:
-		fallthrough
-	default:
-		return corev1alpha1.ClusterUnknown
-	}
-}
-
-func mapNodeStatus(status api.Status) corev1alpha1.NodeConditionStatus {
-	switch status {
-	case api.Status_STATUS_NONE:
-		fallthrough
-	case api.Status_STATUS_OFFLINE:
-		fallthrough
-	case api.Status_STATUS_ERROR:
-		fallthrough
-	case api.Status_STATUS_NEEDS_REBOOT:
-		return corev1alpha1.NodeOfflineStatus
-
-	case api.Status_STATUS_INIT:
-		return corev1alpha1.NodeInitStatus
-
-	case api.Status_STATUS_NOT_IN_QUORUM:
-		fallthrough
-	case api.Status_STATUS_NOT_IN_QUORUM_NO_STORAGE:
-		return corev1alpha1.NodeNotInQuorumStatus
-
-	case api.Status_STATUS_MAINTENANCE:
-		return corev1alpha1.NodeMaintenanceStatus
-
-	case api.Status_STATUS_OK:
-		fallthrough
-	case api.Status_STATUS_STORAGE_DOWN:
-		return corev1alpha1.NodeOnlineStatus
-
-	case api.Status_STATUS_DECOMMISSION:
-		return corev1alpha1.NodeDecommissionedStatus
-
-	case api.Status_STATUS_STORAGE_DEGRADED:
-		fallthrough
-	case api.Status_STATUS_STORAGE_REBALANCE:
-		fallthrough
-	case api.Status_STATUS_STORAGE_DRIVE_REPLACE:
-		return corev1alpha1.NodeDegradedStatus
-
-	default:
-		return corev1alpha1.NodeUnknownStatus
-	}
-}
-
-func isTLSEnabled() bool {
-	enabled, err := strconv.ParseBool(os.Getenv(envKeyPortworxEnableTLS))
-	return err == nil && enabled
 }
 
 func componentVersions(releases *manifest.ReleaseManifest, pxVersion *version.Version) (manifest.Release, error) {
@@ -876,29 +478,6 @@ func setComponentDefaults(
 		}
 		toUpdate.Spec.Monitoring.EnableMetrics = nil
 	}
-}
-
-func getStorageNodePhase(status *corev1alpha1.NodeStatus) string {
-	latestTime := metav1.NewTime(time.Time{})
-	var latestCondition *corev1alpha1.NodeCondition
-
-	for _, condition := range status.Conditions {
-		if latestTime.Before(&condition.LastTransitionTime) ||
-			latestTime.Equal(&condition.LastTransitionTime) {
-			latestCondition = condition.DeepCopy()
-			latestTime = condition.LastTransitionTime
-		}
-	}
-
-	// If no condition or status found return Initializing phase.
-	// Also if the InitCondition is the latest condition and it has succeeded,
-	// then keep the node phase as Initializing
-	if latestCondition == nil || latestCondition.Status == "" ||
-		(latestCondition.Type == corev1alpha1.NodeInitCondition &&
-			latestCondition.Status == corev1alpha1.NodeSucceededStatus) {
-		return string(corev1alpha1.NodeInitStatus)
-	}
-	return string(latestCondition.Status)
 }
 
 func init() {

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -658,6 +658,7 @@ func TestStorageClusterDefaultsForNodeSpecs(t *testing.T) {
 	require.Nil(t, cluster.Spec.Nodes[0].Storage.Devices)
 	require.Nil(t, cluster.Spec.Nodes[0].Storage.JournalDevice)
 	require.Nil(t, cluster.Spec.Nodes[0].Storage.SystemMdDevice)
+	require.Nil(t, cluster.Spec.Nodes[0].Storage.KvdbDevice)
 
 	// Set node spec storage fields from cluster storage spec, if empty at node level
 	// If devices is set, then no need to set UseAll and UseAllWithPartitions as it
@@ -670,6 +671,7 @@ func TestStorageClusterDefaultsForNodeSpecs(t *testing.T) {
 		ForceUseDisks:        boolPtr(true),
 		JournalDevice:        stringPtr("journal"),
 		SystemMdDevice:       stringPtr("metadata"),
+		KvdbDevice:           stringPtr("kvdb"),
 	}
 	cluster.Spec.Nodes = []corev1alpha1.NodeSpec{
 		{
@@ -685,6 +687,7 @@ func TestStorageClusterDefaultsForNodeSpecs(t *testing.T) {
 	require.ElementsMatch(t, clusterDevices, *cluster.Spec.Nodes[0].Storage.Devices)
 	require.Equal(t, "journal", *cluster.Spec.Nodes[0].Storage.JournalDevice)
 	require.Equal(t, "metadata", *cluster.Spec.Nodes[0].Storage.SystemMdDevice)
+	require.Equal(t, "kvdb", *cluster.Spec.Nodes[0].Storage.KvdbDevice)
 
 	// If devices is set and empty, even then no need to set UseAll and UseAllWithPartitions,
 	// as devices take precedence over them.
@@ -777,6 +780,7 @@ func TestStorageClusterDefaultsForNodeSpecs(t *testing.T) {
 		ForceUseDisks:        boolPtr(false),
 		JournalDevice:        stringPtr("node-journal"),
 		SystemMdDevice:       stringPtr("node-metadata"),
+		KvdbDevice:           stringPtr("node-kvdb"),
 	}
 	driver.SetDefaultsOnStorageCluster(cluster)
 	require.False(t, *cluster.Spec.Nodes[0].Storage.UseAll)
@@ -785,6 +789,7 @@ func TestStorageClusterDefaultsForNodeSpecs(t *testing.T) {
 	require.ElementsMatch(t, nodeDevices, *cluster.Spec.Nodes[0].Storage.Devices)
 	require.Equal(t, "node-journal", *cluster.Spec.Nodes[0].Storage.JournalDevice)
 	require.Equal(t, "node-metadata", *cluster.Spec.Nodes[0].Storage.SystemMdDevice)
+	require.Equal(t, "node-kvdb", *cluster.Spec.Nodes[0].Storage.KvdbDevice)
 }
 
 func TestSetDefaultsOnStorageClusterForOpenshift(t *testing.T) {

--- a/drivers/storage/portworx/status.go
+++ b/drivers/storage/portworx/status.go
@@ -1,0 +1,435 @@
+package portworx
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/pkg/grpcserver"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
+	"github.com/libopenstorage/operator/pkg/util"
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	operatorops "github.com/portworx/sched-ops/k8s/operator"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (p *portworx) UpdateStorageClusterStatus(
+	cluster *corev1alpha1.StorageCluster,
+) error {
+	if cluster.Status.Phase == "" {
+		cluster.Status.ClusterName = cluster.Name
+		cluster.Status.Phase = string(corev1alpha1.ClusterInit)
+		return nil
+	}
+
+	if !pxutil.IsPortworxEnabled(cluster) {
+		cluster.Status.Phase = string(corev1alpha1.ClusterOnline)
+		return nil
+	}
+
+	clientConn, err := p.getPortworxClient(cluster)
+	if err != nil {
+		p.updateRemainingStorageNodesWithoutError(cluster, nil)
+		return err
+	}
+
+	clusterClient := api.NewOpenStorageClusterClient(clientConn)
+	pxCluster, err := clusterClient.InspectCurrent(context.TODO(), &api.SdkClusterInspectCurrentRequest{})
+	if err != nil {
+		if closeErr := p.sdkConn.Close(); closeErr != nil {
+			logrus.Warnf("Failed to close grpc connection. %v", closeErr)
+		}
+		p.sdkConn = nil
+		p.updateRemainingStorageNodesWithoutError(cluster, nil)
+		return fmt.Errorf("failed to inspect cluster: %v", err)
+	} else if pxCluster.Cluster == nil {
+		p.updateRemainingStorageNodesWithoutError(cluster, nil)
+		return fmt.Errorf("empty ClusterInspect response")
+	}
+
+	cluster.Status.Phase = string(mapClusterStatus(pxCluster.Cluster.Status))
+	cluster.Status.ClusterName = pxCluster.Cluster.Name
+	cluster.Status.ClusterUID = pxCluster.Cluster.Id
+
+	return p.updateStorageNodes(clientConn, cluster)
+}
+
+func (p *portworx) updateStorageNodes(
+	clientConn *grpc.ClientConn,
+	cluster *corev1alpha1.StorageCluster,
+) error {
+	nodeClient := api.NewOpenStorageNodeClient(clientConn)
+	nodeEnumerateResponse, err := nodeClient.EnumerateWithFilters(
+		context.TODO(),
+		&api.SdkNodeEnumerateWithFiltersRequest{},
+	)
+	if err != nil {
+		p.updateRemainingStorageNodesWithoutError(cluster, nil)
+		return fmt.Errorf("failed to enumerate nodes: %v", err)
+	}
+
+	// Find all k8s nodes where Portworx is actually running
+	currentPxNodes := make(map[string]bool)
+	for _, node := range nodeEnumerateResponse.Nodes {
+		if node.SchedulerNodeName == "" {
+			k8sNode, err := coreops.Instance().SearchNodeByAddresses(
+				[]string{node.DataIp, node.MgmtIp, node.Hostname},
+			)
+			if err != nil {
+				logrus.Warnf("Unable to find kubernetes node name for nodeID %v: %v", node.Id, err)
+				continue
+			}
+			node.SchedulerNodeName = k8sNode.Name
+		}
+
+		currentPxNodes[node.SchedulerNodeName] = true
+
+		storageNode, err := p.updateStorageNodeSpec(cluster, node)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to update StorageNode for nodeID %v: %v", node.Id, err)
+			p.warningEvent(cluster, util.FailedSyncReason, msg)
+			continue
+		}
+
+		err = p.updateStorageNodeStatus(storageNode, node)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to update StorageNode status for nodeID %v: %v", node.Id, err)
+			p.warningEvent(cluster, util.FailedSyncReason, msg)
+		}
+	}
+
+	return p.updateRemainingStorageNodes(cluster, currentPxNodes)
+}
+
+func (p *portworx) updateRemainingStorageNodesWithoutError(
+	cluster *corev1alpha1.StorageCluster,
+	currentPxNodes map[string]bool,
+) {
+	if err := p.updateRemainingStorageNodes(cluster, nil); err != nil {
+		logrus.Warn(err)
+	}
+}
+
+func (p *portworx) updateRemainingStorageNodes(
+	cluster *corev1alpha1.StorageCluster,
+	currentPxNodes map[string]bool,
+) error {
+	// Find all k8s nodes where Portworx pods are running
+	pxLabels := p.GetSelectorLabels()
+	portworxPodList := &v1.PodList{}
+	err := p.k8sClient.List(
+		context.TODO(),
+		portworxPodList,
+		&client.ListOptions{
+			Namespace:     cluster.Namespace,
+			LabelSelector: labels.SelectorFromSet(pxLabels),
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to get list of portworx pods. %v", err)
+	}
+
+	currentPxPodNodes := make(map[string]bool)
+	for _, pod := range portworxPodList.Items {
+		controllerRef := metav1.GetControllerOf(&pod)
+		if controllerRef != nil && controllerRef.UID == cluster.UID && len(pod.Spec.NodeName) != 0 {
+			currentPxPodNodes[pod.Spec.NodeName] = true
+		}
+	}
+
+	storageNodes := &corev1alpha1.StorageNodeList{}
+	if err = p.k8sClient.List(context.TODO(), storageNodes, &client.ListOptions{}); err != nil {
+		return fmt.Errorf("failed to get a list of StorageNode: %v", err)
+	}
+
+	for _, storageNode := range storageNodes.Items {
+		pxNodeExists := currentPxNodes[storageNode.Name]
+		pxPodExists := currentPxPodNodes[storageNode.Name]
+		if !pxNodeExists && !pxPodExists {
+			logrus.Debugf("Deleting orphan StorageNode %v/%v",
+				storageNode.Namespace, storageNode.Name)
+
+			err = p.k8sClient.Delete(context.TODO(), storageNode.DeepCopy())
+			if err != nil && !errors.IsNotFound(err) {
+				msg := fmt.Sprintf("Failed to delete StorageNode %v/%v: %v",
+					storageNode.Namespace, storageNode.Name, err)
+				p.warningEvent(cluster, util.FailedSyncReason, msg)
+			}
+		} else if !pxNodeExists && pxPodExists {
+			// If the portworx pod exists, but corresponding portworx node is missing in
+			// enumerate, then it's either still initializing, failed or removed from cluster.
+			// If it's not initializing or failed, then change the node phase to Unknown.
+			newPhase := getStorageNodePhase(&storageNode.Status)
+			if newPhase != string(corev1alpha1.NodeInitStatus) &&
+				newPhase != string(corev1alpha1.NodeFailedStatus) {
+				newPhase = string(corev1alpha1.NodeUnknownStatus)
+			}
+			if storageNode.Status.Phase != newPhase {
+				storageNodeCopy := storageNode.DeepCopy()
+				storageNodeCopy.Status.Phase = newPhase
+				logrus.Debugf("Updating StorageNode %v/%v status",
+					storageNode.Namespace, storageNode.Name)
+				err = p.k8sClient.Status().Update(context.TODO(), storageNodeCopy)
+				if err != nil && !errors.IsNotFound(err) {
+					msg := fmt.Sprintf("Failed to update StorageNode %v/%v: %v",
+						storageNode.Namespace, storageNode.Name, err)
+					p.warningEvent(cluster, util.FailedSyncReason, msg)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (p *portworx) updateStorageNodeSpec(
+	cluster *corev1alpha1.StorageCluster,
+	node *api.StorageNode,
+) (*corev1alpha1.StorageNode, error) {
+	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	storageNode := &corev1alpha1.StorageNode{}
+	getErr := p.k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      node.SchedulerNodeName,
+			Namespace: cluster.Namespace,
+		},
+		storageNode,
+	)
+	if getErr != nil && !errors.IsNotFound(getErr) {
+		return nil, getErr
+	}
+
+	originalStorageNode := storageNode.DeepCopy()
+	storageNode.Name = node.SchedulerNodeName
+	storageNode.Namespace = cluster.Namespace
+	storageNode.OwnerReferences = []metav1.OwnerReference{*ownerRef}
+	storageNode.Labels = p.GetSelectorLabels()
+
+	if version, ok := node.NodeLabels[labelPortworxVersion]; ok {
+		storageNode.Spec.Version = version
+	} else {
+		partitions := strings.Split(cluster.Spec.Image, ":")
+		if len(partitions) > 1 {
+			storageNode.Spec.Version = partitions[len(partitions)-1]
+		}
+	}
+
+	var err error
+	if errors.IsNotFound(getErr) {
+		logrus.Debugf("Creating StorageNode %s/%s", storageNode.Namespace, storageNode.Name)
+		err = p.k8sClient.Create(context.TODO(), storageNode)
+	} else if !reflect.DeepEqual(originalStorageNode, storageNode) {
+		logrus.Debugf("Updating StorageNode %s/%s", storageNode.Namespace, storageNode.Name)
+		err = p.k8sClient.Update(context.TODO(), storageNode)
+	}
+	return storageNode, err
+}
+
+func (p *portworx) updateStorageNodeStatus(
+	storageNode *corev1alpha1.StorageNode,
+	node *api.StorageNode,
+) error {
+	originalStorageNodeStatus := storageNode.Status.DeepCopy()
+	storageNode.Status.NodeUID = node.Id
+	storageNode.Status.Network = corev1alpha1.NetworkStatus{
+		DataIP: node.DataIp,
+		MgmtIP: node.MgmtIp,
+	}
+	nodeStateCondition := &corev1alpha1.NodeCondition{
+		Type:   corev1alpha1.NodeStateCondition,
+		Status: mapNodeStatus(node.Status),
+	}
+	operatorops.Instance().UpdateStorageNodeCondition(&storageNode.Status, nodeStateCondition)
+	storageNode.Status.Phase = getStorageNodePhase(&storageNode.Status)
+
+	if !reflect.DeepEqual(originalStorageNodeStatus, &storageNode.Status) {
+		logrus.Debugf("Updating StorageNode %s/%s status",
+			storageNode.Namespace, storageNode.Name)
+		return p.k8sClient.Status().Update(context.TODO(), storageNode)
+	}
+	return nil
+}
+
+func (p *portworx) getPortworxClient(
+	cluster *corev1alpha1.StorageCluster,
+) (*grpc.ClientConn, error) {
+	if p.sdkConn != nil {
+		return p.sdkConn, nil
+	}
+
+	pxService := &v1.Service{}
+	err := p.k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      pxutil.PortworxServiceName,
+			Namespace: cluster.Namespace,
+		},
+		pxService,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get k8s service spec: %v", err)
+	} else if len(pxService.Spec.ClusterIP) == 0 {
+		return nil, fmt.Errorf("failed to get endpoint for portworx volume driver")
+	}
+
+	endpoint := pxService.Spec.ClusterIP
+	sdkPort := defaultSDKPort
+
+	// Get the ports from service
+	for _, pxServicePort := range pxService.Spec.Ports {
+		if pxServicePort.Name == pxutil.PortworxSDKPortName && pxServicePort.Port != 0 {
+			sdkPort = int(pxServicePort.Port)
+		}
+	}
+
+	endpoint = fmt.Sprintf("%s:%d", endpoint, sdkPort)
+	return p.getGrpcConn(endpoint)
+}
+
+func (p *portworx) getGrpcConn(endpoint string) (*grpc.ClientConn, error) {
+	dialOptions, err := getDialOptions(isTLSEnabled())
+	if err != nil {
+		return nil, err
+	}
+	p.sdkConn, err = grpcserver.Connect(endpoint, dialOptions)
+	if err != nil {
+		return nil, fmt.Errorf("error connecting to GRPC server [%s]: %v", endpoint, err)
+	}
+	return p.sdkConn, nil
+}
+
+func getDialOptions(tls bool) ([]grpc.DialOption, error) {
+	if !tls {
+		return []grpc.DialOption{grpc.WithInsecure()}, nil
+	}
+	capool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load CA system certs: %v", err)
+	}
+	return []grpc.DialOption{grpc.WithTransportCredentials(
+		credentials.NewClientTLSFromCert(capool, ""),
+	)}, nil
+}
+
+func mapClusterStatus(status api.Status) corev1alpha1.ClusterConditionStatus {
+	switch status {
+	case api.Status_STATUS_NONE:
+		fallthrough
+	case api.Status_STATUS_INIT:
+		fallthrough
+	case api.Status_STATUS_OFFLINE:
+		fallthrough
+	case api.Status_STATUS_ERROR:
+		return corev1alpha1.ClusterOffline
+
+	case api.Status_STATUS_NOT_IN_QUORUM:
+		fallthrough
+	case api.Status_STATUS_NOT_IN_QUORUM_NO_STORAGE:
+		return corev1alpha1.ClusterNotInQuorum
+
+	case api.Status_STATUS_OK:
+		fallthrough
+	case api.Status_STATUS_MAINTENANCE:
+		fallthrough
+	case api.Status_STATUS_NEEDS_REBOOT:
+		fallthrough
+	case api.Status_STATUS_STORAGE_DOWN:
+		fallthrough
+	case api.Status_STATUS_STORAGE_DEGRADED:
+		fallthrough
+	case api.Status_STATUS_STORAGE_REBALANCE:
+		fallthrough
+	case api.Status_STATUS_STORAGE_DRIVE_REPLACE:
+		return corev1alpha1.ClusterOnline
+
+	case api.Status_STATUS_DECOMMISSION:
+		fallthrough
+	default:
+		return corev1alpha1.ClusterUnknown
+	}
+}
+
+func mapNodeStatus(status api.Status) corev1alpha1.NodeConditionStatus {
+	switch status {
+	case api.Status_STATUS_NONE:
+		fallthrough
+	case api.Status_STATUS_OFFLINE:
+		fallthrough
+	case api.Status_STATUS_ERROR:
+		fallthrough
+	case api.Status_STATUS_NEEDS_REBOOT:
+		return corev1alpha1.NodeOfflineStatus
+
+	case api.Status_STATUS_INIT:
+		return corev1alpha1.NodeInitStatus
+
+	case api.Status_STATUS_NOT_IN_QUORUM:
+		fallthrough
+	case api.Status_STATUS_NOT_IN_QUORUM_NO_STORAGE:
+		return corev1alpha1.NodeNotInQuorumStatus
+
+	case api.Status_STATUS_MAINTENANCE:
+		return corev1alpha1.NodeMaintenanceStatus
+
+	case api.Status_STATUS_OK:
+		fallthrough
+	case api.Status_STATUS_STORAGE_DOWN:
+		return corev1alpha1.NodeOnlineStatus
+
+	case api.Status_STATUS_DECOMMISSION:
+		return corev1alpha1.NodeDecommissionedStatus
+
+	case api.Status_STATUS_STORAGE_DEGRADED:
+		fallthrough
+	case api.Status_STATUS_STORAGE_REBALANCE:
+		fallthrough
+	case api.Status_STATUS_STORAGE_DRIVE_REPLACE:
+		return corev1alpha1.NodeDegradedStatus
+
+	default:
+		return corev1alpha1.NodeUnknownStatus
+	}
+}
+
+func getStorageNodePhase(status *corev1alpha1.NodeStatus) string {
+	latestTime := metav1.NewTime(time.Time{})
+	var latestCondition *corev1alpha1.NodeCondition
+
+	for _, condition := range status.Conditions {
+		if latestTime.Before(&condition.LastTransitionTime) ||
+			latestTime.Equal(&condition.LastTransitionTime) {
+			latestCondition = condition.DeepCopy()
+			latestTime = condition.LastTransitionTime
+		}
+	}
+
+	// If no condition or status found return Initializing phase.
+	// Also if the InitCondition is the latest condition and it has succeeded,
+	// then keep the node phase as Initializing
+	if latestCondition == nil || latestCondition.Status == "" ||
+		(latestCondition.Type == corev1alpha1.NodeInitCondition &&
+			latestCondition.Status == corev1alpha1.NodeSucceededStatus) {
+		return string(corev1alpha1.NodeInitStatus)
+	}
+	return string(latestCondition.Status)
+}
+
+func isTLSEnabled() bool {
+	enabled, err := strconv.ParseBool(os.Getenv(envKeyPortworxEnableTLS))
+	return err == nil && enabled
+}

--- a/pkg/apis/core/v1alpha1/storagecluster.go
+++ b/pkg/apis/core/v1alpha1/storagecluster.go
@@ -234,6 +234,8 @@ type StorageSpec struct {
 	JournalDevice *string `json:"journalDevice,omitempty"`
 	// SystemMdDevice device that will be used to store system metadata
 	SystemMdDevice *string `json:"systemMetadataDevice,omitempty"`
+	// KvdbDevice device for internal kvdb
+	KvdbDevice *string `json:"kvdbDevice,omitempty"`
 }
 
 // CloudStorageCapacitySpec details the minimum and maximum amount of storage
@@ -271,6 +273,8 @@ type CloudStorageSpec struct {
 	JournalDeviceSpec *string `json:"journalDeviceSpec,omitempty"`
 	// SystemMdDeviceSpec spec for the metadata device
 	SystemMdDeviceSpec *string `json:"systemMetadataDeviceSpec,omitempty"`
+	// KvdbDeviceSpec spec for the internal kvdb device
+	KvdbDeviceSpec *string `json:"kvdbDeviceSpec,omitempty"`
 	// MaxStorageNodes maximum nodes that will have storage in the cluster
 	MaxStorageNodes *uint32 `json:"maxStorageNodes,omitempty"`
 	// MaxStorageNodesPerZone maximum nodes in every zone that will have

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -116,6 +116,11 @@ func (in *CloudStorageSpec) DeepCopyInto(out *CloudStorageSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.KvdbDeviceSpec != nil {
+		in, out := &in.KvdbDeviceSpec, &out.KvdbDeviceSpec
+		*out = new(string)
+		**out = **in
+	}
 	if in.MaxStorageNodes != nil {
 		in, out := &in.MaxStorageNodes, &out.MaxStorageNodes
 		*out = new(uint32)
@@ -860,6 +865,11 @@ func (in *StorageSpec) DeepCopyInto(out *StorageSpec) {
 	}
 	if in.SystemMdDevice != nil {
 		in, out := &in.SystemMdDevice, &out.SystemMdDevice
+		*out = new(string)
+		**out = **in
+	}
+	if in.KvdbDevice != nil {
+		in, out := &in.KvdbDevice, &out.KvdbDevice
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -3326,6 +3326,18 @@ func TestUpdateStorageClusterCloudStorageSpec(t *testing.T) {
 	require.Empty(t, result)
 	require.Equal(t, []string{oldPod.Name}, podControl.DeletePodName)
 
+	// TestCase: Change spec.cloudStorage.kvdbDeviceSpec
+	kvdbDeviceSpec := "kvdb-dev-spec"
+	cluster.Spec.CloudStorage.KvdbDeviceSpec = &kvdbDeviceSpec
+	k8sClient.Update(context.TODO(), cluster)
+
+	podControl.DeletePodName = nil
+
+	result, err = controller.Reconcile(request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+	require.Equal(t, []string{oldPod.Name}, podControl.DeletePodName)
+
 	// TestCase: Change spec.cloudStorage.maxStorageNodes
 	maxStorageNodes := uint32(3)
 	cluster.Spec.CloudStorage.MaxStorageNodes = &maxStorageNodes
@@ -3447,6 +3459,18 @@ func TestUpdateStorageClusterStorageSpec(t *testing.T) {
 	// TestCase: Change spec.storage.systemMetadataDevice
 	metadataDevice := "metadata-dev"
 	cluster.Spec.Storage.SystemMdDevice = &metadataDevice
+	k8sClient.Update(context.TODO(), cluster)
+
+	podControl.DeletePodName = nil
+
+	result, err = controller.Reconcile(request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+	require.Equal(t, []string{oldPod.Name}, podControl.DeletePodName)
+
+	// TestCase: Change spec.storage.kvdbDevice
+	kvdbDevice := "kvdb-dev"
+	cluster.Spec.Storage.KvdbDevice = &kvdbDevice
 	k8sClient.Update(context.TODO(), cluster)
 
 	podControl.DeletePodName = nil


### PR DESCRIPTION
If users don't have dedicated kvdb nodes, and want to dedicate a kvdb device for all nodes - 
```
spec:
   storage:
     useAll: true
     kvdbDevice: /dev/kvdb
```

If users have dedicated kvdb nodes which can be storage nodes -
```
spec:
   storage: # Not needed if using useAll as operator will put that as the default config if none provided
     useAll: true
   nodes:
   - selector:
       labelSelector:
         matchLabels:
           kvdb: "true"
     storage:
       kvdbDevice: /dev/kvdb
```

If users have dedicated kvdb nodes and want them to be storage less nodes -
```
spec:
   storage: # Not needed if using useAll as operator will put that as the default config if none provided
     useAll: true
   nodes:
   - selector:
       labelSelector:
         matchLabels:
           kvdb: "true"
     storage:
       devices: []
       kvdbDevice: /dev/kvdb
```