### PR TITLE
Cherrypick: Use cluster's image pull policy even for node wiper

### DIFF
--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -215,7 +215,7 @@ func (u *uninstallPortworx) RunNodeWiper(
 						{
 							Name:            pxNodeWiperDaemonSetName,
 							Image:           wiperImage,
-							ImagePullPolicy: v1.PullAlways,
+							ImagePullPolicy: pxutil.ImagePullPolicy(u.cluster),
 							Args:            args,
 							SecurityContext: &v1.SecurityContext{
 								Privileged: &trueVar,


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>