### PR TITLE
Cherrypick: Give portworx permissions for custom secrets namespace

### DIFF
--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -1,14 +1,19 @@
 package component
 
 import (
+	"context"
+
 	"github.com/hashicorp/go-version"
 	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,10 +60,7 @@ func (c *portworxBasic) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 	if err := c.createClusterRoleBinding(cluster.Namespace, ownerRef); err != nil {
 		return NewError(ErrCritical, err)
 	}
-	if err := c.createRole(cluster.Namespace, ownerRef); err != nil {
-		return NewError(ErrCritical, err)
-	}
-	if err := c.createRoleBinding(cluster.Namespace, ownerRef); err != nil {
+	if err := c.prepareForSecrets(cluster, ownerRef); err != nil {
 		return NewError(ErrCritical, err)
 	}
 	if err := c.createPortworxService(cluster, ownerRef); err != nil {
@@ -109,13 +111,62 @@ func (c *portworxBasic) createServiceAccount(
 	)
 }
 
-func (c *portworxBasic) createRole(clusterNamespace string, ownerRef *metav1.OwnerReference) error {
+func (c *portworxBasic) prepareForSecrets(
+	cluster *corev1alpha1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	secretsNamespace := cluster.Namespace
+	for _, env := range cluster.Spec.Env {
+		if env.Name == pxutil.EnvKeyPortworxSecretsNamespace {
+			secretsNamespace = env.Value
+			break
+		}
+	}
+
+	if secretsNamespace != cluster.Namespace {
+		if err := c.createNamespace(secretsNamespace); err != nil {
+			return err
+		}
+	}
+	if err := c.createRole(secretsNamespace, ownerRef); err != nil {
+		return err
+	}
+	if err := c.createRoleBinding(secretsNamespace, cluster.Namespace, ownerRef); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *portworxBasic) createNamespace(namespace string) error {
+	existingNamespace := &v1.Namespace{}
+	err := c.k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name: namespace,
+		},
+		existingNamespace,
+	)
+	if errors.IsNotFound(err) {
+		logrus.Debugf("Creating Namespace %s", namespace)
+		ns := &v1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		}
+		return c.k8sClient.Create(context.TODO(), ns)
+	} else if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *portworxBasic) createRole(namespace string, ownerRef *metav1.OwnerReference) error {
 	return k8sutil.CreateOrUpdateRole(
 		c.k8sClient,
 		&rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            PxRoleName,
-				Namespace:       clusterNamespace,
+				Namespace:       namespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Rules: []rbacv1.PolicyRule{
@@ -131,6 +182,7 @@ func (c *portworxBasic) createRole(clusterNamespace string, ownerRef *metav1.Own
 }
 
 func (c *portworxBasic) createRoleBinding(
+	bindingNamespace string,
 	clusterNamespace string,
 	ownerRef *metav1.OwnerReference,
 ) error {
@@ -139,7 +191,7 @@ func (c *portworxBasic) createRoleBinding(
 		&rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            PxRoleBindingName,
-				Namespace:       clusterNamespace,
+				Namespace:       bindingNamespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Subjects: []rbacv1.Subject{

--- a/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
@@ -1,0 +1,117 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: portworx
+  namespace: kube-system
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: portworx
+    spec:
+      hostNetwork: true
+      hostPID: false
+      containers:
+        - name: portworx
+          image: portworx/oci-monitor:2.1.1
+          imagePullPolicy: Always
+          args:
+            ["-c", "px-cluster",
+             "-x", "kubernetes"]
+          env:
+            - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"
+              value: "300"
+            - name: "PX_TEMPLATE_VERSION"
+              value: "v4"
+            - name: "PX_NAMESPACE"
+              value: "kube-system"
+            - name: "PX_SECRETS_NAMESPACE"
+              value: "custom"
+          livenessProbe:
+            periodSeconds: 30
+            initialDelaySeconds: 840 # allow image pull in slow networks
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 9001
+          readinessProbe:
+            periodSeconds: 10
+            httpGet:
+              host: 127.0.0.1
+              path: /health
+              port: 9015
+          terminationMessagePath: "/tmp/px-termination-log"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: diagsdump
+              mountPath: /var/cores
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+            - name: containerdsock
+              mountPath: /run/containerd
+            - name: criosock
+              mountPath: /var/run/crio
+            - name: crioconf
+              mountPath: /etc/crictl.yaml
+            - name: etcpwx
+              mountPath: /etc/pwx
+            - name: optpwx
+              mountPath: /opt/pwx
+            - name: procmount
+              mountPath: /host_proc
+            - name: sysdmount
+              mountPath: /etc/systemd/system
+            - name: journalmount1
+              mountPath: /var/run/log
+              readOnly: true
+            - name: journalmount2
+              mountPath: /var/log
+              readOnly: true
+            - name: dbusmount
+              mountPath: /var/run/dbus
+      restartPolicy: Always
+      serviceAccountName: portworx
+      volumes:
+        - name: diagsdump
+          hostPath:
+            path: /var/cores
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: containerdsock
+          hostPath:
+            path: /run/containerd
+        - name: criosock
+          hostPath:
+            path: /var/run/crio
+        - name: crioconf
+          hostPath:
+            path: /etc/crictl.yaml
+            type: FileOrCreate
+        - name: etcpwx
+          hostPath:
+            path: /etc/pwx
+        - name: optpwx
+          hostPath:
+            path: /opt/pwx
+        - name: procmount
+          hostPath:
+            path: /proc
+        - name: sysdmount
+          hostPath:
+            path: /etc/systemd/system
+        - name: journalmount1
+          hostPath:
+            path: /var/run/log
+        - name: journalmount2
+          hostPath:
+            path: /var/log
+        - name: dbusmount
+          hostPath:
+            path: /var/run/dbus

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -68,6 +68,9 @@ const (
 	// EnvKeyPortworxServiceName key for the env var which tells the name of the
 	// portworx service to be used
 	EnvKeyPortworxServiceName = "PX_SERVICE_NAME"
+	// EnvKeyPortworxSecretsNamespace key for the env var which tells the namespace
+	// where portworx should look for secrets
+	EnvKeyPortworxSecretsNamespace = "PX_SECRETS_NAMESPACE"
 	// EnvKeyDeprecatedCSIDriverName key for the env var that can force Portworx
 	// to use the deprecated CSI driver name
 	EnvKeyDeprecatedCSIDriverName = "PORTWORX_USEDEPRECATED_CSIDRIVERNAME"


### PR DESCRIPTION
- Also override existing default env var values with
  user-passed values. Dedup env vars.

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>