### PR TITLE
Retrieve version manifest from ConfigMap for airgapped clusters

### DIFF
--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -378,24 +378,24 @@ func (c *csi) createDeployment(
 
 	provisionerImage = util.GetImageURN(
 		cluster.Spec.CustomImageRegistry,
-		csiConfig.Provisioner,
+		cluster.Status.DesiredImages.CSIProvisioner,
 	)
-	if csiConfig.IncludeAttacher && csiConfig.Attacher != "" {
+	if csiConfig.IncludeAttacher && cluster.Status.DesiredImages.CSIAttacher != "" {
 		attacherImage = util.GetImageURN(
 			cluster.Spec.CustomImageRegistry,
-			csiConfig.Attacher,
+			cluster.Status.DesiredImages.CSIAttacher,
 		)
 	}
-	if csiConfig.IncludeSnapshotter && csiConfig.Snapshotter != "" {
+	if csiConfig.IncludeSnapshotter && cluster.Status.DesiredImages.CSISnapshotter != "" {
 		snapshotterImage = util.GetImageURN(
 			cluster.Spec.CustomImageRegistry,
-			csiConfig.Snapshotter,
+			cluster.Status.DesiredImages.CSISnapshotter,
 		)
 	}
-	if csiConfig.IncludeResizer && csiConfig.Resizer != "" {
+	if csiConfig.IncludeResizer && cluster.Status.DesiredImages.CSIResizer != "" {
 		resizerImage = util.GetImageURN(
 			cluster.Spec.CustomImageRegistry,
-			csiConfig.Resizer,
+			cluster.Status.DesiredImages.CSIResizer,
 		)
 	}
 
@@ -658,11 +658,11 @@ func (c *csi) createStatefulSet(
 
 	provisionerImage = util.GetImageURN(
 		cluster.Spec.CustomImageRegistry,
-		csiConfig.Provisioner,
+		cluster.Status.DesiredImages.CSIProvisioner,
 	)
 	attacherImage = util.GetImageURN(
 		cluster.Spec.CustomImageRegistry,
-		csiConfig.Attacher,
+		cluster.Status.DesiredImages.CSIAttacher,
 	)
 
 	modified := provisionerImage != existingProvisionerImage ||

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -471,22 +471,22 @@ func (t *template) csiRegistrarContainer() *v1.Container {
 		},
 	}
 
-	if t.csiConfig.NodeRegistrar != "" {
+	if t.cluster.Status.DesiredImages.CSINodeDriverRegistrar != "" {
 		container.Name = "csi-node-driver-registrar"
 		container.Image = util.GetImageURN(
 			t.cluster.Spec.CustomImageRegistry,
-			t.csiConfig.NodeRegistrar,
+			t.cluster.Status.DesiredImages.CSINodeDriverRegistrar,
 		)
 		container.Args = []string{
 			"--v=5",
 			"--csi-address=$(ADDRESS)",
 			fmt.Sprintf("--kubelet-registration-path=%s/csi.sock", t.csiConfig.DriverBasePath()),
 		}
-	} else if t.csiConfig.Registrar != "" {
+	} else if t.cluster.Status.DesiredImages.CSIDriverRegistrar != "" {
 		container.Name = "csi-driver-registrar"
 		container.Image = util.GetImageURN(
 			t.cluster.Spec.CustomImageRegistry,
-			t.csiConfig.Registrar,
+			t.cluster.Status.DesiredImages.CSIDriverRegistrar,
 		)
 		container.Args = []string{
 			"--v=5",

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -1409,6 +1409,11 @@ func TestPodSpecWithImagePullPolicy(t *testing.T) {
 				string(pxutil.FeatureCSI): "True",
 			},
 		},
+		Status: corev1alpha1.StorageClusterStatus{
+			DesiredImages: &corev1alpha1.ComponentImages{
+				CSINodeDriverRegistrar: "csi/registrar",
+			},
+		},
 	}
 	driver := portworx{}
 
@@ -1596,6 +1601,11 @@ func TestPodSpecForCSIWithOlderCSIVersion(t *testing.T) {
 				string(pxutil.FeatureCSI): "true",
 			},
 		},
+		Status: corev1alpha1.StorageClusterStatus{
+			DesiredImages: &corev1alpha1.ComponentImages{
+				CSIDriverRegistrar: "quay.io/k8scsi/driver-registrar:v0.4.2",
+			},
+		},
 	}
 
 	driver := portworx{}
@@ -1635,6 +1645,11 @@ func TestPodSpecForCSIWithNewerCSIVersion(t *testing.T) {
 			Image: "portworx/oci-monitor:2.1.1",
 			FeatureGates: map[string]string{
 				string(pxutil.FeatureCSI): "true",
+			},
+		},
+		Status: corev1alpha1.StorageClusterStatus{
+			DesiredImages: &corev1alpha1.ComponentImages{
+				CSINodeDriverRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
 			},
 		},
 	}
@@ -1682,6 +1697,11 @@ func TestPodSpecForCSIWithCustomPortworxImage(t *testing.T) {
 						Value: "portworx/oci-monitor:2.1.1-rc1",
 					},
 				},
+			},
+		},
+		Status: corev1alpha1.StorageClusterStatus{
+			DesiredImages: &corev1alpha1.ComponentImages{
+				CSINodeDriverRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
 			},
 		},
 	}
@@ -1750,6 +1770,11 @@ func TestPodSpecForDeprecatedCSIDriverName(t *testing.T) {
 						Value: "true",
 					},
 				},
+			},
+		},
+		Status: corev1alpha1.StorageClusterStatus{
+			DesiredImages: &corev1alpha1.ComponentImages{
+				CSINodeDriverRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
 			},
 		},
 	}

--- a/drivers/storage/portworx/manifest/common.go
+++ b/drivers/storage/portworx/manifest/common.go
@@ -3,6 +3,8 @@ package manifest
 import (
 	"io/ioutil"
 	"net/http"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
 // Methods to override for testing
@@ -17,4 +19,16 @@ func getManifestFromURL(manifestURL string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 	return ioutil.ReadAll(resp.Body)
+}
+
+func parseVersionManifest(content []byte) (*Version, error) {
+	manifest := &Version{}
+	err := yaml.Unmarshal(content, manifest)
+	if err != nil {
+		return nil, err
+	}
+	if manifest.PortworxVersion == "" {
+		return nil, ErrReleaseNotFound
+	}
+	return manifest, nil
 }

--- a/drivers/storage/portworx/manifest/configmap.go
+++ b/drivers/storage/portworx/manifest/configmap.go
@@ -1,0 +1,54 @@
+package manifest
+
+import (
+	"context"
+
+	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	defaultConfigMapName = "px-versions"
+	versionConfigMapKey  = "versions"
+)
+
+type configMap struct {
+	cm *v1.ConfigMap
+}
+
+func newConfigMapManifest(
+	k8sClient client.Client,
+	cluster *corev1alpha1.StorageCluster,
+) (manifest, error) {
+	versionCM := &v1.ConfigMap{}
+	err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      defaultConfigMapName,
+			Namespace: cluster.Namespace,
+		},
+		versionCM,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &configMap{
+		cm: versionCM.DeepCopy(),
+	}, nil
+}
+
+func (m *configMap) Get() (*Version, error) {
+	data, exists := m.cm.Data[versionConfigMapKey]
+	if !exists {
+		// If the exact key does not exist, just take the first one
+		// as only one key is expected
+		for _, value := range m.cm.Data {
+			data = value
+			break
+		}
+	}
+	return parseVersionManifest([]byte(data))
+}

--- a/drivers/storage/portworx/manifest/configmap_test.go
+++ b/drivers/storage/portworx/manifest/configmap_test.go
@@ -1,0 +1,166 @@
+package manifest
+
+import (
+	"context"
+	"testing"
+
+	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConfigMapManifestWithValidData(t *testing.T) {
+	cluster := &corev1alpha1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kube-test",
+		},
+	}
+	versionsConfigMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultConfigMapName,
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string]string{
+			versionConfigMapKey: `
+version: 3.2.1
+components:
+  stork: stork/image:3.2.1
+`,
+		},
+	}
+	k8sClient := testutil.FakeK8sClient(versionsConfigMap)
+
+	m, err := newConfigMapManifest(k8sClient, cluster)
+	require.NoError(t, err)
+
+	r, err := m.Get()
+	require.NoError(t, err)
+	require.Equal(t, "3.2.1", r.PortworxVersion)
+	require.Equal(t, "stork/image:3.2.1", r.Components.Stork)
+}
+
+func TestConfigMapManifestWithValidDataButDifferentKey(t *testing.T) {
+	cluster := &corev1alpha1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kube-test",
+		},
+	}
+	versionsConfigMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultConfigMapName,
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string]string{
+			"invalid": `
+version: 3.2.1
+components:
+  stork: stork/image:3.2.1
+`,
+		},
+	}
+	k8sClient := testutil.FakeK8sClient(versionsConfigMap)
+
+	// TestCase: Has invalid data key but it is the only key present
+	m, err := newConfigMapManifest(k8sClient, cluster)
+	require.NoError(t, err)
+
+	r, err := m.Get()
+	require.NoError(t, err)
+	require.Equal(t, "3.2.1", r.PortworxVersion)
+	require.Equal(t, "stork/image:3.2.1", r.Components.Stork)
+
+	// TestCase: Has both a valid and invalid key.
+	// We should use the valid one, if present
+	versionsConfigMap.Data[versionConfigMapKey] = `
+version: 4.2.1
+components:
+  stork: stork/image:4.2.1
+`
+	k8sClient.Update(context.TODO(), versionsConfigMap)
+
+	m, err = newConfigMapManifest(k8sClient, cluster)
+	require.NoError(t, err)
+
+	r, err = m.Get()
+	require.NoError(t, err)
+	require.Equal(t, "4.2.1", r.PortworxVersion)
+	require.Equal(t, "stork/image:4.2.1", r.Components.Stork)
+}
+
+func TestConfigMapManifestWhenConfigMapMissing(t *testing.T) {
+	cluster := &corev1alpha1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kube-test",
+		},
+	}
+	k8sClient := testutil.FakeK8sClient()
+
+	m, err := newConfigMapManifest(k8sClient, cluster)
+	require.Error(t, err)
+	require.Nil(t, m)
+}
+
+func TestConfigMapManifestWithEmptyData(t *testing.T) {
+	cluster := &corev1alpha1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kube-test",
+		},
+	}
+	versionsConfigMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultConfigMapName,
+			Namespace: cluster.Namespace,
+		},
+	}
+	k8sClient := testutil.FakeK8sClient(versionsConfigMap)
+
+	// TestCase: No versions data present
+	m, err := newConfigMapManifest(k8sClient, cluster)
+	require.NoError(t, err)
+
+	r, err := m.Get()
+	require.Equal(t, err, ErrReleaseNotFound)
+	require.Nil(t, r)
+
+	// TestCase: Empty versions data present
+	versionsConfigMap.Data = map[string]string{
+		versionConfigMapKey: "",
+	}
+	k8sClient.Update(context.TODO(), versionsConfigMap)
+
+	m, err = newConfigMapManifest(k8sClient, cluster)
+	require.NoError(t, err)
+
+	r, err = m.Get()
+	require.Equal(t, err, ErrReleaseNotFound)
+	require.Nil(t, r)
+}
+
+func TestConfigMapManifestWithInvalidData(t *testing.T) {
+	cluster := &corev1alpha1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kube-test",
+		},
+	}
+	versionsConfigMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultConfigMapName,
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string]string{
+			versionConfigMapKey: "invalid_yaml",
+		},
+	}
+	k8sClient := testutil.FakeK8sClient(versionsConfigMap)
+
+	// TestCase: No versions data present
+	m, err := newConfigMapManifest(k8sClient, cluster)
+	require.NoError(t, err)
+
+	r, err := m.Get()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot unmarshal")
+	require.Nil(t, r)
+}

--- a/drivers/storage/portworx/manifest/remote.go
+++ b/drivers/storage/portworx/manifest/remote.go
@@ -10,7 +10,6 @@ import (
 	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -59,18 +58,6 @@ func downloadVersionManifest(
 	}
 
 	return parseVersionManifest(body)
-}
-
-func parseVersionManifest(content []byte) (*Version, error) {
-	manifest := &Version{}
-	err := yaml.Unmarshal(content, manifest)
-	if err != nil {
-		return nil, err
-	}
-	if manifest.PortworxVersion == "" {
-		return nil, ErrReleaseNotFound
-	}
-	return manifest, nil
 }
 
 func manifestURLFromVersion(version string) string {

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -137,7 +137,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1alpha1.StorageClu
 		toUpdate.Spec.Version != toUpdate.Status.Version
 
 	if pxVersionChanged || hasComponentChanged(toUpdate) {
-		release := getVersionManifest(toUpdate, p.recorder)
+		release := getVersionManifest(toUpdate, p.k8sClient, p.recorder)
 		if toUpdate.Spec.Version == "" {
 			if toUpdate.Spec.Image == "" {
 				toUpdate.Spec.Image = defaultPortworxImage

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -4602,6 +4602,7 @@ func fakeClientWithWiperPod(namespace string) client.Client {
 func manifestSetup() {
 	getVersionManifest = func(
 		_ *corev1alpha1.StorageCluster,
+		_ client.Client,
 		_ record.EventRecorder,
 	) *manifest.Version {
 		return &manifest.Version{

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	version "github.com/hashicorp/go-version"
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/pkg/dbg"
 	"github.com/libopenstorage/operator/drivers/storage/portworx/component"
@@ -4604,14 +4605,21 @@ func manifestSetup() {
 		_ *corev1alpha1.StorageCluster,
 		_ client.Client,
 		_ record.EventRecorder,
+		_ *version.Version,
 	) *manifest.Version {
 		return &manifest.Version{
 			PortworxVersion: "2.1.5.1",
 			Components: manifest.Release{
-				Stork:      "openstorage/stork:2.3.4",
-				Autopilot:  "portworx/autopilot:2.3.4",
-				Lighthouse: "portworx/px-lighthouse:2.3.4",
-				NodeWiper:  "portworx/px-node-wiper:2.3.4",
+				Stork:                  "openstorage/stork:2.3.4",
+				Autopilot:              "portworx/autopilot:2.3.4",
+				Lighthouse:             "portworx/px-lighthouse:2.3.4",
+				NodeWiper:              "portworx/px-node-wiper:2.3.4",
+				CSIProvisioner:         "quay.io/k8scsi/csi-provisioner:v1.2.3",
+				CSIAttacher:            "quay.io/k8scsi/csi-attacher:v1.2.3",
+				CSIDriverRegistrar:     "quay.io/k8scsi/driver-registrar:v1.2.3",
+				CSINodeDriverRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.2.3",
+				CSISnapshotter:         "quay.io/k8scsi/csi-snapshotter:v1.2.3",
+				CSIResizer:             "quay.io/k8scsi/csi-resizer:v1.2.3",
 			},
 		}
 	}

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-provisioner:v1.4.0-1
+          image: quay.io/k8scsi/csi-provisioner:v1.2.3
           args:
             - "--v=3"
             - "--provisioner=pxd.portworx.com"

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-provisioner:v1.4.0-1
+          image: quay.io/k8scsi/csi-provisioner:v1.2.3
           args:
             - "--v=3"
             - "--provisioner=pxd.portworx.com"
@@ -45,7 +45,7 @@ spec:
               mountPath: /csi
         - name: csi-resizer
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-resizer:v0.3.0
+          image: quay.io/k8scsi/csi-resizer:v1.2.3
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-provisioner:v1.4.0-1
+          image: quay.io/k8scsi/csi-provisioner:v1.2.3
           args:
             - "--v=3"
             - "--provisioner=com.openstorage.pxd"
@@ -34,7 +34,7 @@ spec:
               mountPath: /csi
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-snapshotter:v2.0.0
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.3
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -49,7 +49,7 @@ spec:
               mountPath: /csi
         - name: csi-resizer
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-resizer:v0.3.0
+          image: quay.io/k8scsi/csi-resizer:v1.2.3
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-provisioner:v1.4.0-1
+          image: quay.io/k8scsi/csi-provisioner:v1.2.3
           args:
             - "--v=3"
             - "--provisioner=pxd.portworx.com"
@@ -45,7 +45,7 @@ spec:
               mountPath: /csi
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-snapshotter:v2.0.0
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.3
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -60,7 +60,7 @@ spec:
               mountPath: /csi
         - name: csi-resizer
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-resizer:v0.3.0
+          image: quay.io/k8scsi/csi-resizer:v1.2.3
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-provisioner:v1.4.0-1
+          image: quay.io/k8scsi/csi-provisioner:v1.2.3
           args:
             - "--v=3"
             - "--provisioner=com.openstorage.pxd"
@@ -45,7 +45,7 @@ spec:
               mountPath: /csi
         - name: csi-attacher
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-attacher:v1.2.1-1
+          image: quay.io/k8scsi/csi-attacher:v1.2.3
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"
@@ -61,7 +61,7 @@ spec:
               mountPath: /csi
         - name: csi-snapshotter
           imagePullPolicy: Always
-          image: quay.io/openstorage/csi-snapshotter:v1.2.2-1
+          image: quay.io/k8scsi/csi-snapshotter:v1.2.3
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"

--- a/drivers/storage/portworx/testspec/csiStatefulSet_0.3.yaml
+++ b/drivers/storage/portworx/testspec/csiStatefulSet_0.3.yaml
@@ -29,7 +29,7 @@ spec:
       containers:
         - name: csi-external-provisioner
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-provisioner:v0.4.3
+          image: quay.io/k8scsi/csi-provisioner:v1.2.3
           args:
             - "--v=3"
             - "--provisioner=com.openstorage.pxd"
@@ -44,7 +44,7 @@ spec:
               mountPath: /csi
         - name: csi-attacher
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-attacher:v0.4.2
+          image: quay.io/k8scsi/csi-attacher:v1.2.3
           args:
             - "--v=3"
             - "--csi-address=$(ADDRESS)"

--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -151,7 +151,10 @@ func (u *uninstallPortworx) WipeMetadata() error {
 	return kv.DeleteTree(u.cluster.Name)
 }
 
-func (u *uninstallPortworx) RunNodeWiper(removeData bool, recorder record.EventRecorder) error {
+func (u *uninstallPortworx) RunNodeWiper(
+	removeData bool,
+	recorder record.EventRecorder,
+) error {
 	pwxHostPathRoot := "/"
 
 	enabled, err := strconv.ParseBool(u.cluster.Annotations[annotationIsPKS])
@@ -168,7 +171,7 @@ func (u *uninstallPortworx) RunNodeWiper(removeData bool, recorder record.EventR
 
 	wiperImage := k8sutil.GetValueFromEnv(envKeyNodeWiperImage, u.cluster.Spec.Env)
 	if len(wiperImage) == 0 {
-		release := getVersionManifest(u.cluster, u.k8sClient, recorder)
+		release := getVersionManifest(u.cluster, u.k8sClient, recorder, nil)
 		wiperImage = release.Components.NodeWiper
 	}
 	wiperImage = util.GetImageURN(u.cluster.Spec.CustomImageRegistry, wiperImage)

--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -168,7 +168,7 @@ func (u *uninstallPortworx) RunNodeWiper(removeData bool, recorder record.EventR
 
 	wiperImage := k8sutil.GetValueFromEnv(envKeyNodeWiperImage, u.cluster.Spec.Env)
 	if len(wiperImage) == 0 {
-		release := getVersionManifest(u.cluster, recorder)
+		release := getVersionManifest(u.cluster, u.k8sClient, recorder)
 		wiperImage = release.Components.NodeWiper
 	}
 	wiperImage = util.GetImageURN(u.cluster.Spec.CustomImageRegistry, wiperImage)

--- a/drivers/storage/portworx/util/csi_generator.go
+++ b/drivers/storage/portworx/util/csi_generator.go
@@ -16,14 +16,7 @@ const (
 // CSIConfiguration holds the versions of the all the CSI sidecar containers,
 // containers, CSI Version, and other flags
 type CSIConfiguration struct {
-	Version       string
-	Attacher      string
-	Snapshotter   string
-	Resizer       string
-	NodeRegistrar string
-	Provisioner   string
-	// old pre-Kube 1.13 registrar
-	Registrar string
+	Version string
 	// For Kube v1.12 and v1.13 we need to create the CRD
 	// See: https://kubernetes-csi.github.io/docs/csi-node-object.html#enabling-csinodeinfo-on-kubernetes
 	// When enabled it also means we need to use the Alpha version of CsiNodeInfo RBAC
@@ -46,6 +39,16 @@ type CSIConfiguration struct {
 	// IncludeConfigMapsForLeases is used only in Kubernetes 1.13 for leader election.
 	// In Kubernetes Kubernetes 1.14+ leader election does not use configmaps.
 	IncludeEndpointsAndConfigMapsForLeases bool
+}
+
+// CSIImages holds the images of all the CSI sidecar containers
+type CSIImages struct {
+	NodeRegistrar string
+	Registrar     string
+	Provisioner   string
+	Attacher      string
+	Snapshotter   string
+	Resizer       string
 }
 
 // CSIGenerator contains information needed to generate CSI side car versions
@@ -90,20 +93,13 @@ func (g *CSIGenerator) GetCSIConfiguration() *CSIConfiguration {
 	k8sVer1_14, _ := version.NewVersion("1.14")
 	k8sVer1_16, _ := version.NewVersion("1.16")
 	k8sVer1_17, _ := version.NewVersion("1.17")
-	pxVer2_1, _ := version.NewVersion("2.1")
 	pxVer2_2, _ := version.NewVersion("2.2")
 
 	var cv *CSIConfiguration
-	if g.pxVersion.GreaterThan(pxVer2_1) || g.pxVersion.Equal(pxVer2_1) {
-		// Portworx version >= 2.1
-		// Can only use Csi 1.0 in Kubernetes 1.13+
-		if g.kubeVersion.GreaterThan(k8sVer1_13) || g.kubeVersion.Equal(k8sVer1_13) {
-			cv = g.setSidecarContainerVersionsV1_0()
-		} else {
-			cv = g.setSidecarContainerVersionsV0_4()
-		}
+	if g.kubeVersion.GreaterThan(k8sVer1_13) || g.kubeVersion.Equal(k8sVer1_13) {
+		cv = g.getDefaultConfigV1_0()
 	} else {
-		cv = g.setSidecarContainerVersionsV0_4()
+		cv = g.getDefaultConfigV0_4()
 	}
 
 	// Check if configmaps are necessary for leader election.
@@ -111,7 +107,6 @@ func (g *CSIGenerator) GetCSIConfiguration() *CSIConfiguration {
 	if (g.kubeVersion.GreaterThan(k8sVer1_13) || g.kubeVersion.Equal(k8sVer1_13)) &&
 		g.kubeVersion.LessThan(k8sVer1_14) {
 		cv.IncludeEndpointsAndConfigMapsForLeases = true
-		cv.Snapshotter = "quay.io/openstorage/csi-snapshotter:v1.2.2-1"
 	}
 
 	// Enable resizer sidecar when PX >= 2.2 and k8s >= 1.14.0
@@ -166,6 +161,26 @@ func (g *CSIGenerator) GetCSIConfiguration() *CSIConfiguration {
 	return cv
 }
 
+// GetCSIImages returns the appropriate sidecar images for the
+// specified Kubernetes and Portworx versions
+func (g *CSIGenerator) GetCSIImages() *CSIImages {
+	var csiImages *CSIImages
+	k8sVer1_13, _ := version.NewVersion("1.13")
+	if g.kubeVersion.GreaterThan(k8sVer1_13) || g.kubeVersion.Equal(k8sVer1_13) {
+		csiImages = getSidecarContainerVersionsV1_0()
+	} else {
+		csiImages = getSidecarContainerVersionsV0_4()
+	}
+
+	k8sVer1_14, _ := version.NewVersion("1.14")
+	if (g.kubeVersion.GreaterThan(k8sVer1_13) || g.kubeVersion.Equal(k8sVer1_13)) &&
+		g.kubeVersion.LessThan(k8sVer1_14) {
+		csiImages.Snapshotter = "quay.io/openstorage/csi-snapshotter:v1.2.2-1"
+	}
+
+	return csiImages
+}
+
 func (g *CSIGenerator) driverName() string {
 	pxVer2_2, _ := version.NewVersion("2.2")
 	// PX Versions <2.2.0 will always use the deprecated CSI Driver Name.
@@ -176,30 +191,15 @@ func (g *CSIGenerator) driverName() string {
 	return CSIDriverName
 }
 
-func (g *CSIGenerator) setSidecarContainerVersionsV1_0() *CSIConfiguration {
+func (g *CSIGenerator) getDefaultConfigV1_0() *CSIConfiguration {
 	return &CSIConfiguration{
-		Attacher:      "quay.io/openstorage/csi-attacher:v1.2.1-1",
-		NodeRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
-		Provisioner:   "quay.io/openstorage/csi-provisioner:v1.4.0-1",
-		Snapshotter:   "quay.io/k8scsi/csi-snapshotter:v2.0.0",
-		Resizer:       "quay.io/k8scsi/csi-resizer:v0.3.0",
-		// Single registrar has been deprecated
-		Registrar: "",
-		// Deployments are support in 1.x
 		UseDeployment: true,
 	}
 }
 
-func (g *CSIGenerator) setSidecarContainerVersionsV0_4() *CSIConfiguration {
+func (g *CSIGenerator) getDefaultConfigV0_4() *CSIConfiguration {
 	pxVer2_1, _ := version.NewVersion("2.1")
 	c := &CSIConfiguration{
-		Attacher:    "quay.io/k8scsi/csi-attacher:v0.4.2",
-		Registrar:   "quay.io/k8scsi/driver-registrar:v0.4.2",
-		Provisioner: "quay.io/k8scsi/csi-provisioner:v0.4.3",
-		Snapshotter: "",
-		// no split driver registrars. These are for Csi 1.0 in Kube 1.13+
-		NodeRegistrar: "",
-		// Deployments not supported yet, so use statefulset
 		UseDeployment: false,
 	}
 
@@ -213,4 +213,22 @@ func (g *CSIGenerator) setSidecarContainerVersionsV0_4() *CSIConfiguration {
 // DriverBasePath returns the basepath under which the CSI driver is stored
 func (c *CSIConfiguration) DriverBasePath() string {
 	return path.Join("/var/lib/kubelet/plugins", c.DriverName)
+}
+
+func getSidecarContainerVersionsV1_0() *CSIImages {
+	return &CSIImages{
+		Attacher:      "quay.io/openstorage/csi-attacher:v1.2.1-1",
+		NodeRegistrar: "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0",
+		Provisioner:   "quay.io/openstorage/csi-provisioner:v1.4.0-1",
+		Snapshotter:   "quay.io/k8scsi/csi-snapshotter:v2.0.0",
+		Resizer:       "quay.io/k8scsi/csi-resizer:v0.3.0",
+	}
+}
+
+func getSidecarContainerVersionsV0_4() *CSIImages {
+	return &CSIImages{
+		Attacher:    "quay.io/k8scsi/csi-attacher:v0.4.2",
+		Registrar:   "quay.io/k8scsi/driver-registrar:v0.4.2",
+		Provisioner: "quay.io/k8scsi/csi-provisioner:v0.4.3",
+	}
 }

--- a/drivers/storage/portworx/util/csi_generator_test.go
+++ b/drivers/storage/portworx/util/csi_generator_test.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"testing"
+
+	version "github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCSIImages(t *testing.T) {
+	k8sVersion, _ := version.NewSemver("1.12.5")
+	gen := NewCSIGenerator(*k8sVersion, version.Version{}, false, false)
+	images := gen.GetCSIImages()
+	require.Equal(t, "quay.io/k8scsi/csi-attacher:v0.4.2", images.Attacher)
+	require.Equal(t, "quay.io/k8scsi/driver-registrar:v0.4.2", images.Registrar)
+	require.Equal(t, "quay.io/k8scsi/csi-provisioner:v0.4.3", images.Provisioner)
+
+	k8sVersion, _ = version.NewSemver("1.13.5")
+	gen = NewCSIGenerator(*k8sVersion, version.Version{}, false, false)
+	images = gen.GetCSIImages()
+	require.Equal(t, "quay.io/openstorage/csi-attacher:v1.2.1-1", images.Attacher)
+	require.Equal(t, "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0", images.NodeRegistrar)
+	require.Equal(t, "quay.io/openstorage/csi-provisioner:v1.4.0-1", images.Provisioner)
+	require.Equal(t, "quay.io/openstorage/csi-snapshotter:v1.2.2-1", images.Snapshotter)
+	require.Equal(t, "quay.io/k8scsi/csi-resizer:v0.3.0", images.Resizer)
+
+	k8sVersion, _ = version.NewSemver("1.14.5")
+	gen = NewCSIGenerator(*k8sVersion, version.Version{}, false, false)
+	images = gen.GetCSIImages()
+	require.Equal(t, "quay.io/openstorage/csi-attacher:v1.2.1-1", images.Attacher)
+	require.Equal(t, "quay.io/k8scsi/csi-node-driver-registrar:v1.1.0", images.NodeRegistrar)
+	require.Equal(t, "quay.io/openstorage/csi-provisioner:v1.4.0-1", images.Provisioner)
+	require.Equal(t, "quay.io/k8scsi/csi-snapshotter:v2.0.0", images.Snapshotter)
+	require.Equal(t, "quay.io/k8scsi/csi-resizer:v0.3.0", images.Resizer)
+}

--- a/pkg/apis/core/v1alpha1/storagecluster.go
+++ b/pkg/apis/core/v1alpha1/storagecluster.go
@@ -400,9 +400,15 @@ type StorageClusterStatus struct {
 
 // ComponentImages is a collection of all the images managed by the operator
 type ComponentImages struct {
-	Stork         string `json:"stork,omitempty"`
-	UserInterface string `json:"userInterface,omitempty"`
-	Autopilot     string `json:"autopilot,omitempty"`
+	Stork                  string `json:"stork,omitempty"`
+	UserInterface          string `json:"userInterface,omitempty"`
+	Autopilot              string `json:"autopilot,omitempty"`
+	CSINodeDriverRegistrar string `json:"csiNodeDriverRegistrar,omitempty"`
+	CSIDriverRegistrar     string `json:"csiDriverRegistrar,omitempty"`
+	CSIProvisioner         string `json:"csiProvisioner,omitempty"`
+	CSIAttacher            string `json:"csiAttacher,omitempty"`
+	CSIResizer             string `json:"csiResizer,omitempty"`
+	CSISnapshotter         string `json:"csiSnapshotter,omitempty"`
 }
 
 // Storage represents cluster storage details


### PR DESCRIPTION
- Get CSI images from version manifest instead of hard-coded logic