### PR TITLE
Not own cross namespaces objects by storagecluster

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -76,10 +76,10 @@ func (c *autopilot) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 	if err := c.createServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createClusterRole(ownerRef); err != nil {
+	if err := c.createClusterRole(); err != nil {
 		return err
 	}
-	if err := c.createClusterRoleBinding(cluster.Namespace, ownerRef); err != nil {
+	if err := c.createClusterRoleBinding(cluster.Namespace); err != nil {
 		return err
 	}
 	if err := c.createDeployment(cluster, ownerRef); err != nil {
@@ -96,10 +96,10 @@ func (c *autopilot) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteServiceAccount(c.k8sClient, AutopilotServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRole(c.k8sClient, AutopilotClusterRoleName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRole(c.k8sClient, AutopilotClusterRoleName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, AutopilotClusterRoleBindingName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, AutopilotClusterRoleBindingName); err != nil {
 		return err
 	}
 	if err := k8sutil.DeleteDeployment(c.k8sClient, AutopilotDeploymentName, cluster.Namespace, *ownerRef); err != nil {
@@ -176,13 +176,12 @@ func (c *autopilot) createServiceAccount(
 	)
 }
 
-func (c *autopilot) createClusterRole(ownerRef *metav1.OwnerReference) error {
+func (c *autopilot) createClusterRole() error {
 	return k8sutil.CreateOrUpdateClusterRole(
 		c.k8sClient,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            AutopilotClusterRoleName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: AutopilotClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -192,20 +191,17 @@ func (c *autopilot) createClusterRole(ownerRef *metav1.OwnerReference) error {
 				},
 			},
 		},
-		ownerRef,
 	)
 }
 
 func (c *autopilot) createClusterRoleBinding(
 	clusterNamespace string,
-	ownerRef *metav1.OwnerReference,
 ) error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		c.k8sClient,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            AutopilotClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: AutopilotClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -220,7 +216,6 @@ func (c *autopilot) createClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -105,7 +105,7 @@ func (c *autopilot) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteDeployment(c.k8sClient, AutopilotDeploymentName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	c.isCreated = false
+	c.MarkDeleted()
 	return nil
 }
 

--- a/drivers/storage/portworx/component/component.go
+++ b/drivers/storage/portworx/component/component.go
@@ -31,7 +31,7 @@ type PortworxComponent interface {
 	Reconcile(cluster *corev1alpha1.StorageCluster) error
 	// Delete deletes the component if present
 	Delete(cluster *corev1alpha1.StorageCluster) error
-	// MarkDeleted marks the component as deleted in situations like StorageCluster deletion
+	// MarkDeleted marks the component as deleted for testing purposes
 	MarkDeleted()
 }
 

--- a/drivers/storage/portworx/component/lighthouse.go
+++ b/drivers/storage/portworx/component/lighthouse.go
@@ -109,7 +109,7 @@ func (c *lighthouse) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteDeployment(c.k8sClient, LhDeploymentName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	c.isCreated = false
+	c.MarkDeleted()
 	return nil
 }
 

--- a/drivers/storage/portworx/component/lighthouse.go
+++ b/drivers/storage/portworx/component/lighthouse.go
@@ -77,10 +77,10 @@ func (c *lighthouse) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 	if err := c.createServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createClusterRole(ownerRef); err != nil {
+	if err := c.createClusterRole(); err != nil {
 		return err
 	}
-	if err := c.createClusterRoleBinding(cluster.Namespace, ownerRef); err != nil {
+	if err := c.createClusterRoleBinding(cluster.Namespace); err != nil {
 		return err
 	}
 	if err := c.createService(cluster, ownerRef); err != nil {
@@ -97,10 +97,10 @@ func (c *lighthouse) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteServiceAccount(c.k8sClient, LhServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRole(c.k8sClient, LhClusterRoleName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRole(c.k8sClient, LhClusterRoleName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, LhClusterRoleBindingName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, LhClusterRoleBindingName); err != nil {
 		return err
 	}
 	if err := k8sutil.DeleteService(c.k8sClient, LhServiceName, cluster.Namespace, *ownerRef); err != nil {
@@ -134,13 +134,12 @@ func (c *lighthouse) createServiceAccount(
 	)
 }
 
-func (c *lighthouse) createClusterRole(ownerRef *metav1.OwnerReference) error {
+func (c *lighthouse) createClusterRole() error {
 	return k8sutil.CreateOrUpdateClusterRole(
 		c.k8sClient,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            LhClusterRoleName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: LhClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -197,20 +196,17 @@ func (c *lighthouse) createClusterRole(ownerRef *metav1.OwnerReference) error {
 				},
 			},
 		},
-		ownerRef,
 	)
 }
 
 func (c *lighthouse) createClusterRoleBinding(
 	clusterNamespace string,
-	ownerRef *metav1.OwnerReference,
 ) error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		c.k8sClient,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            LhClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: LhClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -225,7 +221,6 @@ func (c *lighthouse) createClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -65,7 +65,7 @@ func (c *portworxAPI) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteDaemonSet(c.k8sClient, PxAPIDaemonSetName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	c.isCreated = false
+	c.MarkDeleted()
 	return nil
 }
 

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -54,10 +54,10 @@ func (c *portworxBasic) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 	if err := c.createServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return NewError(ErrCritical, err)
 	}
-	if err := c.createClusterRole(ownerRef); err != nil {
+	if err := c.createClusterRole(); err != nil {
 		return NewError(ErrCritical, err)
 	}
-	if err := c.createClusterRoleBinding(cluster.Namespace, ownerRef); err != nil {
+	if err := c.createClusterRoleBinding(cluster.Namespace); err != nil {
 		return NewError(ErrCritical, err)
 	}
 	if err := c.prepareForSecrets(cluster, ownerRef); err != nil {
@@ -74,10 +74,10 @@ func (c *portworxBasic) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteServiceAccount(c.k8sClient, pxutil.PortworxServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRole(c.k8sClient, PxClusterRoleName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRole(c.k8sClient, PxClusterRoleName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PxClusterRoleBindingName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PxClusterRoleBindingName); err != nil {
 		return err
 	}
 	if err := k8sutil.DeleteRole(c.k8sClient, PxRoleName, cluster.Namespace, *ownerRef); err != nil {
@@ -211,13 +211,12 @@ func (c *portworxBasic) createRoleBinding(
 	)
 }
 
-func (c *portworxBasic) createClusterRole(ownerRef *metav1.OwnerReference) error {
+func (c *portworxBasic) createClusterRole() error {
 	return k8sutil.CreateOrUpdateClusterRole(
 		c.k8sClient,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PxClusterRoleName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PxClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -284,20 +283,17 @@ func (c *portworxBasic) createClusterRole(ownerRef *metav1.OwnerReference) error
 				},
 			},
 		},
-		ownerRef,
 	)
 }
 
 func (c *portworxBasic) createClusterRoleBinding(
 	clusterNamespace string,
-	ownerRef *metav1.OwnerReference,
 ) error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		c.k8sClient,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PxClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PxClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -312,7 +308,6 @@ func (c *portworxBasic) createClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 
@@ -341,10 +336,9 @@ func getPortworxServiceSpec(
 
 	newService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            pxutil.PortworxServiceName,
-			Namespace:       cluster.Namespace,
-			Labels:          labels,
-			OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			Name:      pxutil.PortworxServiceName,
+			Namespace: cluster.Namespace,
+			Labels:    labels,
 		},
 		Spec: v1.ServiceSpec{
 			Selector: labels,
@@ -376,6 +370,10 @@ func getPortworxServiceSpec(
 				},
 			},
 		},
+	}
+
+	if ownerRef != nil {
+		newService.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	}
 
 	serviceType := pxutil.ServiceType(cluster)

--- a/drivers/storage/portworx/component/portworx_crd.go
+++ b/drivers/storage/portworx/component/portworx_crd.go
@@ -50,6 +50,7 @@ func (c *portworxCRD) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 }
 
 func (c *portworxCRD) Delete(cluster *corev1alpha1.StorageCluster) error {
+	c.MarkDeleted()
 	return nil
 }
 

--- a/drivers/storage/portworx/component/portworx_proxy.go
+++ b/drivers/storage/portworx/component/portworx_proxy.go
@@ -8,6 +8,7 @@ import (
 	corev1alpha1 "github.com/libopenstorage/operator/pkg/apis/core/v1alpha1"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -32,7 +33,6 @@ const (
 	PxProxyClusterRoleBindingName = "portworx-proxy"
 	// PxProxyDaemonSetName name of the Portworx proxy daemon set
 	PxProxyDaemonSetName = "portworx-proxy"
-
 	pxProxyContainerName = "portworx-proxy"
 )
 
@@ -57,17 +57,16 @@ func (c *portworxProxy) IsEnabled(cluster *corev1alpha1.StorageCluster) bool {
 }
 
 func (c *portworxProxy) Reconcile(cluster *corev1alpha1.StorageCluster) error {
-	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
-	if err := c.createServiceAccount(ownerRef); err != nil {
+	if err := c.createServiceAccount(); err != nil {
 		return NewError(ErrCritical, err)
 	}
-	if err := c.createClusterRoleBinding(ownerRef); err != nil {
+	if err := c.createClusterRoleBinding(); err != nil {
 		return NewError(ErrCritical, err)
 	}
-	if err := c.createPortworxService(cluster, ownerRef); err != nil {
+	if err := c.createPortworxService(cluster); err != nil {
 		return NewError(ErrCritical, err)
 	}
-	if err := c.createDaemonSet(cluster, ownerRef); err != nil {
+	if err := c.createDaemonSet(cluster); err != nil {
 		return NewError(ErrCritical, err)
 	}
 	return nil
@@ -80,17 +79,16 @@ func (c *portworxProxy) Delete(cluster *corev1alpha1.StorageCluster) error {
 		return nil
 	}
 
-	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
-	if err := k8sutil.DeleteServiceAccount(c.k8sClient, PxProxyServiceAccountName, api.NamespaceSystem, *ownerRef); err != nil {
+	if err := k8sutil.DeleteServiceAccount(c.k8sClient, PxProxyServiceAccountName, api.NamespaceSystem); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PxProxyClusterRoleBindingName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PxProxyClusterRoleBindingName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteService(c.k8sClient, pxutil.PortworxServiceName, api.NamespaceSystem, *ownerRef); err != nil {
+	if err := k8sutil.DeleteService(c.k8sClient, pxutil.PortworxServiceName, api.NamespaceSystem); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteDaemonSet(c.k8sClient, PxProxyDaemonSetName, api.NamespaceSystem, *ownerRef); err != nil {
+	if err := k8sutil.DeleteDaemonSet(c.k8sClient, PxProxyDaemonSetName, api.NamespaceSystem); err != nil {
 		return err
 	}
 	c.isCreated = false
@@ -99,31 +97,44 @@ func (c *portworxProxy) Delete(cluster *corev1alpha1.StorageCluster) error {
 
 func (c *portworxProxy) MarkDeleted() {}
 
-func (c *portworxProxy) createServiceAccount(
-	ownerRef *metav1.OwnerReference,
-) error {
-	return k8sutil.CreateOrUpdateServiceAccount(
-		c.k8sClient,
-		&v1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            PxProxyServiceAccountName,
-				Namespace:       api.NamespaceSystem,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
+func (c *portworxProxy) createServiceAccount() error {
+	sa := &v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      PxProxyServiceAccountName,
+			Namespace: api.NamespaceSystem,
 		},
-		ownerRef,
+	}
+
+	// Remove ownership information from the object as Kuberentes
+	// does not handle cross-namespace ownership. This code should
+	// be removed eventually when existing customers are upgraded.
+	existingSA := &v1.ServiceAccount{}
+	err := c.k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      sa.Name,
+			Namespace: sa.Namespace,
+		},
+		existingSA,
 	)
+	if err == nil && len(existingSA.OwnerReferences) > 0 {
+		existingSA.OwnerReferences = nil
+		logrus.Debugf("Updating %s/%s ServiceAccount", sa.Namespace, sa.Name)
+		if err := c.k8sClient.Update(context.TODO(), existingSA); err != nil {
+			return err
+		}
+		sa.ResourceVersion = existingSA.ResourceVersion
+	}
+
+	return k8sutil.CreateOrUpdateServiceAccount(c.k8sClient, sa, nil)
 }
 
-func (c *portworxProxy) createClusterRoleBinding(
-	ownerRef *metav1.OwnerReference,
-) error {
+func (c *portworxProxy) createClusterRoleBinding() error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		c.k8sClient,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PxProxyClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PxProxyClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -138,25 +149,42 @@ func (c *portworxProxy) createClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 
 func (c *portworxProxy) createPortworxService(
 	cluster *corev1alpha1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
 ) error {
-	service := getPortworxServiceSpec(cluster, ownerRef)
+	service := getPortworxServiceSpec(cluster, nil)
 	service.Namespace = api.NamespaceSystem
 	service.Labels = getPortworxProxyServiceLabels()
 	service.Spec.Selector = getPortworxProxyServiceLabels()
 
-	return k8sutil.CreateOrUpdateService(c.k8sClient, service, ownerRef)
+	// Remove ownership information from the object as Kuberentes
+	// does not handle cross-namespace ownership. This code should
+	// be removed eventually when existing customers are upgraded.
+	existingSvc := &v1.Service{}
+	err := c.k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      service.Name,
+			Namespace: service.Namespace,
+		},
+		existingSvc,
+	)
+	if err == nil && len(existingSvc.OwnerReferences) > 0 {
+		existingSvc.OwnerReferences = nil
+		logrus.Debugf("Updating %s/%s Service", service.Namespace, service.Name)
+		if err := c.k8sClient.Update(context.TODO(), existingSvc); err != nil {
+			return err
+		}
+	}
+
+	return k8sutil.CreateOrUpdateService(c.k8sClient, service, nil)
 }
 
 func (c *portworxProxy) createDaemonSet(
 	cluster *corev1alpha1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
 ) error {
 	existingDaemonSet := &appsv1.DaemonSet{}
 	getErr := c.k8sClient.Get(
@@ -184,8 +212,20 @@ func (c *portworxProxy) createDaemonSet(
 		util.HaveTolerationsChanged(cluster, existingDaemonSet.Spec.Template.Spec.Tolerations)
 
 	if !c.isCreated || errors.IsNotFound(getErr) || modified {
-		daemonSet := getPortworxProxyDaemonSetSpec(cluster, ownerRef, imageName)
-		if err := k8sutil.CreateOrUpdateDaemonSet(c.k8sClient, daemonSet, ownerRef); err != nil {
+		daemonSet := getPortworxProxyDaemonSetSpec(cluster, imageName)
+
+		// Remove ownership information from the object as Kuberentes
+		// does not handle cross-namespace ownership. This code should
+		// be removed eventually when existing customers are upgraded.
+		if !errors.IsNotFound(getErr) && len(existingDaemonSet.OwnerReferences) > 0 {
+			existingDaemonSet.OwnerReferences = nil
+			logrus.Debugf("Updating %s/%s DaemonSet", daemonSet.Namespace, daemonSet.Name)
+			if err := c.k8sClient.Update(context.TODO(), existingDaemonSet); err != nil {
+				return err
+			}
+		}
+
+		if err := k8sutil.CreateOrUpdateDaemonSet(c.k8sClient, daemonSet, nil); err != nil {
 			return err
 		}
 	}
@@ -195,7 +235,6 @@ func (c *portworxProxy) createDaemonSet(
 
 func getPortworxProxyDaemonSetSpec(
 	cluster *corev1alpha1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
 	imageName string,
 ) *appsv1.DaemonSet {
 	maxUnavailable := intstr.FromString("100%")
@@ -203,9 +242,8 @@ func getPortworxProxyDaemonSetSpec(
 
 	newDaemonSet := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            PxProxyDaemonSetName,
-			Namespace:       api.NamespaceSystem,
-			OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			Name:      PxProxyDaemonSetName,
+			Namespace: api.NamespaceSystem,
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{

--- a/drivers/storage/portworx/component/portworx_proxy.go
+++ b/drivers/storage/portworx/component/portworx_proxy.go
@@ -91,11 +91,13 @@ func (c *portworxProxy) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteDaemonSet(c.k8sClient, PxProxyDaemonSetName, api.NamespaceSystem); err != nil {
 		return err
 	}
-	c.isCreated = false
+	c.MarkDeleted()
 	return nil
 }
 
-func (c *portworxProxy) MarkDeleted() {}
+func (c *portworxProxy) MarkDeleted() {
+	c.isCreated = false
+}
 
 func (c *portworxProxy) createServiceAccount() error {
 	sa := &v1.ServiceAccount{

--- a/drivers/storage/portworx/component/portworx_sc.go
+++ b/drivers/storage/portworx/component/portworx_sc.go
@@ -186,6 +186,13 @@ annotations:
 }
 
 func (c *portworxStorageClass) Delete(cluster *corev1alpha1.StorageCluster) error {
+	if cluster.DeletionTimestamp != nil &&
+		(cluster.Spec.DeleteStrategy == nil || cluster.Spec.DeleteStrategy.Type == "") {
+		// If the cluster is deleted without any delete strategy do not delete the
+		// storage classes as Portworx is still running on the nodes
+		return nil
+	}
+
 	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbStorageClass); err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/component/portworx_sc.go
+++ b/drivers/storage/portworx/component/portworx_sc.go
@@ -57,7 +57,6 @@ func (c *portworxStorageClass) IsEnabled(cluster *corev1alpha1.StorageCluster) b
 }
 
 func (c *portworxStorageClass) Reconcile(cluster *corev1alpha1.StorageCluster) error {
-	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
 	docAnnotations := map[string]string{
 		"params/docs":              "https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html",
 		"params/fs":                "Filesystem to be laid out: none|xfs|ext4",
@@ -75,9 +74,8 @@ func (c *portworxStorageClass) Reconcile(cluster *corev1alpha1.StorageCluster) e
 	storageClasses := []*storagev1.StorageClass{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PxDbStorageClass,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-				Annotations:     docAnnotations,
+				Name:        PxDbStorageClass,
+				Annotations: docAnnotations,
 			},
 			Provisioner: portworxProvisioner,
 			Parameters: map[string]string{
@@ -87,8 +85,7 @@ func (c *portworxStorageClass) Reconcile(cluster *corev1alpha1.StorageCluster) e
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PxDbEncryptedStorageClass,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PxDbEncryptedStorageClass,
 				Annotations: map[string]string{
 					"params/note": "Ensure that you have a cluster-wide secret created in the configured secrets provider",
 				},
@@ -102,8 +99,7 @@ func (c *portworxStorageClass) Reconcile(cluster *corev1alpha1.StorageCluster) e
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PxReplicatedStorageClass,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PxReplicatedStorageClass,
 			},
 			Provisioner: portworxProvisioner,
 			Parameters: map[string]string{
@@ -112,8 +108,7 @@ func (c *portworxStorageClass) Reconcile(cluster *corev1alpha1.StorageCluster) e
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PxReplicatedEncryptedStorageClass,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PxReplicatedEncryptedStorageClass,
 			},
 			Provisioner: portworxProvisioner,
 			Parameters: map[string]string{
@@ -127,8 +122,7 @@ func (c *portworxStorageClass) Reconcile(cluster *corev1alpha1.StorageCluster) e
 		storageClasses = append(storageClasses,
 			&storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            PxDbLocalSnapshotStorageClass,
-					OwnerReferences: []metav1.OwnerReference{*ownerRef},
+					Name: PxDbLocalSnapshotStorageClass,
 				},
 				Provisioner: portworxProvisioner,
 				Parameters: map[string]string{
@@ -141,8 +135,7 @@ annotations:
 			},
 			&storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            PxDbLocalSnapshotEncryptedStorageClass,
-					OwnerReferences: []metav1.OwnerReference{*ownerRef},
+					Name: PxDbLocalSnapshotEncryptedStorageClass,
 				},
 				Provisioner: portworxProvisioner,
 				Parameters: map[string]string{
@@ -156,8 +149,7 @@ annotations:
 			},
 			&storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            PxDbCloudSnapshotStorageClass,
-					OwnerReferences: []metav1.OwnerReference{*ownerRef},
+					Name: PxDbCloudSnapshotStorageClass,
 				},
 				Provisioner: portworxProvisioner,
 				Parameters: map[string]string{
@@ -170,8 +162,7 @@ annotations:
 			},
 			&storagev1.StorageClass{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            PxDbCloudSnapshotEncryptedStorageClass,
-					OwnerReferences: []metav1.OwnerReference{*ownerRef},
+					Name: PxDbCloudSnapshotEncryptedStorageClass,
 				},
 				Provisioner: portworxProvisioner,
 				Parameters: map[string]string{
@@ -195,29 +186,28 @@ annotations:
 }
 
 func (c *portworxStorageClass) Delete(cluster *corev1alpha1.StorageCluster) error {
-	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
-	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbStorageClass, *ownerRef); err != nil {
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbStorageClass); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxReplicatedStorageClass, *ownerRef); err != nil {
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxReplicatedStorageClass); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbLocalSnapshotStorageClass, *ownerRef); err != nil {
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbLocalSnapshotStorageClass); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbCloudSnapshotStorageClass, *ownerRef); err != nil {
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbCloudSnapshotStorageClass); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbEncryptedStorageClass, *ownerRef); err != nil {
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbEncryptedStorageClass); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxReplicatedEncryptedStorageClass, *ownerRef); err != nil {
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxReplicatedEncryptedStorageClass); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbLocalSnapshotEncryptedStorageClass, *ownerRef); err != nil {
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbLocalSnapshotEncryptedStorageClass); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbCloudSnapshotEncryptedStorageClass, *ownerRef); err != nil {
+	if err := k8sutil.DeleteStorageClass(c.k8sClient, PxDbCloudSnapshotEncryptedStorageClass); err != nil {
 		return err
 	}
 	return nil

--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -164,6 +164,7 @@ func (c *prometheus) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteDeployment(c.k8sClient, PrometheusOperatorDeploymentName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
+	c.MarkDeleted()
 	return nil
 }
 

--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -88,10 +88,10 @@ func (c *prometheus) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 	if err := c.createOperatorServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createOperatorClusterRole(ownerRef); err != nil {
+	if err := c.createOperatorClusterRole(); err != nil {
 		return err
 	}
-	if err := c.createOperatorClusterRoleBinding(cluster.Namespace, ownerRef); err != nil {
+	if err := c.createOperatorClusterRoleBinding(cluster.Namespace); err != nil {
 		return err
 	}
 	if err := c.createOperatorDeployment(cluster, ownerRef); err != nil {
@@ -100,10 +100,10 @@ func (c *prometheus) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 	if err := c.createPrometheusServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createPrometheusClusterRole(ownerRef); err != nil {
+	if err := c.createPrometheusClusterRole(); err != nil {
 		return err
 	}
-	if err := c.createPrometheusClusterRoleBinding(cluster.Namespace, ownerRef); err != nil {
+	if err := c.createPrometheusClusterRoleBinding(cluster.Namespace); err != nil {
 		return err
 	}
 	if err := c.createPrometheusService(cluster.Namespace, ownerRef); err != nil {
@@ -143,10 +143,10 @@ func (c *prometheus) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteServiceAccount(c.k8sClient, PrometheusServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRole(c.k8sClient, PrometheusClusterRoleName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRole(c.k8sClient, PrometheusClusterRoleName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PrometheusClusterRoleBindingName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PrometheusClusterRoleBindingName); err != nil {
 		return err
 	}
 	if err := k8sutil.DeleteService(c.k8sClient, PrometheusServiceName, cluster.Namespace, *ownerRef); err != nil {
@@ -155,10 +155,10 @@ func (c *prometheus) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteServiceAccount(c.k8sClient, PrometheusOperatorServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRole(c.k8sClient, PrometheusOperatorClusterRoleName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRole(c.k8sClient, PrometheusOperatorClusterRoleName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PrometheusOperatorClusterRoleBindingName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PrometheusOperatorClusterRoleBindingName); err != nil {
 		return err
 	}
 	if err := k8sutil.DeleteDeployment(c.k8sClient, PrometheusOperatorDeploymentName, cluster.Namespace, *ownerRef); err != nil {
@@ -205,13 +205,12 @@ func (c *prometheus) createPrometheusServiceAccount(
 	)
 }
 
-func (c *prometheus) createOperatorClusterRole(ownerRef *metav1.OwnerReference) error {
+func (c *prometheus) createOperatorClusterRole() error {
 	return k8sutil.CreateOrUpdateClusterRole(
 		c.k8sClient,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PrometheusOperatorClusterRoleName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PrometheusOperatorClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -268,17 +267,15 @@ func (c *prometheus) createOperatorClusterRole(ownerRef *metav1.OwnerReference) 
 				},
 			},
 		},
-		ownerRef,
 	)
 }
 
-func (c *prometheus) createPrometheusClusterRole(ownerRef *metav1.OwnerReference) error {
+func (c *prometheus) createPrometheusClusterRole() error {
 	return k8sutil.CreateOrUpdateClusterRole(
 		c.k8sClient,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PrometheusClusterRoleName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PrometheusClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -297,20 +294,17 @@ func (c *prometheus) createPrometheusClusterRole(ownerRef *metav1.OwnerReference
 				},
 			},
 		},
-		ownerRef,
 	)
 }
 
 func (c *prometheus) createOperatorClusterRoleBinding(
 	clusterNamespace string,
-	ownerRef *metav1.OwnerReference,
 ) error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		c.k8sClient,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PrometheusOperatorClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PrometheusOperatorClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -325,20 +319,17 @@ func (c *prometheus) createOperatorClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 
 func (c *prometheus) createPrometheusClusterRoleBinding(
 	clusterNamespace string,
-	ownerRef *metav1.OwnerReference,
 ) error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		c.k8sClient,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PrometheusClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PrometheusClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -353,7 +344,6 @@ func (c *prometheus) createPrometheusClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -81,10 +81,10 @@ func (c *pvcController) Reconcile(cluster *corev1alpha1.StorageCluster) error {
 	if err := c.createServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createClusterRole(ownerRef); err != nil {
+	if err := c.createClusterRole(); err != nil {
 		return err
 	}
-	if err := c.createClusterRoleBinding(cluster.Namespace, ownerRef); err != nil {
+	if err := c.createClusterRoleBinding(cluster.Namespace); err != nil {
 		return err
 	}
 	if err := c.createDeployment(cluster, ownerRef); err != nil {
@@ -98,10 +98,10 @@ func (c *pvcController) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteServiceAccount(c.k8sClient, PVCServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRole(c.k8sClient, PVCClusterRoleName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRole(c.k8sClient, PVCClusterRoleName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PVCClusterRoleBindingName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PVCClusterRoleBindingName); err != nil {
 		return err
 	}
 	if err := k8sutil.DeleteDeployment(c.k8sClient, PVCDeploymentName, cluster.Namespace, *ownerRef); err != nil {
@@ -132,13 +132,12 @@ func (c *pvcController) createServiceAccount(
 	)
 }
 
-func (c *pvcController) createClusterRole(ownerRef *metav1.OwnerReference) error {
+func (c *pvcController) createClusterRole() error {
 	return k8sutil.CreateOrUpdateClusterRole(
 		c.k8sClient,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PVCClusterRoleName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PVCClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -214,20 +213,17 @@ func (c *pvcController) createClusterRole(ownerRef *metav1.OwnerReference) error
 				},
 			},
 		},
-		ownerRef,
 	)
 }
 
 func (c *pvcController) createClusterRoleBinding(
 	clusterNamespace string,
-	ownerRef *metav1.OwnerReference,
 ) error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		c.k8sClient,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            PVCClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: PVCClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -242,7 +238,6 @@ func (c *pvcController) createClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -107,7 +107,7 @@ func (c *pvcController) Delete(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteDeployment(c.k8sClient, PVCDeploymentName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	c.isCreated = false
+	c.MarkDeleted()
 	return nil
 }
 

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -94,8 +94,7 @@ func TestBasicComponentsInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCR, component.PxClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, actualCR.Name)
-	require.Len(t, actualCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCR.OwnerReferences[0].Name)
+	require.Empty(t, actualCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, actualCR.Rules)
 
 	// Portworx ClusterRoleBinding
@@ -104,8 +103,7 @@ func TestBasicComponentsInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCRB, component.PxClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, actualCRB.Name)
-	require.Len(t, actualCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCRB.OwnerReferences[0].Name)
+	require.Empty(t, actualCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
 
@@ -171,8 +169,7 @@ func TestBasicComponentsInstall(t *testing.T) {
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.PxProxyServiceAccountName, api.NamespaceSystem)
 	require.NoError(t, err)
-	require.Len(t, sa.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, sa.OwnerReferences[0].Name)
+	require.Empty(t, sa.OwnerReferences)
 
 	// Portworx Proxy ClusterRoleBinding
 	expectedCRB = testutil.GetExpectedClusterRoleBinding(t, "pxProxyClusterRoleBinding.yaml")
@@ -180,8 +177,7 @@ func TestBasicComponentsInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCRB, component.PxProxyClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, actualCRB.Name)
-	require.Len(t, actualCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCRB.OwnerReferences[0].Name)
+	require.Empty(t, actualCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
 
@@ -192,8 +188,7 @@ func TestBasicComponentsInstall(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedPxProxyService.Name, pxProxyService.Name)
 	require.Equal(t, expectedPxProxyService.Namespace, pxProxyService.Namespace)
-	require.Len(t, pxProxyService.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, pxProxyService.OwnerReferences[0].Name)
+	require.Empty(t, pxProxyService.OwnerReferences)
 	require.Equal(t, expectedPxProxyService.Labels, pxProxyService.Labels)
 	require.Equal(t, expectedPxProxyService.Spec, pxProxyService.Spec)
 
@@ -204,8 +199,7 @@ func TestBasicComponentsInstall(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedDaemonSet.Name, ds.Name)
 	require.Equal(t, expectedDaemonSet.Namespace, ds.Namespace)
-	require.Len(t, ds.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, ds.OwnerReferences[0].Name)
+	require.Empty(t, ds.OwnerReferences)
 	require.Equal(t, expectedDaemonSet.Spec, ds.Spec)
 }
 
@@ -615,8 +609,7 @@ func TestDefaultStorageClassesWithStork(t *testing.T) {
 	err = testutil.Get(k8sClient, actualSC, component.PxDbStorageClass, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSC.Name, component.PxDbStorageClass)
-	require.Len(t, actualSC.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualSC.OwnerReferences[0].Name)
+	require.Empty(t, actualSC.OwnerReferences)
 	require.Equal(t, expectedSC.Annotations, actualSC.Annotations)
 	require.Equal(t, expectedSC.Provisioner, actualSC.Provisioner)
 	require.Equal(t, expectedSC.Parameters, actualSC.Parameters)
@@ -626,8 +619,7 @@ func TestDefaultStorageClassesWithStork(t *testing.T) {
 	err = testutil.Get(k8sClient, actualSC, component.PxDbEncryptedStorageClass, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSC.Name, component.PxDbEncryptedStorageClass)
-	require.Len(t, actualSC.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualSC.OwnerReferences[0].Name)
+	require.Empty(t, actualSC.OwnerReferences)
 	require.Equal(t, expectedSC.Annotations, actualSC.Annotations)
 	require.Equal(t, expectedSC.Provisioner, actualSC.Provisioner)
 	require.Equal(t, expectedSC.Parameters, actualSC.Parameters)
@@ -637,8 +629,7 @@ func TestDefaultStorageClassesWithStork(t *testing.T) {
 	err = testutil.Get(k8sClient, actualSC, component.PxReplicatedStorageClass, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSC.Name, component.PxReplicatedStorageClass)
-	require.Len(t, actualSC.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualSC.OwnerReferences[0].Name)
+	require.Empty(t, actualSC.OwnerReferences)
 	require.Equal(t, expectedSC.Annotations, actualSC.Annotations)
 	require.Equal(t, expectedSC.Provisioner, actualSC.Provisioner)
 	require.Equal(t, expectedSC.Parameters, actualSC.Parameters)
@@ -648,8 +639,7 @@ func TestDefaultStorageClassesWithStork(t *testing.T) {
 	err = testutil.Get(k8sClient, actualSC, component.PxReplicatedEncryptedStorageClass, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSC.Name, component.PxReplicatedEncryptedStorageClass)
-	require.Len(t, actualSC.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualSC.OwnerReferences[0].Name)
+	require.Empty(t, actualSC.OwnerReferences)
 	require.Equal(t, expectedSC.Annotations, actualSC.Annotations)
 	require.Equal(t, expectedSC.Provisioner, actualSC.Provisioner)
 	require.Equal(t, expectedSC.Parameters, actualSC.Parameters)
@@ -659,8 +649,7 @@ func TestDefaultStorageClassesWithStork(t *testing.T) {
 	err = testutil.Get(k8sClient, actualSC, component.PxDbLocalSnapshotStorageClass, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSC.Name, component.PxDbLocalSnapshotStorageClass)
-	require.Len(t, actualSC.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualSC.OwnerReferences[0].Name)
+	require.Empty(t, actualSC.OwnerReferences)
 	require.Equal(t, expectedSC.Annotations, actualSC.Annotations)
 	require.Equal(t, expectedSC.Provisioner, actualSC.Provisioner)
 	require.Equal(t, expectedSC.Parameters, actualSC.Parameters)
@@ -670,8 +659,7 @@ func TestDefaultStorageClassesWithStork(t *testing.T) {
 	err = testutil.Get(k8sClient, actualSC, component.PxDbLocalSnapshotEncryptedStorageClass, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSC.Name, component.PxDbLocalSnapshotEncryptedStorageClass)
-	require.Len(t, actualSC.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualSC.OwnerReferences[0].Name)
+	require.Empty(t, actualSC.OwnerReferences)
 	require.Equal(t, expectedSC.Annotations, actualSC.Annotations)
 	require.Equal(t, expectedSC.Provisioner, actualSC.Provisioner)
 	require.Equal(t, expectedSC.Parameters, actualSC.Parameters)
@@ -681,8 +669,7 @@ func TestDefaultStorageClassesWithStork(t *testing.T) {
 	err = testutil.Get(k8sClient, actualSC, component.PxDbCloudSnapshotStorageClass, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSC.Name, component.PxDbCloudSnapshotStorageClass)
-	require.Len(t, actualSC.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualSC.OwnerReferences[0].Name)
+	require.Empty(t, actualSC.OwnerReferences)
 	require.Equal(t, expectedSC.Annotations, actualSC.Annotations)
 	require.Equal(t, expectedSC.Provisioner, actualSC.Provisioner)
 	require.Equal(t, expectedSC.Parameters, actualSC.Parameters)
@@ -692,8 +679,7 @@ func TestDefaultStorageClassesWithStork(t *testing.T) {
 	err = testutil.Get(k8sClient, actualSC, component.PxDbCloudSnapshotEncryptedStorageClass, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSC.Name, component.PxDbCloudSnapshotEncryptedStorageClass)
-	require.Len(t, actualSC.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualSC.OwnerReferences[0].Name)
+	require.Empty(t, actualSC.OwnerReferences)
 	require.Equal(t, expectedSC.Annotations, actualSC.Annotations)
 	require.Equal(t, expectedSC.Provisioner, actualSC.Provisioner)
 	require.Equal(t, expectedSC.Parameters, actualSC.Parameters)
@@ -1354,8 +1340,7 @@ func verifyPVCControllerInstall(
 	err = testutil.Get(k8sClient, actualCR, component.PVCClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, actualCR.Name)
-	require.Len(t, actualCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCR.OwnerReferences[0].Name)
+	require.Empty(t, actualCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, actualCR.Rules)
 
 	// PVC Controller ClusterRoleBinding
@@ -1369,8 +1354,7 @@ func verifyPVCControllerInstall(
 	err = testutil.Get(k8sClient, actualCRB, component.PVCClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, actualCRB.Name)
-	require.Len(t, actualCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCRB.OwnerReferences[0].Name)
+	require.Empty(t, actualCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
 }
@@ -1605,8 +1589,7 @@ func TestLighthouseInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCR, component.LhClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, actualCR.Name)
-	require.Len(t, actualCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCR.OwnerReferences[0].Name)
+	require.Empty(t, actualCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, actualCR.Rules)
 
 	// Lighthouse ClusterRoleBinding
@@ -1620,8 +1603,7 @@ func TestLighthouseInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCRB, component.LhClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, actualCRB.Name)
-	require.Len(t, actualCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCRB.OwnerReferences[0].Name)
+	require.Empty(t, actualCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
 
@@ -2207,8 +2189,7 @@ func TestAutopilotInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCR, component.AutopilotClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, actualCR.Name)
-	require.Len(t, actualCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCR.OwnerReferences[0].Name)
+	require.Empty(t, actualCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, actualCR.Rules)
 
 	// Autopilot ClusterRoleBinding
@@ -2217,8 +2198,7 @@ func TestAutopilotInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCRB, component.AutopilotClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, actualCRB.Name)
-	require.Len(t, actualCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCRB.OwnerReferences[0].Name)
+	require.Empty(t, actualCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
 
@@ -2719,6 +2699,7 @@ func TestSecurityInstall(t *testing.T) {
 	cluster.Spec.Security.Enabled = false
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
+
 	err = testutil.Get(k8sClient, securitySecret, pxutil.SecurityPXAuthKeysSecretName, cluster.Namespace)
 	require.NoError(t, err)
 
@@ -2821,8 +2802,7 @@ func TestCSIInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCR, component.CSIClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, actualCR.Name)
-	require.Len(t, actualCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCR.OwnerReferences[0].Name)
+	require.Empty(t, actualCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, actualCR.Rules)
 
 	// CSI ClusterRoleBinding
@@ -2836,8 +2816,7 @@ func TestCSIInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCRB, component.CSIClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, actualCRB.Name)
-	require.Len(t, actualCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCRB.OwnerReferences[0].Name)
+	require.Empty(t, actualCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
 
@@ -2939,8 +2918,7 @@ func TestCSIInstallWithNewerCSIVersion(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCR, component.CSIClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, actualCR.Name)
-	require.Len(t, actualCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCR.OwnerReferences[0].Name)
+	require.Empty(t, actualCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, actualCR.Rules)
 
 	expectedDeployment := testutil.GetExpectedDeployment(t, "csiDeployment_1.0.yaml")
@@ -2987,8 +2965,7 @@ func TestCSIInstallWithNewerCSIVersion(t *testing.T) {
 	csiDriver = &storagev1beta1.CSIDriver{}
 	err = testutil.Get(k8sClient, csiDriver, pxutil.CSIDriverName, "")
 	require.NoError(t, err)
-	require.Len(t, csiDriver.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, csiDriver.OwnerReferences[0].Name)
+	require.Empty(t, csiDriver.OwnerReferences)
 	require.False(t, *csiDriver.Spec.AttachRequired)
 	require.False(t, *csiDriver.Spec.PodInfoOnMount)
 
@@ -3161,8 +3138,7 @@ func TestCSIInstallWithDeprecatedCSIDriverName(t *testing.T) {
 	csiDriver := &storagev1beta1.CSIDriver{}
 	err = testutil.Get(k8sClient, csiDriver, pxutil.DeprecatedCSIDriverName, "")
 	require.NoError(t, err)
-	require.Len(t, csiDriver.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, csiDriver.OwnerReferences[0].Name)
+	require.Empty(t, csiDriver.OwnerReferences)
 	require.False(t, *csiDriver.Spec.AttachRequired)
 	require.False(t, *csiDriver.Spec.PodInfoOnMount)
 
@@ -3358,8 +3334,7 @@ func TestCSIClusterRoleK8sVersionGreaterThan_1_14(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCR, component.CSIClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, actualCR.Name)
-	require.Len(t, actualCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCR.OwnerReferences[0].Name)
+	require.Empty(t, actualCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, actualCR.Rules)
 }
 
@@ -4013,8 +3988,7 @@ func TestPrometheusInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCR, component.PrometheusOperatorClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, actualCR.Name)
-	require.Len(t, actualCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCR.OwnerReferences[0].Name)
+	require.Empty(t, actualCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, actualCR.Rules)
 
 	// Prometheus operator ClusterRoleBinding
@@ -4023,8 +3997,7 @@ func TestPrometheusInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCRB, component.PrometheusOperatorClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, actualCRB.Name)
-	require.Len(t, actualCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCRB.OwnerReferences[0].Name)
+	require.Empty(t, actualCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
 
@@ -4054,8 +4027,7 @@ func TestPrometheusInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCR, component.PrometheusClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, actualCR.Name)
-	require.Len(t, actualCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCR.OwnerReferences[0].Name)
+	require.Empty(t, actualCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, actualCR.Rules)
 
 	// Prometheus ClusterRoleBinding
@@ -4064,8 +4036,7 @@ func TestPrometheusInstall(t *testing.T) {
 	err = testutil.Get(k8sClient, actualCRB, component.PrometheusClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, actualCRB.Name)
-	require.Len(t, actualCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, actualCRB.OwnerReferences[0].Name)
+	require.Empty(t, actualCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
 
@@ -6732,7 +6703,6 @@ func TestRemovePVCController(t *testing.T) {
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 
-	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.PVCServiceAccountName, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
@@ -6793,7 +6763,6 @@ func TestDisablePVCController(t *testing.T) {
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 
-	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.PVCServiceAccountName, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
@@ -6860,7 +6829,6 @@ func TestRemoveLighthouse(t *testing.T) {
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 
-	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.LhServiceAccountName, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
@@ -6931,7 +6899,6 @@ func TestDisableLighthouse(t *testing.T) {
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 
-	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.LhServiceAccountName, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
@@ -7142,10 +7109,9 @@ func TestDisableCSI_0_3(t *testing.T) {
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 
-	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.CSIServiceAccountName, cluster.Namespace)
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	cr = &rbacv1.ClusterRole{}
 	err = testutil.Get(k8sClient, cr, component.CSIClusterRoleName, "")
@@ -7168,10 +7134,9 @@ func TestDisableCSI_0_3(t *testing.T) {
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 
-	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.CSIServiceAccountName, cluster.Namespace)
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	cr = &rbacv1.ClusterRole{}
 	err = testutil.Get(k8sClient, cr, component.CSIClusterRoleName, "")
@@ -7247,10 +7212,9 @@ func TestDisableCSI_1_0(t *testing.T) {
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 
-	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.CSIServiceAccountName, cluster.Namespace)
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	cr = &rbacv1.ClusterRole{}
 	err = testutil.Get(k8sClient, cr, component.CSIClusterRoleName, "")
@@ -7277,10 +7241,9 @@ func TestDisableCSI_1_0(t *testing.T) {
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 
-	// Keep the service account
 	sa = &v1.ServiceAccount{}
 	err = testutil.Get(k8sClient, sa, component.CSIServiceAccountName, cluster.Namespace)
-	require.NoError(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	cr = &rbacv1.ClusterRole{}
 	err = testutil.Get(k8sClient, cr, component.CSIClusterRoleName, "")

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -224,7 +224,7 @@ func (p *portworx) PreInstall(cluster *corev1alpha1.StorageCluster) error {
 func (p *portworx) DeleteStorage(
 	cluster *corev1alpha1.StorageCluster,
 ) (*corev1alpha1.ClusterCondition, error) {
-	p.markComponentsAsDeleted()
+	p.deleteComponents(cluster)
 
 	if cluster.Spec.DeleteStrategy == nil || !pxutil.IsPortworxEnabled(cluster) {
 		// No Delete strategy provided or Portworx not installed through the operator,
@@ -267,6 +267,9 @@ func (p *portworx) DeleteStorage(
 	}
 
 	if completed != 0 && total != 0 && completed == total {
+		if err := u.DeleteNodeWiper(); err != nil {
+			logrus.Errorf("Failed to cleanup node wiper. %v", err)
+		}
 		// all the nodes are wiped
 		if removeData {
 			logrus.Debugf("Deleting portworx metadata")
@@ -293,9 +296,12 @@ func (p *portworx) DeleteStorage(
 	}, nil
 }
 
-func (p *portworx) markComponentsAsDeleted() {
-	for _, comp := range component.GetAll() {
-		comp.MarkDeleted()
+func (p *portworx) deleteComponents(cluster *corev1alpha1.StorageCluster) {
+	for componentName, comp := range component.GetAll() {
+		if err := comp.Delete(cluster); err != nil {
+			msg := fmt.Sprintf("Failed to cleanup %v. %v", componentName, err)
+			p.warningEvent(cluster, util.FailedComponentReason, msg)
+		}
 	}
 }
 

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -3645,10 +3645,11 @@ func TestDeleteClusterWithoutDeleteStrategy(t *testing.T) {
 }
 
 func TestDeleteClusterWithUninstallStrategy(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	k8sClient := testutil.FakeK8sClient()
-	driver := portworx{
-		k8sClient: k8sClient,
-	}
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+
 	cluster := &corev1alpha1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
@@ -3682,8 +3683,7 @@ func TestDeleteClusterWithUninstallStrategy(t *testing.T) {
 	err = testutil.Get(k8sClient, wiperCR, pxNodeWiperClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, wiperCR.Name)
-	require.Len(t, wiperCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, wiperCR.OwnerReferences[0].Name)
+	require.Empty(t, wiperCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, wiperCR.Rules)
 
 	// Check wiper cluster role binding
@@ -3692,8 +3692,7 @@ func TestDeleteClusterWithUninstallStrategy(t *testing.T) {
 	err = testutil.Get(k8sClient, wiperCRB, pxNodeWiperClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, wiperCRB.Name)
-	require.Len(t, wiperCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, wiperCRB.OwnerReferences[0].Name)
+	require.Empty(t, wiperCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, wiperCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, wiperCRB.RoleRef)
 
@@ -3912,10 +3911,11 @@ func TestDeleteClusterWithCustomNodeWiperImage(t *testing.T) {
 }
 
 func TestDeleteClusterWithUninstallStrategyForPKS(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	k8sClient := testutil.FakeK8sClient()
-	driver := portworx{
-		k8sClient: k8sClient,
-	}
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+
 	cluster := &corev1alpha1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
@@ -3952,8 +3952,7 @@ func TestDeleteClusterWithUninstallStrategyForPKS(t *testing.T) {
 	err = testutil.Get(k8sClient, wiperCR, pxNodeWiperClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, wiperCR.Name)
-	require.Len(t, wiperCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, wiperCR.OwnerReferences[0].Name)
+	require.Empty(t, wiperCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, wiperCR.Rules)
 
 	// Check wiper cluster role binding
@@ -3962,8 +3961,7 @@ func TestDeleteClusterWithUninstallStrategyForPKS(t *testing.T) {
 	err = testutil.Get(k8sClient, wiperCRB, pxNodeWiperClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, wiperCRB.Name)
-	require.Len(t, wiperCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, wiperCRB.OwnerReferences[0].Name)
+	require.Empty(t, wiperCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, wiperCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, wiperCRB.RoleRef)
 
@@ -3980,10 +3978,11 @@ func TestDeleteClusterWithUninstallStrategyForPKS(t *testing.T) {
 }
 
 func TestDeleteClusterWithUninstallAndWipeStrategy(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	k8sClient := testutil.FakeK8sClient()
-	driver := portworx{
-		k8sClient: k8sClient,
-	}
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+
 	cluster := &corev1alpha1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
@@ -4017,8 +4016,7 @@ func TestDeleteClusterWithUninstallAndWipeStrategy(t *testing.T) {
 	err = testutil.Get(k8sClient, wiperCR, pxNodeWiperClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCR.Name, wiperCR.Name)
-	require.Len(t, wiperCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, wiperCR.OwnerReferences[0].Name)
+	require.Empty(t, wiperCR.OwnerReferences)
 	require.ElementsMatch(t, expectedCR.Rules, wiperCR.Rules)
 
 	// Check wiper cluster role binding
@@ -4027,8 +4025,7 @@ func TestDeleteClusterWithUninstallAndWipeStrategy(t *testing.T) {
 	err = testutil.Get(k8sClient, wiperCRB, pxNodeWiperClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedCRB.Name, wiperCRB.Name)
-	require.Len(t, wiperCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, wiperCRB.OwnerReferences[0].Name)
+	require.Empty(t, wiperCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedCRB.Subjects, wiperCRB.Subjects)
 	require.Equal(t, expectedCRB.RoleRef, wiperCRB.RoleRef)
 

--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -188,12 +188,12 @@ func (u *uninstallPortworx) RunNodeWiper(
 		return err
 	}
 
-	err = u.createClusterRole(ownerRef)
+	err = u.createClusterRole()
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
 
-	err = u.createClusterRoleBinding(ownerRef)
+	err = u.createClusterRoleBinding()
 	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
@@ -413,15 +413,12 @@ func (u *uninstallPortworx) createServiceAccount(
 	)
 }
 
-func (u *uninstallPortworx) createClusterRole(
-	ownerRef *metav1.OwnerReference,
-) error {
+func (u *uninstallPortworx) createClusterRole() error {
 	return k8sutil.CreateOrUpdateClusterRole(
 		u.k8sClient,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            pxNodeWiperClusterRoleName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: pxNodeWiperClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -432,19 +429,15 @@ func (u *uninstallPortworx) createClusterRole(
 				},
 			},
 		},
-		ownerRef,
 	)
 }
 
-func (u *uninstallPortworx) createClusterRoleBinding(
-	ownerRef *metav1.OwnerReference,
-) error {
+func (u *uninstallPortworx) createClusterRoleBinding() error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		u.k8sClient,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            pxNodeWiperClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: pxNodeWiperClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -459,7 +452,6 @@ func (u *uninstallPortworx) createClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 

--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -71,6 +71,8 @@ type UninstallPortworx interface {
 	// GetNodeWiperStatus returns the status of the node-wiper daemonset
 	// returns the no. of completed, in progress and total pods
 	GetNodeWiperStatus() (int32, int32, int32, error)
+	// DeleteNodeWiper deletes the node-wiper daemonset
+	DeleteNodeWiper() error
 	// WipeMetadata wipes the metadata associated with Portworx cluster
 	WipeMetadata() error
 }
@@ -395,6 +397,23 @@ func (u *uninstallPortworx) RunNodeWiper(
 	}
 
 	return u.k8sClient.Create(context.TODO(), ds)
+}
+
+func (u *uninstallPortworx) DeleteNodeWiper() error {
+	ownerRef := metav1.NewControllerRef(u.cluster, pxutil.StorageClusterKind())
+	if err := k8sutil.DeleteServiceAccount(u.k8sClient, pxNodeWiperServiceAccountName, u.cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteClusterRole(u.k8sClient, pxNodeWiperClusterRoleName); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteClusterRoleBinding(u.k8sClient, pxNodeWiperClusterRoleBindingName); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteDaemonSet(u.k8sClient, pxNodeWiperDaemonSetName, u.cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (u *uninstallPortworx) createServiceAccount(

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	fakeextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -2351,6 +2353,129 @@ func TestDeleteStorageClusterWithFinalizers(t *testing.T) {
 	require.Len(t, updatedCluster.Status.Conditions, 2)
 	require.Equal(t, *condition, updatedCluster.Status.Conditions[1])
 	require.Empty(t, updatedCluster.Finalizers)
+}
+
+func TestDeleteStorageClusterShouldDeleteStork(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cluster := &corev1alpha1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1alpha1.StorageClusterSpec{
+			Stork: &corev1alpha1.StorkSpec{
+				Enabled: true,
+				Image:   "osd/stork:test",
+			},
+		},
+	}
+
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient := testutil.FakeK8sClient(cluster)
+	// podControl := &k8scontroller.FakePodControl{}
+	// recorder := record.NewFakeRecorder(0)
+	controller := Controller{
+		client: k8sClient,
+		Driver: driver,
+		// podControl:        podControl,
+		// recorder:          recorder,
+		kubernetesVersion: k8sVersion,
+	}
+
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return("pxd").AnyTimes()
+	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
+	driver.EXPECT().GetStorkEnvList(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+	result, err := controller.Reconcile(request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+
+	serviceAccountList := &v1.ServiceAccountList{}
+	err = testutil.List(k8sClient, serviceAccountList)
+	require.NoError(t, err)
+	require.NotEmpty(t, serviceAccountList.Items)
+
+	clusterRoleList := &rbacv1.ClusterRoleList{}
+	err = testutil.List(k8sClient, clusterRoleList)
+	require.NoError(t, err)
+	require.NotEmpty(t, clusterRoleList.Items)
+
+	crbList := &rbacv1.ClusterRoleBindingList{}
+	err = testutil.List(k8sClient, crbList)
+	require.NoError(t, err)
+	require.NotEmpty(t, crbList.Items)
+
+	configMapList := &v1.ConfigMapList{}
+	err = testutil.List(k8sClient, configMapList)
+	require.NoError(t, err)
+	require.NotEmpty(t, configMapList.Items)
+
+	storageClassList := &storagev1.StorageClassList{}
+	err = testutil.List(k8sClient, storageClassList)
+	require.NoError(t, err)
+	require.NotEmpty(t, storageClassList.Items)
+
+	serviceList := &v1.ServiceList{}
+	err = testutil.List(k8sClient, serviceList)
+	require.NoError(t, err)
+	require.NotEmpty(t, serviceList.Items)
+
+	deploymentList := &appsv1.DeploymentList{}
+	err = testutil.List(k8sClient, deploymentList)
+	require.NoError(t, err)
+	require.NotEmpty(t, deploymentList.Items)
+
+	// On deleting the storage cluster, stork specs should
+	// also get removed
+	deletionTimeStamp := metav1.Now()
+	cluster.DeletionTimestamp = &deletionTimeStamp
+	k8sClient.Update(context.TODO(), cluster)
+
+	result, err = controller.Reconcile(request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+
+	err = testutil.List(k8sClient, serviceAccountList)
+	require.NoError(t, err)
+	require.Empty(t, serviceAccountList.Items)
+
+	err = testutil.List(k8sClient, clusterRoleList)
+	require.NoError(t, err)
+	require.Empty(t, clusterRoleList.Items)
+
+	err = testutil.List(k8sClient, crbList)
+	require.NoError(t, err)
+	require.Empty(t, crbList.Items)
+
+	err = testutil.List(k8sClient, configMapList)
+	require.NoError(t, err)
+	require.Empty(t, configMapList.Items)
+
+	err = testutil.List(k8sClient, storageClassList)
+	require.NoError(t, err)
+	require.Empty(t, storageClassList.Items)
+
+	err = testutil.List(k8sClient, serviceList)
+	require.NoError(t, err)
+	require.Empty(t, serviceList.Items)
+
+	err = testutil.List(k8sClient, deploymentList)
+	require.NoError(t, err)
+	require.Empty(t, deploymentList.Items)
 }
 
 func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -455,9 +455,10 @@ func (c *Controller) deleteStorageCluster(
 		}
 	}
 
-	c.isStorkDeploymentCreated = false
-	c.isStorkSchedDeploymentCreated = false
-
+	if err := c.removeStork(cluster); err != nil {
+		msg := fmt.Sprintf("Failed to cleanup Stork. %v", err)
+		c.warningEvent(cluster, util.FailedComponentReason, msg)
+	}
 	return nil
 }
 

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -77,10 +77,10 @@ func (c *Controller) setupStork(cluster *corev1alpha1.StorageCluster) error {
 	if err := c.createStorkServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createStorkClusterRole(ownerRef); err != nil {
+	if err := c.createStorkClusterRole(); err != nil {
 		return err
 	}
-	if err := c.createStorkClusterRoleBinding(cluster.Namespace, ownerRef); err != nil {
+	if err := c.createStorkClusterRoleBinding(cluster.Namespace); err != nil {
 		return err
 	}
 	if err := c.createStorkService(cluster.Namespace, ownerRef); err != nil {
@@ -89,7 +89,7 @@ func (c *Controller) setupStork(cluster *corev1alpha1.StorageCluster) error {
 	if err := c.createStorkDeployment(cluster, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createStorkSnapshotStorageClass(ownerRef); err != nil {
+	if err := c.createStorkSnapshotStorageClass(); err != nil {
 		return err
 	}
 	return c.setupStorkScheduler(cluster)
@@ -100,10 +100,10 @@ func (c *Controller) setupStorkScheduler(cluster *corev1alpha1.StorageCluster) e
 	if err := c.createStorkSchedServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createStorkSchedClusterRole(ownerRef); err != nil {
+	if err := c.createStorkSchedClusterRole(); err != nil {
 		return err
 	}
-	if err := c.createStorkSchedClusterRoleBinding(cluster.Namespace, ownerRef); err != nil {
+	if err := c.createStorkSchedClusterRoleBinding(cluster.Namespace); err != nil {
 		return err
 	}
 	if err := c.createStorkSchedDeployment(cluster, ownerRef); err != nil {
@@ -121,10 +121,10 @@ func (c *Controller) removeStork(cluster *corev1alpha1.StorageCluster) error {
 	if err := k8sutil.DeleteServiceAccount(c.client, storkServiceAccountName, namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRole(c.client, storkClusterRoleName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRole(c.client, storkClusterRoleName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(c.client, storkClusterRoleBindingName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(c.client, storkClusterRoleBindingName); err != nil {
 		return err
 	}
 	if err := k8sutil.DeleteService(c.client, storkServiceName, namespace, *ownerRef); err != nil {
@@ -134,7 +134,7 @@ func (c *Controller) removeStork(cluster *corev1alpha1.StorageCluster) error {
 		return err
 	}
 	c.isStorkDeploymentCreated = false
-	if err := k8sutil.DeleteStorageClass(c.client, storkSnapshotStorageClassName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteStorageClass(c.client, storkSnapshotStorageClassName); err != nil {
 		return err
 	}
 	return c.removeStorkScheduler(namespace, ownerRef)
@@ -147,10 +147,10 @@ func (c *Controller) removeStorkScheduler(
 	if err := k8sutil.DeleteServiceAccount(c.client, storkSchedServiceAccountName, namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRole(c.client, storkSchedClusterRoleName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRole(c.client, storkSchedClusterRoleName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(c.client, storkSchedClusterRoleBindingName, *ownerRef); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(c.client, storkSchedClusterRoleBindingName); err != nil {
 		return err
 	}
 	if err := k8sutil.DeleteDeployment(c.client, storkSchedDeploymentName, namespace, *ownerRef); err != nil {
@@ -205,15 +205,12 @@ func (c *Controller) createStorkConfigMap(
 	)
 }
 
-func (c *Controller) createStorkSnapshotStorageClass(
-	ownerRef *metav1.OwnerReference,
-) error {
+func (c *Controller) createStorkSnapshotStorageClass() error {
 	return k8sutil.CreateStorageClass(
 		c.client,
 		&storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            storkSnapshotStorageClassName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: storkSnapshotStorageClassName,
 			},
 			Provisioner: "stork-snapshot",
 		},
@@ -254,13 +251,12 @@ func (c *Controller) createStorkSchedServiceAccount(
 	)
 }
 
-func (c *Controller) createStorkClusterRole(ownerRef *metav1.OwnerReference) error {
+func (c *Controller) createStorkClusterRole() error {
 	return k8sutil.CreateOrUpdateClusterRole(
 		c.client,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            storkClusterRoleName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: storkClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -270,17 +266,15 @@ func (c *Controller) createStorkClusterRole(ownerRef *metav1.OwnerReference) err
 				},
 			},
 		},
-		ownerRef,
 	)
 }
 
-func (c *Controller) createStorkSchedClusterRole(ownerRef *metav1.OwnerReference) error {
+func (c *Controller) createStorkSchedClusterRole() error {
 	return k8sutil.CreateOrUpdateClusterRole(
 		c.client,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            storkSchedClusterRoleName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: storkSchedClusterRoleName,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -361,20 +355,17 @@ func (c *Controller) createStorkSchedClusterRole(ownerRef *metav1.OwnerReference
 				},
 			},
 		},
-		ownerRef,
 	)
 }
 
 func (c *Controller) createStorkClusterRoleBinding(
 	clusterNamespace string,
-	ownerRef *metav1.OwnerReference,
 ) error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		c.client,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            storkClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: storkClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -389,20 +380,17 @@ func (c *Controller) createStorkClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 
 func (c *Controller) createStorkSchedClusterRoleBinding(
 	clusterNamespace string,
-	ownerRef *metav1.OwnerReference,
 ) error {
 	return k8sutil.CreateOrUpdateClusterRoleBinding(
 		c.client,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            storkSchedClusterRoleBindingName,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+				Name: storkSchedClusterRoleBindingName,
 			},
 			Subjects: []rbacv1.Subject{
 				{
@@ -417,7 +405,6 @@ func (c *Controller) createStorkSchedClusterRoleBinding(
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
-		ownerRef,
 	)
 }
 

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -140,8 +140,7 @@ func TestStorkInstallation(t *testing.T) {
 	err = testutil.Get(k8sClient, storkCR, storkClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedStorkCR.Name, storkCR.Name)
-	require.Len(t, storkCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, storkCR.OwnerReferences[0].Name)
+	require.Empty(t, storkCR.OwnerReferences)
 	require.ElementsMatch(t, expectedStorkCR.Rules, storkCR.Rules)
 
 	// Stork Scheduler ClusterRole
@@ -150,8 +149,7 @@ func TestStorkInstallation(t *testing.T) {
 	err = testutil.Get(k8sClient, schedCR, storkSchedClusterRoleName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSchedCR.Name, schedCR.Name)
-	require.Len(t, schedCR.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, schedCR.OwnerReferences[0].Name)
+	require.Empty(t, schedCR.OwnerReferences)
 	require.ElementsMatch(t, expectedSchedCR.Rules, schedCR.Rules)
 
 	// ClusterRoleBindings
@@ -166,8 +164,7 @@ func TestStorkInstallation(t *testing.T) {
 	err = testutil.Get(k8sClient, storkCRB, storkClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedStorkCRB.Name, storkCRB.Name)
-	require.Len(t, storkCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, storkCRB.OwnerReferences[0].Name)
+	require.Empty(t, storkCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedStorkCRB.Subjects, storkCRB.Subjects)
 	require.Equal(t, expectedStorkCRB.RoleRef, storkCRB.RoleRef)
 
@@ -177,8 +174,7 @@ func TestStorkInstallation(t *testing.T) {
 	err = testutil.Get(k8sClient, schedCRB, storkSchedClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSchedCRB.Name, schedCRB.Name)
-	require.Len(t, schedCRB.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, schedCRB.OwnerReferences[0].Name)
+	require.Empty(t, schedCRB.OwnerReferences)
 	require.ElementsMatch(t, expectedSchedCRB.Subjects, schedCRB.Subjects)
 	require.Equal(t, expectedSchedCRB.RoleRef, schedCRB.RoleRef)
 
@@ -241,8 +237,7 @@ func TestStorkInstallation(t *testing.T) {
 	err = testutil.Get(k8sClient, storkStorageClass, storkSnapshotStorageClassName, "")
 	require.NoError(t, err)
 	require.Equal(t, storkSnapshotStorageClassName, storkStorageClass.Name)
-	require.Len(t, storkStorageClass.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, storkStorageClass.OwnerReferences[0].Name)
+	require.Empty(t, storkStorageClass.OwnerReferences)
 	require.Equal(t, "stork-snapshot", storkStorageClass.Provisioner)
 }
 

--- a/pkg/util/k8s/k8s_test.go
+++ b/pkg/util/k8s/k8s_test.go
@@ -291,16 +291,6 @@ func TestDeleteClusterRole(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, clusterRole)
 
-	// Don't delete when there is no owner in the cluster role
-	// but trying to delete for specific owners
-	err = DeleteClusterRole(k8sClient, name, metav1.OwnerReference{UID: "foo"})
-	require.NoError(t, err)
-
-	clusterRole = &rbacv1.ClusterRole{}
-	err = testutil.Get(k8sClient, clusterRole, name, "")
-	require.NoError(t, err)
-	require.Equal(t, expected, clusterRole)
-
 	// Delete when there is no owner in the cluster role
 	err = DeleteClusterRole(k8sClient, name)
 	require.NoError(t, err)
@@ -310,7 +300,6 @@ func TestDeleteClusterRole(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 
 	// Don't delete when the cluster role is owned by an object
-	// and no owner reference passed in delete call
 	expected.OwnerReferences = []metav1.OwnerReference{{UID: "alpha"}, {UID: "beta"}, {UID: "gamma"}}
 	k8sClient.Create(context.TODO(), expected)
 
@@ -321,30 +310,6 @@ func TestDeleteClusterRole(t *testing.T) {
 	err = testutil.Get(k8sClient, clusterRole, name, "")
 	require.NoError(t, err)
 	require.Equal(t, expected, clusterRole)
-
-	// Don't delete when the cluster role is owned by objects
-	// more than what are passed on delete call
-	err = DeleteClusterRole(k8sClient, name, metav1.OwnerReference{UID: "beta"})
-	require.NoError(t, err)
-
-	clusterRole = &rbacv1.ClusterRole{}
-	err = testutil.Get(k8sClient, clusterRole, name, "")
-	require.NoError(t, err)
-	require.Len(t, clusterRole.OwnerReferences, 2)
-	require.Equal(t, types.UID("alpha"), clusterRole.OwnerReferences[0].UID)
-	require.Equal(t, types.UID("gamma"), clusterRole.OwnerReferences[1].UID)
-
-	// Delete when delete call passes all owners (or more) of the cluster role
-	err = DeleteClusterRole(k8sClient, name,
-		metav1.OwnerReference{UID: "theta"},
-		metav1.OwnerReference{UID: "gamma"},
-		metav1.OwnerReference{UID: "alpha"},
-	)
-	require.NoError(t, err)
-
-	clusterRole = &rbacv1.ClusterRole{}
-	err = testutil.Get(k8sClient, clusterRole, name, "")
-	require.True(t, errors.IsNotFound(err))
 }
 
 func TestDeleteClusterRoleBinding(t *testing.T) {
@@ -365,16 +330,6 @@ func TestDeleteClusterRoleBinding(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, crb)
 
-	// Don't delete when there is no owner in the cluster role binding
-	// but trying to delete for specific owners
-	err = DeleteClusterRoleBinding(k8sClient, name, metav1.OwnerReference{UID: "foo"})
-	require.NoError(t, err)
-
-	crb = &rbacv1.ClusterRoleBinding{}
-	err = testutil.Get(k8sClient, crb, name, "")
-	require.NoError(t, err)
-	require.Equal(t, expected, crb)
-
 	// Delete when there is no owner in the cluster role binding
 	err = DeleteClusterRoleBinding(k8sClient, name)
 	require.NoError(t, err)
@@ -384,7 +339,6 @@ func TestDeleteClusterRoleBinding(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 
 	// Don't delete when the cluster role binding is owned by an object
-	// and no owner reference passed in delete call
 	expected.OwnerReferences = []metav1.OwnerReference{{UID: "alpha"}, {UID: "beta"}, {UID: "gamma"}}
 	k8sClient.Create(context.TODO(), expected)
 
@@ -395,30 +349,6 @@ func TestDeleteClusterRoleBinding(t *testing.T) {
 	err = testutil.Get(k8sClient, crb, name, "")
 	require.NoError(t, err)
 	require.Equal(t, expected, crb)
-
-	// Don't delete when the cluster role binding is owned by objects
-	// more than what are passed on delete call
-	err = DeleteClusterRoleBinding(k8sClient, name, metav1.OwnerReference{UID: "beta"})
-	require.NoError(t, err)
-
-	crb = &rbacv1.ClusterRoleBinding{}
-	err = testutil.Get(k8sClient, crb, name, "")
-	require.NoError(t, err)
-	require.Len(t, crb.OwnerReferences, 2)
-	require.Equal(t, types.UID("alpha"), crb.OwnerReferences[0].UID)
-	require.Equal(t, types.UID("gamma"), crb.OwnerReferences[1].UID)
-
-	// Delete when delete call passes all owners (or more) of the cluster role binding
-	err = DeleteClusterRoleBinding(k8sClient, name,
-		metav1.OwnerReference{UID: "theta"},
-		metav1.OwnerReference{UID: "gamma"},
-		metav1.OwnerReference{UID: "alpha"},
-	)
-	require.NoError(t, err)
-
-	crb = &rbacv1.ClusterRoleBinding{}
-	err = testutil.Get(k8sClient, crb, name, "")
-	require.True(t, errors.IsNotFound(err))
 }
 
 func TestCreateStorageClass(t *testing.T) {
@@ -468,16 +398,6 @@ func TestDeleteStorageClass(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, storageClass)
 
-	// Don't delete when there is no owner in the storage class
-	// but trying to delete for specific owners
-	err = DeleteStorageClass(k8sClient, name, metav1.OwnerReference{UID: "foo"})
-	require.NoError(t, err)
-
-	storageClass = &storagev1.StorageClass{}
-	err = testutil.Get(k8sClient, storageClass, name, "")
-	require.NoError(t, err)
-	require.Equal(t, expected, storageClass)
-
 	// Delete when there is no owner in the storage class
 	err = DeleteStorageClass(k8sClient, name)
 	require.NoError(t, err)
@@ -487,7 +407,6 @@ func TestDeleteStorageClass(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 
 	// Don't delete when the storage class is owned by an object
-	// and no owner reference passed in delete call
 	expected.OwnerReferences = []metav1.OwnerReference{{UID: "alpha"}, {UID: "beta"}, {UID: "gamma"}}
 	k8sClient.Create(context.TODO(), expected)
 
@@ -498,30 +417,6 @@ func TestDeleteStorageClass(t *testing.T) {
 	err = testutil.Get(k8sClient, storageClass, name, "")
 	require.NoError(t, err)
 	require.Equal(t, expected, storageClass)
-
-	// Don't delete when the storage class is owned by objects
-	// more than what are passed on delete call
-	err = DeleteStorageClass(k8sClient, name, metav1.OwnerReference{UID: "beta"})
-	require.NoError(t, err)
-
-	storageClass = &storagev1.StorageClass{}
-	err = testutil.Get(k8sClient, storageClass, name, "")
-	require.NoError(t, err)
-	require.Len(t, storageClass.OwnerReferences, 2)
-	require.Equal(t, types.UID("alpha"), storageClass.OwnerReferences[0].UID)
-	require.Equal(t, types.UID("gamma"), storageClass.OwnerReferences[1].UID)
-
-	// Delete when delete call passes all owners (or more) of the storage class
-	err = DeleteStorageClass(k8sClient, name,
-		metav1.OwnerReference{UID: "theta"},
-		metav1.OwnerReference{UID: "gamma"},
-		metav1.OwnerReference{UID: "alpha"},
-	)
-	require.NoError(t, err)
-
-	storageClass = &storagev1.StorageClass{}
-	err = testutil.Get(k8sClient, storageClass, name, "")
-	require.True(t, errors.IsNotFound(err))
 }
 
 func TestDeleteConfigMap(t *testing.T) {
@@ -618,16 +513,6 @@ func TestDeleteCSIDriver(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, csiDriver)
 
-	// Don't delete when there is no owner in the CSI driver
-	// but trying to delete for specific owners
-	err = DeleteCSIDriver(k8sClient, name, metav1.OwnerReference{UID: "foo"})
-	require.NoError(t, err)
-
-	csiDriver = &storagev1beta1.CSIDriver{}
-	err = testutil.Get(k8sClient, csiDriver, name, "")
-	require.NoError(t, err)
-	require.Equal(t, expected, csiDriver)
-
 	// Delete when there is no owner in the CSI driver
 	err = DeleteCSIDriver(k8sClient, name)
 	require.NoError(t, err)
@@ -637,7 +522,6 @@ func TestDeleteCSIDriver(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 
 	// Don't delete when the CSI driver is owned by an object
-	// and no owner reference passed in delete call
 	expected.OwnerReferences = []metav1.OwnerReference{{UID: "alpha"}, {UID: "beta"}, {UID: "gamma"}}
 	k8sClient.Create(context.TODO(), expected)
 
@@ -648,30 +532,6 @@ func TestDeleteCSIDriver(t *testing.T) {
 	err = testutil.Get(k8sClient, csiDriver, name, "")
 	require.NoError(t, err)
 	require.Equal(t, expected, csiDriver)
-
-	// Don't delete when the CSI driver is owned by objects
-	// more than what are passed on delete call
-	err = DeleteCSIDriver(k8sClient, name, metav1.OwnerReference{UID: "beta"})
-	require.NoError(t, err)
-
-	csiDriver = &storagev1beta1.CSIDriver{}
-	err = testutil.Get(k8sClient, csiDriver, name, "")
-	require.NoError(t, err)
-	require.Len(t, csiDriver.OwnerReferences, 2)
-	require.Equal(t, types.UID("alpha"), csiDriver.OwnerReferences[0].UID)
-	require.Equal(t, types.UID("gamma"), csiDriver.OwnerReferences[1].UID)
-
-	// Delete when delete call passes all owners (or more) of the CSI driver
-	err = DeleteCSIDriver(k8sClient, name,
-		metav1.OwnerReference{UID: "theta"},
-		metav1.OwnerReference{UID: "gamma"},
-		metav1.OwnerReference{UID: "alpha"},
-	)
-	require.NoError(t, err)
-
-	csiDriver = &storagev1beta1.CSIDriver{}
-	err = testutil.Get(k8sClient, csiDriver, name, "")
-	require.True(t, errors.IsNotFound(err))
 }
 
 func TestDeleteService(t *testing.T) {
@@ -1571,7 +1431,7 @@ func TestCSIDriverChangeSpec(t *testing.T) {
 		},
 	}
 
-	err := CreateOrUpdateCSIDriver(k8sClient, expectedDriver, nil)
+	err := CreateOrUpdateCSIDriver(k8sClient, expectedDriver)
 	require.NoError(t, err)
 
 	actualDriver := &storagev1beta1.CSIDriver{}
@@ -1582,54 +1442,38 @@ func TestCSIDriverChangeSpec(t *testing.T) {
 	// Change spec
 	attachRequired = false
 
-	err = CreateOrUpdateCSIDriver(k8sClient, expectedDriver, nil)
+	err = CreateOrUpdateCSIDriver(k8sClient, expectedDriver)
 	require.NoError(t, err)
 
 	actualDriver = &storagev1beta1.CSIDriver{}
 	err = testutil.Get(k8sClient, actualDriver, "test", "")
 	require.NoError(t, err)
 	require.False(t, *actualDriver.Spec.AttachRequired)
-}
 
-func TestCSIDriverWithOwnerReferences(t *testing.T) {
-	k8sClient := fake.NewFakeClient()
+	// Do not add owner reference if the input object has it
+	driver := actualDriver.DeepCopy()
+	driver.OwnerReferences = []metav1.OwnerReference{{UID: "uid"}}
 
-	firstOwner := metav1.OwnerReference{UID: "first-owner"}
-	expectedDriver := &storagev1beta1.CSIDriver{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "test",
-			OwnerReferences: []metav1.OwnerReference{firstOwner},
-		},
-	}
-
-	err := CreateOrUpdateCSIDriver(k8sClient, expectedDriver, nil)
-	require.NoError(t, err)
-
-	actualDriver := &storagev1beta1.CSIDriver{}
-	err = testutil.Get(k8sClient, actualDriver, "test", "")
-	require.NoError(t, err)
-	require.ElementsMatch(t, []metav1.OwnerReference{firstOwner}, actualDriver.OwnerReferences)
-
-	// Update with the same owner. Nothing should change as owner hasn't changed.
-	err = CreateOrUpdateCSIDriver(k8sClient, expectedDriver, &firstOwner)
+	err = CreateOrUpdateCSIDriver(k8sClient, driver)
 	require.NoError(t, err)
 
 	actualDriver = &storagev1beta1.CSIDriver{}
 	err = testutil.Get(k8sClient, actualDriver, "test", "")
 	require.NoError(t, err)
-	require.ElementsMatch(t, []metav1.OwnerReference{firstOwner}, actualDriver.OwnerReferences)
+	require.Empty(t, actualDriver.OwnerReferences)
 
-	// Update with a new owner.
-	secondOwner := metav1.OwnerReference{UID: "second-owner"}
-	expectedDriver.OwnerReferences = []metav1.OwnerReference{secondOwner}
+	// Remove owner reference if already present
+	driver = actualDriver.DeepCopy()
+	driver.OwnerReferences = []metav1.OwnerReference{{UID: "uid"}}
+	k8sClient.Update(context.TODO(), driver)
 
-	err = CreateOrUpdateCSIDriver(k8sClient, expectedDriver, &secondOwner)
+	err = CreateOrUpdateCSIDriver(k8sClient, expectedDriver)
 	require.NoError(t, err)
 
 	actualDriver = &storagev1beta1.CSIDriver{}
 	err = testutil.Get(k8sClient, actualDriver, "test", "")
 	require.NoError(t, err)
-	require.ElementsMatch(t, []metav1.OwnerReference{secondOwner, firstOwner}, actualDriver.OwnerReferences)
+	require.Empty(t, actualDriver.OwnerReferences)
 }
 
 func TestServicePortAddition(t *testing.T) {


### PR DESCRIPTION
- As per k8s docs - https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/ cross namespace ownership is disallowed. So removing all object ownership on cluster-scoped and other namespace objects.
- Removing ownership on already installed objects 
- Delete all object during cluster deletion. Mostly need to explicitly delete cross namespace objects only because they don't have ownership, but it is easier to deleted all objects once.
- Delete px storageclasses only when portworx is uninstalled