### PR TITLE
Add option to run stork in host network

### DIFF
--- a/deploy/crds/core_v1alpha1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1alpha1_storagecluster_crd.yaml
@@ -397,6 +397,9 @@ spec:
                 image:
                   type: string
                   description: Docker image of the STORK container.
+                hostNetwork:
+                  type: boolean
+                  description: Flag indicating if Stork pods should run in host network.
                 args:
                   type: object
                   description: >-

--- a/pkg/apis/core/v1alpha1/storagecluster.go
+++ b/pkg/apis/core/v1alpha1/storagecluster.go
@@ -349,6 +349,8 @@ type StorkSpec struct {
 	Args map[string]string `json:"args,omitempty"`
 	// Env is a list of environment variables used by stork
 	Env []v1.EnvVar `json:"env,omitempty"`
+	// HostNetwork if set, will use host's network for stork pods
+	HostNetwork *bool `json:"hostNetwork,omitempty"`
 }
 
 // AutopilotSpec contains details of an autopilot component

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -1018,6 +1018,11 @@ func (in *StorkSpec) DeepCopyInto(out *StorkSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.HostNetwork != nil {
+		in, out := &in.HostNetwork, &out.HostNetwork
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -520,6 +520,7 @@ func (c *Controller) createStorkDeployment(
 		!reflect.DeepEqual(existingCommand, command) ||
 		!reflect.DeepEqual(existingEnvs, envVars) ||
 		existingCPUQuantity.Cmp(targetCPUQuantity) != 0 ||
+		!reflect.DeepEqual(cluster.Spec.Stork.HostNetwork, &existingDeployment.Spec.Template.Spec.HostNetwork) ||
 		util.HasPullSecretChanged(cluster, existingDeployment.Spec.Template.Spec.ImagePullSecrets) ||
 		util.HasNodeAffinityChanged(cluster, existingDeployment.Spec.Template.Spec.Affinity) ||
 		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations)
@@ -633,6 +634,10 @@ func (c *Controller) getStorkDeploymentSpec(
 				Name: *cluster.Spec.ImagePullSecret,
 			},
 		)
+	}
+
+	if cluster.Spec.Stork.HostNetwork != nil {
+		deployment.Spec.Template.Spec.HostNetwork = *cluster.Spec.Stork.HostNetwork
 	}
 
 	if cluster.Spec.Placement != nil {

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -1589,6 +1589,83 @@ func TestStorkInstallWithImagePullPolicy(t *testing.T) {
 	)
 }
 
+func TestStorkInstallWithHostNetwork(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	hostNetwork := true
+	cluster := &corev1alpha1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1alpha1.StorageClusterSpec{
+			ImagePullPolicy: v1.PullIfNotPresent,
+			Stork: &corev1alpha1.StorkSpec{
+				Enabled:     true,
+				Image:       "osd/stork:test",
+				HostNetwork: &hostNetwork,
+			},
+		},
+	}
+
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient := testutil.FakeK8sClient(cluster)
+	controller := Controller{
+		client:            k8sClient,
+		Driver:            driver,
+		kubernetesVersion: k8sVersion,
+	}
+
+	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
+	driver.EXPECT().GetStorkEnvList(cluster).
+		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+		AnyTimes()
+
+	// TestCase: Stork host network is set to true
+	err := controller.syncStork(cluster)
+	require.NoError(t, err)
+
+	storkDeployment := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, storkDeployment, storkDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.True(t, storkDeployment.Spec.Template.Spec.HostNetwork)
+
+	// TestCase: Stork host network is set to false
+	hostNetwork = false
+	cluster.Spec.Stork.HostNetwork = &hostNetwork
+
+	err = controller.syncStork(cluster)
+	require.NoError(t, err)
+
+	storkDeployment = &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, storkDeployment, storkDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.False(t, storkDeployment.Spec.Template.Spec.HostNetwork)
+
+	// TestCase: Stork host network is nil
+	hostNetwork = true
+	cluster.Spec.Stork.HostNetwork = &hostNetwork
+	err = controller.syncStork(cluster)
+	require.NoError(t, err)
+
+	storkDeployment = &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, storkDeployment, storkDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.True(t, storkDeployment.Spec.Template.Spec.HostNetwork)
+
+	cluster.Spec.Stork.HostNetwork = nil
+	err = controller.syncStork(cluster)
+	require.NoError(t, err)
+
+	storkDeployment = &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, storkDeployment, storkDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.False(t, storkDeployment.Spec.Template.Spec.HostNetwork)
+}
+
 func TestDisableStork(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()


### PR DESCRIPTION
Adding a flag under stork section in the StorageCluster spec to toggle host network for stork pods. 
From what I understand, this is needed for px-backup to work in AWS.
```
spec:
  stork:
    enabled: true
    hostNetwork: true
```

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>