### PR TITLE
Correctly delete security secrets

### DIFF
--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1361,7 +1361,7 @@ func CreateOrUpdateSecret(
 	modified := !reflect.DeepEqual(secret.Data, existingSecret.Data)
 
 	for _, o := range existingSecret.OwnerReferences {
-		if o.UID != ownerRef.UID {
+		if ownerRef != nil && o.UID != ownerRef.UID {
 			secret.OwnerReferences = append(secret.OwnerReferences, o)
 		}
 	}


### PR DESCRIPTION
- Add ownership on token secrets so they get deleted on
  StorageCluster deletion
- Do not add ownership on secret keys to avoid deletion
  on StorageCluster deletion

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>