### PR TITLE
Add an option to deploy essentials only cluster

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -3,6 +3,7 @@ package portworx
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -711,6 +712,31 @@ func (t *template) getArguments() []string {
 			args = append(args, parts...)
 		} else {
 			logrus.Warnf("error parsing misc args: %v", err)
+		}
+	}
+
+	if pxutil.EssentialsEnabled() {
+		for args[len(args)-1] == "--oem" {
+			args = args[:len(args)-1]
+		}
+		essePresent := false
+		for i, arg := range args {
+			if arg == "--oem" {
+				args[i+1] = "esse"
+				essePresent = true
+				break
+			}
+		}
+		if !essePresent {
+			args = append(args, "--oem", "esse")
+		}
+
+		marketplaceName := strings.TrimSpace(os.Getenv(pxutil.EnvKeyMarketplaceName))
+		if marketplaceName != "" {
+			pxVer2_5_5, _ := version.NewVersion("2.5.5")
+			if t.pxVersion.GreaterThanOrEqual(pxVer2_5_5) {
+				args = append(args, "-marketplace_name", marketplaceName)
+			}
 		}
 	}
 

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -1391,6 +1391,10 @@ func TestPodSpecWithInvalidMiscArgs(t *testing.T) {
 }
 
 func TestPodSpecWithEssentials(t *testing.T) {
+	defer func() {
+		os.Unsetenv(pxutil.EnvKeyPortworxEssentials)
+		os.Unsetenv(pxutil.EnvKeyMarketplaceName)
+	}()
 	fakeClient := fakek8sclient.NewSimpleClientset()
 	coreops.SetInstance(coreops.New(fakeClient))
 	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -46,6 +46,12 @@ const (
 	PortworxSDKPortName = "px-sdk"
 	// PortworxKVDBPortName name of the Portworx internal KVDB port
 	PortworxKVDBPortName = "px-kvdb"
+	// EssentialsSecretName name of the Portworx Essentials secret
+	EssentialsSecretName = "px-essential"
+	// EssentialsUserIDKey is the secret key for Essentials user ID
+	EssentialsUserIDKey = "px-essen-user-id"
+	// EssentialsOSBEndpointKey is the secret key for Essentials OSB endpoint
+	EssentialsOSBEndpointKey = "px-osb-endpoint"
 
 	// AnnotationIsPKS annotation indicating whether it is a PKS cluster
 	AnnotationIsPKS = pxAnnotationPrefix + "/is-pks"

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -105,6 +105,10 @@ const (
 	// EnvKeyPortworxAuthStorkKey is an environment variable for the auth secret
 	// that stork and the operator use to communicate with portworx
 	EnvKeyPortworxAuthStorkKey = "PORTWORX_AUTH_STORK_KEY"
+	// EnvKeyPortworxEssentials env var to deploy Portworx Essentials cluster
+	EnvKeyPortworxEssentials = "PORTWORX_ESSENTIALS"
+	// EnvKeyMarketplaceName env var for the name of the source marketplace
+	EnvKeyMarketplaceName = "MARKETPLACE_NAME"
 
 	// SecurityPXSystemSecretsSecretName is the secret name for PX security system secrets
 	SecurityPXSystemSecretsSecretName = "px-system-secrets"
@@ -536,4 +540,11 @@ func EncodeBase64(src []byte) []byte {
 	base64.StdEncoding.Encode(encoded, src)
 
 	return encoded
+}
+
+// EssentialsEnabled returns true if the env var has an override
+// to deploy an PX Essentials cluster
+func EssentialsEnabled() bool {
+	enabled, err := strconv.ParseBool(os.Getenv(EnvKeyPortworxEssentials))
+	return err == nil && enabled
 }

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -478,8 +478,7 @@ func (c *Controller) manage(
 ) error {
 	// Run the pre install hook for the driver to ensure we are ready to create storage pods
 	if err := c.Driver.PreInstall(cluster); err != nil {
-		return fmt.Errorf("failed to run preinstall hooks for %v/%v: %v",
-			cluster.Namespace, cluster.Name, err)
+		return fmt.Errorf("pre-install hook failed: %v", err)
 	}
 
 	// Find out the pods which are created for the nodes by StorageCluster


### PR DESCRIPTION
- Operator takes `PORTWORX_ESSENTIALS` env var which tells it to only deploy an essentials cluster
- Pass `-marketplace_name` argument to Portworx (>= 2.5.5) which operator gets from `MARKETPLACE_NAME` env var
- Raise a warning event on StorageCluster object if `px-essential` secret is not present. Do not deploy portworx pods until the secret is created.

Here are some sample error events wrt the secret - 
```
Events:
  Type     Reason      Age                   From                       Message
  ----     ------      ----                  ----                       -------
  Warning  FailedSync  60s (x2 over 61s)     storagecluster-controller  pre-install hook failed: secret kube-system/px-essential does not have Essentials Entitlement ID (px-essen-user-id)
  Warning  FailedSync  30s (x20 over 2m43s)  storagecluster-controller  pre-install hook failed: secret kube-system/px-essential should be present to deploy a Portworx Essentials cluster
  Warning  FailedSync  0s (x2 over 1s)       storagecluster-controller  pre-install hook failed: secret kube-system/px-essential does not have Portworx OSB endpoint (px-osb-endpoint)
```