### PR TITLE
Use cluster's namespace by default for leader election

### DIFF
--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -30,7 +30,6 @@ const (
 	flagLeaderElectLockNamespace = "leader-elect-lock-namespace"
 	flagMetricsPort              = "metrics-port"
 	defaultLockObjectName        = "openstorage-operator"
-	defaultLockObjectNamespace   = "kube-system"
 	defaultResyncPeriod          = 30 * time.Second
 	defaultMetricsPort           = 8999
 	metricsPortName              = "metrics"
@@ -64,7 +63,6 @@ func main() {
 		cli.StringFlag{
 			Name:  flagLeaderElectLockNamespace,
 			Usage: "Namespace for the leader election lock object",
-			Value: defaultLockObjectNamespace,
 		},
 		cli.IntFlag{
 			Name:  flagMetricsPort,

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -482,6 +482,7 @@ func (c *Controller) createStorkDeployment(
 		"verbose":                 "true",
 		"leader-elect":            "true",
 		"health-monitor-interval": "120",
+		"lock-object-namespace":   cluster.Namespace,
 	}
 	for k, v := range cluster.Spec.Stork.Args {
 		key := strings.TrimLeft(k, "-")

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -434,7 +434,7 @@ func TestStorkArgumentsChange(t *testing.T) {
 	storkDeployment := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, storkDeployment, storkDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, storkDeployment.Spec.Template.Spec.Containers[0].Command, 6)
+	require.Len(t, storkDeployment.Spec.Template.Spec.Containers[0].Command, 7)
 	require.Contains(t,
 		storkDeployment.Spec.Template.Spec.Containers[0].Command,
 		"--test-key=test-value",
@@ -452,7 +452,7 @@ func TestStorkArgumentsChange(t *testing.T) {
 
 	err = testutil.Get(k8sClient, storkDeployment, storkDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, storkDeployment.Spec.Template.Spec.Containers[0].Command, 6)
+	require.Len(t, storkDeployment.Spec.Template.Spec.Containers[0].Command, 7)
 	require.Contains(t,
 		storkDeployment.Spec.Template.Spec.Containers[0].Command,
 		"--verbose=false",

--- a/pkg/controller/storagecluster/testspec/storkDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkDeployment.yaml
@@ -32,6 +32,7 @@ spec:
         - --driver=pxd
         - --health-monitor-interval=120
         - --leader-elect=true
+        - --lock-object-namespace=kube-test
         - --verbose=true
         imagePullPolicy: Always
         image: osd/stork:test


### PR DESCRIPTION
- Even for stork use the cluster's namespace for leader
  election, unless the user explicitly overrides it

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>