### PR TITLE
Multiple minor fixes

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -5082,6 +5082,21 @@ func TestDeleteClusterWithUninstallWhenNodeWiperCreated(t *testing.T) {
 	err = k8sClient.List(context.TODO(), dsList)
 	require.NoError(t, err)
 	require.Empty(t, dsList.Items)
+
+	// TestCase: Wiper daemonset should not be created again if already
+	// completed and deleted
+	cluster.Status.Phase = "DeleteCompleted"
+	condition, err = driver.DeleteStorage(cluster)
+	require.NoError(t, err)
+
+	require.Equal(t, corev1alpha1.ClusterConditionTypeDelete, condition.Type)
+	require.Equal(t, corev1alpha1.ClusterOperationCompleted, condition.Status)
+	require.Contains(t, condition.Reason, storageClusterUninstallMsg)
+
+	dsList = &appsv1.DaemonSetList{}
+	err = k8sClient.List(context.TODO(), dsList)
+	require.NoError(t, err)
+	require.Empty(t, dsList.Items)
 }
 
 func TestDeleteClusterWithUninstallWipeStrategyWhenNodeWiperCreated(t *testing.T) {
@@ -5192,6 +5207,21 @@ func TestDeleteClusterWithUninstallWipeStrategyWhenNodeWiperCreated(t *testing.T
 
 	// Node wiper daemon set should be removed
 	dsList := &appsv1.DaemonSetList{}
+	err = k8sClient.List(context.TODO(), dsList)
+	require.NoError(t, err)
+	require.Empty(t, dsList.Items)
+
+	// TestCase: Wiper daemonset should not be created again if already
+	// completed and deleted
+	cluster.Status.Phase = "DeleteCompleted"
+	condition, err = driver.DeleteStorage(cluster)
+	require.NoError(t, err)
+
+	require.Equal(t, corev1alpha1.ClusterConditionTypeDelete, condition.Type)
+	require.Equal(t, corev1alpha1.ClusterOperationCompleted, condition.Status)
+	require.Contains(t, condition.Reason, storageClusterUninstallAndWipeMsg)
+
+	dsList = &appsv1.DaemonSetList{}
 	err = k8sClient.List(context.TODO(), dsList)
 	require.NoError(t, err)
 	require.Empty(t, dsList.Items)

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2159,7 +2159,7 @@ func TestUpdateClusterStatusServiceGrpcServerError(t *testing.T) {
 			Namespace: "kube-test",
 		},
 		Status: corev1alpha1.StorageClusterStatus{
-			Phase: "Initializing",
+			Phase: "Maintenance",
 		},
 	}
 

--- a/drivers/storage/portworx/status.go
+++ b/drivers/storage/portworx/status.go
@@ -40,6 +40,13 @@ func (p *portworx) UpdateStorageClusterStatus(
 	p.sdkConn, err = pxutil.GetPortworxConn(p.sdkConn, p.k8sClient, cluster.Namespace)
 	if err != nil {
 		p.updateRemainingStorageNodesWithoutError(cluster, nil)
+		if cluster.Status.Phase == string(corev1alpha1.ClusterInit) &&
+			strings.HasPrefix(err.Error(), pxutil.ErrMsgGrpcConnection) {
+			// Don't return grpc connection error during initialization,
+			// as SDK server won't be up anyway
+			logrus.Warn(err)
+			return nil
+		}
 		return err
 	}
 

--- a/drivers/storage/portworx/status.go
+++ b/drivers/storage/portworx/status.go
@@ -360,8 +360,12 @@ func getStorageNodePhase(status *corev1alpha1.NodeStatus) string {
 	var latestCondition *corev1alpha1.NodeCondition
 
 	for _, condition := range status.Conditions {
+		// Find the latest condition. If it is InitCondition, and has
+		// the same timestamp as the latest one then don't make it latest
 		if latestTime.Before(&condition.LastTransitionTime) ||
-			latestTime.Equal(&condition.LastTransitionTime) {
+			latestTime.IsZero() ||
+			(latestTime.Equal(&condition.LastTransitionTime) &&
+				condition.Type != corev1alpha1.NodeInitCondition) {
 			latestCondition = condition.DeepCopy()
 			latestTime = condition.LastTransitionTime
 		}

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -137,6 +137,9 @@ const (
 	// SecurityPortworxStorkIssuer is the issuer for stork to communicate with the PX SDK pre-2.6
 	SecurityPortworxStorkIssuer = "stork.openstorage.io"
 
+	// ErrMsgGrpcConnection error message if failed to connect to GRPC server
+	ErrMsgGrpcConnection = "error connecting to GRPC server"
+
 	pxAnnotationPrefix = "portworx.io"
 	labelKeyName       = "name"
 	defaultSDKPort     = 9020
@@ -416,7 +419,7 @@ func GetGrpcConn(endpoint string) (*grpc.ClientConn, error) {
 	}
 	sdkConn, err := grpcserver.Connect(endpoint, dialOptions)
 	if err != nil {
-		return nil, fmt.Errorf("error connecting to GRPC server [%s]: %v", endpoint, err)
+		return nil, fmt.Errorf("%s [%s]: %v", ErrMsgGrpcConnection, endpoint, err)
 	}
 	return sdkConn, nil
 }


### PR DESCRIPTION
- If NodeInit condition and NodeState condition have the same  timestamp, then we should use NodeState condition as that  is the latest response from SDK.
  Taking latest NodeInit condition causes it to be stuck in  Initializing/Failed state even though node may have a different  status.
- Do not raise warning event on GRPC connection during cluster init. 
  As the cluster is initializing the SDK server won't be up. There  is no need to panic the user by raising GRPC connection events.  Once the cluster is up, if the connection is lost, then we should  raise such an event.
- Don't recreate node-wiper if already ran and finished 