### PR TITLE
Use uint64 for size instead of resource.Quantity

### DIFF
--- a/deploy/crds/core_v1alpha1_storagenode_crd.yaml
+++ b/deploy/crds/core_v1alpha1_storagenode_crd.yaml
@@ -94,6 +94,7 @@ spec:
                 information about the state of the node.
             network:
               type: object
+              description: Contains network information used by the storage node
               properties:
                 dataIP:
                   type: string
@@ -103,6 +104,7 @@ spec:
                   description: IP address used by the storage driver for management traffic.
             storage:
               type: object
+              description: Contains details of the status of storage for the node
               properties:
                 totalSize:
                   type: string

--- a/deploy/olm-catalog/portworx/1.4.0/core_v1alpha1_storagenode_crd.yaml
+++ b/deploy/olm-catalog/portworx/1.4.0/core_v1alpha1_storagenode_crd.yaml
@@ -94,6 +94,7 @@ spec:
                 information about the state of the node.
             network:
               type: object
+              description: Contains network information used by the storage node
               properties:
                 dataIP:
                   type: string
@@ -103,6 +104,7 @@ spec:
                   description: IP address used by the storage driver for management traffic.
             storage:
               type: object
+              description: Contains details of the status of storage for the node
               properties:
                 totalSize:
                   type: string


### PR DESCRIPTION
- resource.Quantity does not return true with DeepEqual for the same quantity.
  This was causing the storage node to get updated even if there is no change.

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>