### PR TITLE
Add STORK-NAMESPACE env variable to stork

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -89,7 +89,7 @@ func TestGetStorkDriverName(t *testing.T) {
 	require.Equal(t, storkDriverName, actualStorkDriverName)
 }
 
-func TestGetStorkEnvList(t *testing.T) {
+func TestGetStorkEnvMap(t *testing.T) {
 	driver := portworx{}
 	cluster := &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -110,44 +110,43 @@ func TestGetStorkEnvList(t *testing.T) {
 	cluster.Status.DesiredImages = &corev1.ComponentImages{
 		Stork: "stork/image:2.5.0",
 	}
-	envVars := driver.GetStorkEnvList(cluster)
+	envVars := driver.GetStorkEnvMap(cluster)
 	require.Len(t, envVars, 4)
-	require.Equal(t, pxutil.EnvKeyPortworxNamespace, envVars[0].Name)
-	require.Equal(t, cluster.Namespace, envVars[0].Value)
-	require.Equal(t, pxutil.EnvKeyPortworxServiceName, envVars[1].Name)
-	require.Equal(t, component.PxAPIServiceName, envVars[1].Value)
-	require.Equal(t, pxutil.SecurityPXSystemSecretsSecretName, envVars[2].ValueFrom.SecretKeyRef.Name)
-	require.Equal(t, pxutil.SecurityAppsSecretKey, envVars[2].ValueFrom.SecretKeyRef.Key)
-	require.Equal(t, pxutil.EnvKeyStorkPXJwtIssuer, envVars[3].Name)
-	require.Equal(t, "apps.portworx.io", envVars[3].Value)
+	require.Equal(t, cluster.Namespace, envVars[pxutil.EnvKeyPortworxNamespace].Value)
+	require.Equal(t, component.PxAPIServiceName, envVars[pxutil.EnvKeyPortworxServiceName].Value)
+	require.Equal(t, pxutil.SecurityPXSystemSecretsSecretName,
+		envVars[pxutil.EnvKeyStorkPXSharedSecret].ValueFrom.SecretKeyRef.Name)
+	require.Equal(t, pxutil.SecurityAppsSecretKey,
+		envVars[pxutil.EnvKeyStorkPXSharedSecret].ValueFrom.SecretKeyRef.Key)
+	require.Equal(t, "apps.portworx.io", envVars[pxutil.EnvKeyStorkPXJwtIssuer].Value)
 
 	cluster.Spec.Image = "portworx/image:2.6.0"
 	cluster.Spec.Stork = &corev1.StorkSpec{
 		Enabled: true,
 		Image:   "stork/image:2.5.0",
 	}
-	envVars = driver.GetStorkEnvList(cluster)
+	envVars = driver.GetStorkEnvMap(cluster)
 	require.Len(t, envVars, 4)
-	require.Equal(t, pxutil.EnvKeyPortworxNamespace, envVars[0].Name)
-	require.Equal(t, cluster.Namespace, envVars[0].Value)
-	require.Equal(t, pxutil.EnvKeyPortworxServiceName, envVars[1].Name)
-	require.Equal(t, component.PxAPIServiceName, envVars[1].Value)
-	require.Equal(t, pxutil.SecurityPXSystemSecretsSecretName, envVars[2].ValueFrom.SecretKeyRef.Name)
-	require.Equal(t, pxutil.SecurityAppsSecretKey, envVars[2].ValueFrom.SecretKeyRef.Key)
-	require.Equal(t, pxutil.EnvKeyStorkPXJwtIssuer, envVars[3].Name)
-	require.Equal(t, "apps.portworx.io", envVars[3].Value)
+	require.Len(t, envVars, 4)
+	require.Equal(t, cluster.Namespace, envVars[pxutil.EnvKeyPortworxNamespace].Value)
+	require.Equal(t, component.PxAPIServiceName, envVars[pxutil.EnvKeyPortworxServiceName].Value)
+	require.Equal(t, pxutil.SecurityPXSystemSecretsSecretName,
+		envVars[pxutil.EnvKeyStorkPXSharedSecret].ValueFrom.SecretKeyRef.Name)
+	require.Equal(t, pxutil.SecurityAppsSecretKey,
+		envVars[pxutil.EnvKeyStorkPXSharedSecret].ValueFrom.SecretKeyRef.Key)
+	require.Equal(t, "apps.portworx.io", envVars[pxutil.EnvKeyStorkPXJwtIssuer].Value)
 
 	cluster.Spec.Image = "portworx/image:2.5.0"
-	envVars = driver.GetStorkEnvList(cluster)
+	envVars = driver.GetStorkEnvMap(cluster)
 	require.Len(t, envVars, 4)
-	require.Equal(t, pxutil.EnvKeyStorkPXSharedSecret, envVars[2].Name)
-	require.Equal(t, pxutil.SecurityPXSystemSecretsSecretName, envVars[2].ValueFrom.SecretKeyRef.Name)
-	require.Equal(t, pxutil.SecurityAppsSecretKey, envVars[2].ValueFrom.SecretKeyRef.Key)
-	require.Equal(t, pxutil.EnvKeyStorkPXJwtIssuer, envVars[3].Name)
-	require.Equal(t, "stork.openstorage.io", envVars[3].Value)
+	require.Equal(t, pxutil.SecurityPXSystemSecretsSecretName,
+		envVars[pxutil.EnvKeyStorkPXSharedSecret].ValueFrom.SecretKeyRef.Name)
+	require.Equal(t, pxutil.SecurityAppsSecretKey,
+		envVars[pxutil.EnvKeyStorkPXSharedSecret].ValueFrom.SecretKeyRef.Key)
+	require.Equal(t, "stork.openstorage.io", envVars[pxutil.EnvKeyStorkPXJwtIssuer].Value)
 
 	cluster.Spec.Security.Enabled = false
-	envVars = driver.GetStorkEnvList(cluster)
+	envVars = driver.GetStorkEnvMap(cluster)
 	require.Len(t, envVars, 2)
 }
 

--- a/drivers/storage/storage.go
+++ b/drivers/storage/storage.go
@@ -41,8 +41,8 @@ type Driver interface {
 type StorkInterface interface {
 	// GetStorkDriverName returns the string name of the driver in Stork
 	GetStorkDriverName() (string, error)
-	// GetStorkEnvList returns a list of env vars that need to be passed to Stork
-	GetStorkEnvList(cluster *corev1.StorageCluster) []v1.EnvVar
+	// GetStorkEnvMap returns a map of env vars that need to be passed to Stork
+	GetStorkEnvMap(cluster *corev1.StorageCluster) map[string]*v1.EnvVar
 }
 
 // ClusterPluginInterface interface to manage storage cluster

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -2391,13 +2391,9 @@ func TestDeleteStorageClusterShouldDeleteStork(t *testing.T) {
 	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 	driver := testutil.MockDriver(mockCtrl)
 	k8sClient := testutil.FakeK8sClient(cluster)
-	// podControl := &k8scontroller.FakePodControl{}
-	// recorder := record.NewFakeRecorder(0)
 	controller := Controller{
-		client: k8sClient,
-		Driver: driver,
-		// podControl:        podControl,
-		// recorder:          recorder,
+		client:            k8sClient,
+		Driver:            driver,
 		kubernetesVersion: k8sVersion,
 	}
 
@@ -2405,7 +2401,7 @@ func TestDeleteStorageClusterShouldDeleteStork(t *testing.T) {
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return("pxd").AnyTimes()
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().GetStorkEnvMap(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -70,9 +70,15 @@ func TestStorkInstallation(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -317,9 +323,15 @@ func TestStorkWithDesiredImage(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -368,9 +380,15 @@ func TestStorkImageChange(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -422,9 +440,15 @@ func TestStorkArgumentsChange(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -493,8 +517,13 @@ func TestStorkEnvVarsChange(t *testing.T) {
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driverEnvs := []v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}
-	driver.EXPECT().GetStorkEnvList(cluster).
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
+	driver.EXPECT().GetStorkEnvMap(cluster).
 		Return(driverEnvs).
 		AnyTimes()
 
@@ -502,7 +531,20 @@ func TestStorkEnvVarsChange(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check envs are passed to deployment
-	expectedEnvs := append(driverEnvs, cluster.Spec.Stork.Env...)
+	expectedEnvs := []v1.EnvVar{
+		{
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+		{
+			Name:  "STORK-NAMESPACE",
+			Value: cluster.Namespace,
+		},
+		{
+			Name:  "FOO",
+			Value: "foo",
+		},
+	}
 	storkDeployment := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, storkDeployment, storkDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
@@ -514,7 +556,7 @@ func TestStorkEnvVarsChange(t *testing.T) {
 	err = controller.syncStork(cluster)
 	require.NoError(t, err)
 
-	expectedEnvs[1].Value = "bar"
+	expectedEnvs[2].Value = "bar"
 	err = testutil.Get(k8sClient, storkDeployment, storkDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.ElementsMatch(t, storkDeployment.Spec.Template.Spec.Containers[0].Env, expectedEnvs)
@@ -562,9 +604,15 @@ func TestStorkCustomRegistryChange(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	// Case: Custom registry should be applied to the images
@@ -687,9 +735,15 @@ func TestStorkCustomRepoRegistryChange(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	// Case: Custom repo-registry should be applied to the images
@@ -812,8 +866,13 @@ func TestStorkImagePullSecretChange(t *testing.T) {
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driverEnvs := []v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}
-	driver.EXPECT().GetStorkEnvList(cluster).
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
+	driver.EXPECT().GetStorkEnvMap(cluster).
 		Return(driverEnvs).
 		AnyTimes()
 
@@ -946,8 +1005,13 @@ func TestStorkTolerationsChange(t *testing.T) {
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driverEnvs := []v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}
-	driver.EXPECT().GetStorkEnvList(cluster).
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
+	driver.EXPECT().GetStorkEnvMap(cluster).
 		Return(driverEnvs).
 		AnyTimes()
 
@@ -1121,8 +1185,13 @@ func TestStorkNodeAffinityChange(t *testing.T) {
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driverEnvs := []v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}
-	driver.EXPECT().GetStorkEnvList(cluster).
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
+	driver.EXPECT().GetStorkEnvMap(cluster).
 		Return(driverEnvs).
 		AnyTimes()
 
@@ -1240,9 +1309,15 @@ func TestStorkCPUChange(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -1297,9 +1372,15 @@ func TestStorkSchedulerCPUChange(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -1402,9 +1483,15 @@ func TestStorkSchedulerInvalidCPU(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	// Should not return error, instead raise an event
@@ -1445,9 +1532,15 @@ func TestStorkSchedulerRollbackImageChange(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -1507,9 +1600,15 @@ func TestStorkSchedulerRollbackCommandChange(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -1564,9 +1663,15 @@ func TestStorkInstallWithImagePullPolicy(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -1619,9 +1724,15 @@ func TestStorkInstallWithHostNetwork(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	// TestCase: Stork host network is set to true
@@ -1693,9 +1804,15 @@ func TestDisableStork(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)
@@ -1823,9 +1940,15 @@ func TestRemoveStork(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driverEnvs := map[string]*v1.EnvVar{
+		"PX_NAMESPACE": {
+			Name:  "PX_NAMESPACE",
+			Value: cluster.Namespace,
+		},
+	}
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
-	driver.EXPECT().GetStorkEnvList(cluster).
-		Return([]v1.EnvVar{{Name: "PX_NAMESPACE", Value: cluster.Namespace}}).
+	driver.EXPECT().GetStorkEnvMap(cluster).
+		Return(driverEnvs).
 		AnyTimes()
 
 	err := controller.syncStork(cluster)

--- a/pkg/controller/storagecluster/testspec/storkDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkDeployment.yaml
@@ -44,6 +44,8 @@ spec:
             secretKeyRef:
               name: secret-name
               key: secret-key
+        - name: STORK-NAMESPACE
+          value: kube-test
         - name: TEST
           value: test-value
         resources:

--- a/pkg/mock/storagedriver.mock.go
+++ b/pkg/mock/storagedriver.mock.go
@@ -112,18 +112,18 @@ func (mr *MockDriverMockRecorder) GetStorkDriverName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorkDriverName", reflect.TypeOf((*MockDriver)(nil).GetStorkDriverName))
 }
 
-// GetStorkEnvList mocks base method
-func (m *MockDriver) GetStorkEnvList(arg0 *v1.StorageCluster) []v10.EnvVar {
+// GetStorkEnvMap mocks base method
+func (m *MockDriver) GetStorkEnvMap(arg0 *v1.StorageCluster) map[string]*v10.EnvVar {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStorkEnvList", arg0)
-	ret0, _ := ret[0].([]v10.EnvVar)
+	ret := m.ctrl.Call(m, "GetStorkEnvMap", arg0)
+	ret0, _ := ret[0].(map[string]*v10.EnvVar)
 	return ret0
 }
 
-// GetStorkEnvList indicates an expected call of GetStorkEnvList
-func (mr *MockDriverMockRecorder) GetStorkEnvList(arg0 interface{}) *gomock.Call {
+// GetStorkEnvMap indicates an expected call of GetStorkEnvMap
+func (mr *MockDriverMockRecorder) GetStorkEnvMap(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorkEnvList", reflect.TypeOf((*MockDriver)(nil).GetStorkEnvList), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStorkEnvMap", reflect.TypeOf((*MockDriver)(nil).GetStorkEnvMap), arg0)
 }
 
 // Init mocks base method


### PR DESCRIPTION
- Also remove duplicate env variables before passing to
  stork deployment. Give spec.stork.env priority over
  build-in env variables, so users can override them.

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>