### PR TITLE
Let users specify the service account to be used by portworx pods

### DIFF
--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -151,8 +151,11 @@ func (c *portworxAPI) createDaemonSet(
 	}
 
 	imageName := util.GetImageURN(cluster.Spec.CustomImageRegistry, pxutil.ImageNamePause)
+	serviceAccount := pxutil.PortworxServiceAccountName(cluster)
+	existingServiceAccount := existingDaemonSet.Spec.Template.Spec.ServiceAccountName
 
 	modified := existingImageName != imageName ||
+		existingServiceAccount != serviceAccount ||
 		util.HasPullSecretChanged(cluster, existingDaemonSet.Spec.Template.Spec.ImagePullSecrets) ||
 		util.HasNodeAffinityChanged(cluster, existingDaemonSet.Spec.Template.Spec.Affinity) ||
 		util.HaveTolerationsChanged(cluster, existingDaemonSet.Spec.Template.Spec.Tolerations)
@@ -196,7 +199,7 @@ func getPortworxAPIDaemonSetSpec(
 					Labels: getPortworxAPIServiceLabels(),
 				},
 				Spec: v1.PodSpec{
-					ServiceAccountName: pxutil.PortworxServiceAccountName,
+					ServiceAccountName: pxutil.PortworxServiceAccountName(cluster),
 					RestartPolicy:      v1.RestartPolicyAlways,
 					HostNetwork:        true,
 					Containers: []v1.Container{

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -276,7 +276,7 @@ func (p *portworx) GetKVDBPodSpec(
 	podSpec := v1.PodSpec{
 		HostNetwork:        true,
 		RestartPolicy:      v1.RestartPolicyAlways,
-		ServiceAccountName: pxutil.PortworxServiceAccountName,
+		ServiceAccountName: pxutil.PortworxServiceAccountName(cluster),
 		Containers:         []v1.Container{containers},
 		NodeName:           nodeName,
 	}
@@ -302,7 +302,6 @@ func (p *portworx) GetKVDBPodSpec(
 	return podSpec, nil
 }
 
-// TODO [Imp] Validate the cluster spec and return errors in the configuration
 func (p *portworx) GetStoragePodSpec(
 	cluster *corev1.StorageCluster, nodeName string,
 ) (v1.PodSpec, error) {
@@ -337,7 +336,7 @@ func (p *portworx) GetStoragePodSpec(
 	podSpec := v1.PodSpec{
 		HostNetwork:        true,
 		RestartPolicy:      v1.RestartPolicyAlways,
-		ServiceAccountName: pxutil.PortworxServiceAccountName,
+		ServiceAccountName: pxutil.PortworxServiceAccountName(cluster),
 		Containers:         []v1.Container{containers},
 		Volumes:            t.getVolumes(),
 	}

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -36,8 +36,8 @@ const (
 	// PortworxSpecsDir is the directory where all the Portworx specs are stored
 	PortworxSpecsDir = "/configs"
 
-	// PortworxServiceAccountName name of the Portworx service account
-	PortworxServiceAccountName = "portworx"
+	// DefaultPortworxServiceAccountName default name of the Portworx service account
+	DefaultPortworxServiceAccountName = "portworx"
 	// PortworxServiceName name of the Portworx Kubernetes service
 	PortworxServiceName = "portworx-service"
 	// PortworxRESTPortName name of the Portworx API port
@@ -88,6 +88,9 @@ const (
 	// EnvKeyPortworxNamespace key for the env var which tells namespace in which
 	// Portworx is installed
 	EnvKeyPortworxNamespace = "PX_NAMESPACE"
+	// EnvKeyPortworxServiceAccount key for the env var which tells custom Portworx
+	// service account
+	EnvKeyPortworxServiceAccount = "PX_SERVICE_ACCOUNT"
 	// EnvKeyPortworxServiceName key for the env var which tells the name of the
 	// portworx service to be used
 	EnvKeyPortworxServiceName = "PX_SERVICE_NAME"
@@ -250,6 +253,16 @@ func KubeletPath(cluster *corev1.StorageCluster) string {
 		return "/var/vcap/data/kubelet"
 	}
 	return "/var/lib/kubelet"
+}
+
+// PortworxServiceAccountName returns name of the portworx service account
+func PortworxServiceAccountName(cluster *corev1.StorageCluster) string {
+	for _, env := range cluster.Spec.Env {
+		if env.Name == EnvKeyPortworxServiceAccount && len(env.Value) > 0 {
+			return env.Value
+		}
+	}
+	return DefaultPortworxServiceAccountName
 }
 
 // UseDeprecatedCSIDriverName returns true if the cluster env variables has


### PR DESCRIPTION
In AWS marketplace, portworx has to use a service account associated
with the IAM role so that the metering would work for Portworx.
The users can create that service account and ask the operator to use
that service account instead of the default one.

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>