### PR TITLE
Removing FileOrCreate for socket file

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1107,10 +1107,9 @@ func (t *template) getCSIVolumeInfoList() []volumeInfo {
 func (t *template) getK3sVolumeInfoList() []volumeInfo {
 	return []volumeInfo{
 		{
-			name:         "containerd-k3s",
-			hostPath:     "/run/k3s/containerd/containerd.sock",
-			mountPath:    "/run/containerd/containerd.sock",
-			hostPathType: hostPathTypePtr(v1.HostPathFileOrCreate),
+			name:      "containerd-k3s",
+			hostPath:  "/run/k3s/containerd/containerd.sock",
+			mountPath: "/run/containerd/containerd.sock",
 		},
 	}
 }

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -168,4 +168,3 @@ spec:
         - name: containerd-k3s
           hostPath:
             path: /run/k3s/containerd/containerd.sock
-            type: FileOrCreate


### PR DESCRIPTION
FileOrCreate type is not supported for socket file,
starting k8s 1.19

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>