### PR TITLE
Delay creation of deleted pods on cordoned nodes

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,9 @@
+package constants
+
+import "time"
+
+const (
+	// DefaultCordonedRestartDelay duration for which the operator should not try
+	// to restart pods after the node is cordoned
+	DefaultCordonedRestartDelay = 2 * time.Minute
+)

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -5,11 +5,11 @@ const (
 	OperatorPrefix = "operator.libopenstorage.org"
 	// LabelKeyClusterName is the name of the label key for the cluster name
 	LabelKeyClusterName = OperatorPrefix + "/name"
-	// LabelKeyDriverName is the name of the label key for the storage driver for the cluster`
+	// LabelKeyDriverName is the name of the label key for the storage driver for the cluster
 	LabelKeyDriverName = OperatorPrefix + "/driver"
 	// LabelKeyStoragePod is the name of the key for the label on the pod that indicates it's on a storage node
 	LabelKeyStoragePod = "storage"
-	// LabelKeyKVDBPod is the name of the key for the label on the pod that indicates it's on a KVDB node`
+	// LabelKeyKVDBPod is the name of the key for the label on the pod that indicates it's on a KVDB node
 	LabelKeyKVDBPod = "kvdb"
 	// LabelValueTrue is the constant for a "true" label value
 	LabelValueTrue = "true"
@@ -17,6 +17,10 @@ const (
 	AnnotationDisableStorage = OperatorPrefix + "/disable-storage"
 	// AnnotationReconcileObject annotation to toggle reconciliation of operator created objects
 	AnnotationReconcileObject = OperatorPrefix + "/reconcile"
-	// AnnotationClusterAPIMachine is the annotation key name for the name of the machine that's backing the k8s node
+	// AnnotationClusterAPIMachine is the annotation key name for the name of the
+	// machine that's backing the k8s node
 	AnnotationClusterAPIMachine = "cluster.k8s.io/machine"
+	// AnnotationCordonedRestartDelay is the annotation key name for the duration
+	// (in seconds) to wait before restarting the storage pods
+	AnnotationCordonedRestartDelay = OperatorPrefix + "/cordoned-restart-delay-secs"
 )

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -523,7 +523,6 @@ func (c *Controller) manage(
 	}
 
 	return nil
-	// TODO: Update the status of the pods in the CR (available, running, etc)
 }
 
 // syncNodes deletes given pods and creates new storage pods on the given nodes
@@ -811,6 +810,10 @@ func (c *Controller) nodeShouldRunStoragePod(
 
 	if isBeingDeleted {
 		logrus.Infof("node: %s is in the process of being deleted. Will not create new pods here.", node.Name)
+		return false, false, true, nil
+	}
+
+	if k8s.IsNodeRecentlyCordoned(node, cluster) {
 		return false, false, true, nil
 	}
 

--- a/pkg/util/k8s/node.go
+++ b/pkg/util/k8s/node.go
@@ -3,10 +3,14 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"time"
 
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/scheduler/api"
 	cluster_v1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/deprecated/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,4 +37,42 @@ func IsNodeBeingDeleted(node *v1.Node, cl client.Client) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// IsNodeRecentlyCordoned returns true if the given node is cordoned within the
+// default delay or the user provided delay in given StorageCluster object
+func IsNodeRecentlyCordoned(
+	node *v1.Node,
+	cluster *corev1.StorageCluster,
+) bool {
+	cordoned, startTime := IsNodeCordoned(node)
+	if !cordoned || startTime.IsZero() {
+		return false
+	}
+
+	var waitDuration time.Duration
+	if duration, err := strconv.Atoi(cluster.Annotations[constants.AnnotationCordonedRestartDelay]); err == nil {
+		waitDuration = time.Duration(duration) * time.Second
+	} else {
+		waitDuration = constants.DefaultCordonedRestartDelay
+	}
+	return time.Now().Add(-waitDuration).Before(startTime)
+}
+
+// IsNodeCordoned returns true if the given noode is marked unschedulable. It
+// also returns the time when the node was cordoned if available in the node
+// taints.
+func IsNodeCordoned(node *v1.Node) (bool, time.Time) {
+	if node.Spec.Unschedulable {
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == api.TaintNodeUnschedulable {
+				if taint.TimeAdded != nil {
+					return true, taint.TimeAdded.Time
+				}
+				break
+			}
+		}
+		return true, time.Time{}
+	}
+	return false, time.Time{}
 }

--- a/pkg/util/k8s/node_test.go
+++ b/pkg/util/k8s/node_test.go
@@ -2,12 +2,15 @@ package k8s
 
 import (
 	"testing"
+	"time"
 
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/scheduler/api"
 	cluster_v1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/deprecated/v1alpha1"
 )
 
@@ -59,4 +62,141 @@ func TestIsNodeBeingDeleted(t *testing.T) {
 	isBeingDeleted, err = IsNodeBeingDeleted(n2, k8sClient)
 	require.Error(t, err)
 	require.False(t, isBeingDeleted)
+}
+
+func TestIsNodeCordoned(t *testing.T) {
+	// TestCase: Not marked as unschedulable
+	node := &v1.Node{}
+
+	cordoned, startTime := IsNodeCordoned(node)
+
+	require.False(t, cordoned)
+	require.True(t, startTime.IsZero())
+
+	// TestCase: Marked as unschedulable but no startTime
+	node.Spec.Unschedulable = true
+
+	cordoned, startTime = IsNodeCordoned(node)
+
+	require.True(t, cordoned)
+	require.True(t, startTime.IsZero())
+
+	// TestCase: Marked as unschedulable but Unschedulable taint not present
+	node.Spec.Taints = []v1.Taint{}
+
+	cordoned, startTime = IsNodeCordoned(node)
+
+	require.True(t, cordoned)
+	require.True(t, startTime.IsZero())
+
+	// TestCase: Marked as unschedulable but Unschedulable taint without timeAdded
+	taint := v1.Taint{
+		Key: api.TaintNodeUnschedulable,
+	}
+	node.Spec.Taints = append(node.Spec.Taints, taint)
+
+	cordoned, startTime = IsNodeCordoned(node)
+
+	require.True(t, cordoned)
+	require.True(t, startTime.IsZero())
+
+	// TestCase: Marked as unschedulable with timeAdded
+	timeAdded := metav1.Now()
+	node.Spec.Taints[0].TimeAdded = &timeAdded
+
+	cordoned, startTime = IsNodeCordoned(node)
+
+	require.True(t, cordoned)
+	require.False(t, startTime.IsZero())
+	require.Equal(t, timeAdded.Time, startTime)
+}
+
+func TestIsNodeRecentlyCordoned(t *testing.T) {
+	// TestCase: Node not cordoned
+	node := &v1.Node{}
+	cluster := &corev1.StorageCluster{}
+
+	recentlyCordoned := IsNodeRecentlyCordoned(node, cluster)
+
+	require.False(t, recentlyCordoned)
+
+	// TestCase: Node cordoned, but time of cordon is zero
+	node.Spec.Unschedulable = true
+
+	recentlyCordoned = IsNodeRecentlyCordoned(node, cluster)
+
+	require.False(t, recentlyCordoned)
+
+	// TestCase: Node cordoned, but time of cordon is zero
+	node.Spec.Taints = []v1.Taint{
+		{
+			Key:       api.TaintNodeUnschedulable,
+			TimeAdded: nil,
+		},
+	}
+
+	recentlyCordoned = IsNodeRecentlyCordoned(node, cluster)
+
+	require.False(t, recentlyCordoned)
+
+	// TestCase: Cordon time is older than default restart wait duration
+	timeAdded := metav1.NewTime(
+		metav1.Now().
+			Add(-constants.DefaultCordonedRestartDelay).
+			Add(-time.Second),
+	)
+	node.Spec.Taints[0].TimeAdded = &timeAdded
+
+	recentlyCordoned = IsNodeRecentlyCordoned(node, cluster)
+
+	require.False(t, recentlyCordoned)
+
+	// TestCase: Cordon time is newer than default restart wait duration
+	timeAdded = metav1.NewTime(
+		metav1.Now().
+			Add(-constants.DefaultCordonedRestartDelay).
+			Add(time.Second),
+	)
+
+	recentlyCordoned = IsNodeRecentlyCordoned(node, cluster)
+
+	require.True(t, recentlyCordoned)
+
+	// TestCase: Cordon time is older than overriden restart wait duration
+	cluster.Annotations = map[string]string{
+		constants.AnnotationCordonedRestartDelay: "10",
+	}
+
+	recentlyCordoned = IsNodeRecentlyCordoned(node, cluster)
+
+	require.False(t, recentlyCordoned)
+
+	// TestCase: Cordon time is newer than overriden restart wait duration
+	timeAdded = metav1.NewTime(metav1.Now().Add(-5 * time.Second))
+
+	recentlyCordoned = IsNodeRecentlyCordoned(node, cluster)
+
+	require.True(t, recentlyCordoned)
+
+	// TestCase: Failure to parse the annotation will result in using default delay
+	cluster.Annotations[constants.AnnotationCordonedRestartDelay] = "invalid"
+	timeAdded = metav1.NewTime(
+		metav1.Now().
+			Add(-constants.DefaultCordonedRestartDelay).
+			Add(time.Second),
+	)
+
+	recentlyCordoned = IsNodeRecentlyCordoned(node, cluster)
+
+	require.True(t, recentlyCordoned)
+
+	timeAdded = metav1.NewTime(
+		metav1.Now().
+			Add(-constants.DefaultCordonedRestartDelay).
+			Add(-time.Second),
+	)
+
+	recentlyCordoned = IsNodeRecentlyCordoned(node, cluster)
+
+	require.False(t, recentlyCordoned)
 }


### PR DESCRIPTION
Keep the default delay of 2 min before we start creating the pods again. 
Also adding an annotation to overwrite the default delay of 2 minutes.

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>