### PR TITLE
Removed http from remote write endpoint url

### DIFF
--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -571,7 +571,7 @@ func (c *prometheus) createPrometheusInstance(
 		cluster.Spec.Monitoring.Prometheus.RemoteWriteEndpoint != "" {
 		prometheusInst.Spec.RemoteWrite = []monitoringv1.RemoteWriteSpec{
 			{
-				URL: fmt.Sprintf("http://%s/api/prom/push", cluster.Spec.Monitoring.Prometheus.RemoteWriteEndpoint),
+				URL: fmt.Sprintf("%s/api/prom/push", cluster.Spec.Monitoring.Prometheus.RemoteWriteEndpoint),
 			},
 		}
 	}

--- a/drivers/storage/portworx/testspec/prometheusInstanceWithRemoteWriteEndpoint.yaml
+++ b/drivers/storage/portworx/testspec/prometheusInstanceWithRemoteWriteEndpoint.yaml
@@ -16,7 +16,7 @@ spec:
       - portworx
       - px-backup
   remoteWrite:
-  - url: "http://test.endpoint:1234/api/prom/push"
+  - url: "test.endpoint:1234/api/prom/push"
   resources:
     requests:
       memory: 400Mi


### PR DESCRIPTION
From pxcentral-api server side, install module api will take care of adding http or https based on either ssl is required/enabled in cortex endpoint.