### PR TITLE
PWX-17604: fix OpenShift upgrades

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -852,7 +852,7 @@ func (t *template) getEnvList() []v1.EnvVar {
 	if t.isOpenshift {
 		envMap["PRE-EXEC"] = &v1.EnvVar{
 			Name:  "PRE-EXEC",
-			Value: "if [ -d /ostree/deploy/rhcos/deploy ] && [ -f /etc/pwx/.private.json ]; then chattr -i /etc/pwx/.private.json /ostree/deploy/rhcos/deploy/*/etc/pwx/.private.json || /bin/true; fi",
+			Value: "if [ -f /etc/pwx/.private.json ] && [ -d /ostree/deploy/rhcos/deploy ]; then chattr -i /etc/pwx/.private.json /ostree/deploy/rhcos/deploy/*/etc/pwx/.private.json || /bin/true; fi",
 		}
 	}
 

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -849,6 +849,13 @@ func (t *template) getEnvList() []v1.EnvVar {
 		}
 	}
 
+	if t.isOpenshift {
+		envMap["PRE-EXEC"] = &v1.EnvVar{
+			Name:  "PRE-EXEC",
+			Value: "if [ -d /ostree/deploy/rhcos/deploy ] && [ -f /etc/pwx/.private.json ]; then chattr -i /etc/pwx/.private.json /ostree/deploy/rhcos/deploy/*/etc/pwx/.private.json || /bin/true; fi",
+		}
+	}
+
 	if pxutil.FeatureCSI.IsEnabled(t.cluster.Spec.FeatureGates) {
 		envMap["CSI_ENDPOINT"] = &v1.EnvVar{
 			Name:  "CSI_ENDPOINT",

--- a/drivers/storage/portworx/testspec/openshift_runc.yaml
+++ b/drivers/storage/portworx/testspec/openshift_runc.yaml
@@ -47,6 +47,8 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "PRE-EXEC"
+              value: "if [ -f /etc/pwx/.private.json ] && [ -d /ostree/deploy/rhcos/deploy ]; then chattr -i /etc/pwx/.private.json /ostree/deploy/rhcos/deploy/*/etc/pwx/.private.json || /bin/true; fi"
           livenessProbe:
             periodSeconds: 30
             initialDelaySeconds: 840 # allow image pull in slow networks


### PR DESCRIPTION
* adding a pre-exec rule to fix protection on cached px-configs

Signed-off-by: Zoran Rajic <zox@portworx.com>