### PR TITLE
PTX-2938 Remove copy of the whole test dir from Dockerfile

### DIFF
--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update && \
 
 WORKDIR /
 
-COPY * /operator-test/
+COPY operator.test /

--- a/test/integration_test/operator-test-pod.yaml
+++ b/test/integration_test/operator-test-pod.yaml
@@ -49,7 +49,7 @@ spec:
     - tool
     - test2json
     - -t
-    - /operator-test/operator.test
+    - /operator.test
     - -test.v
     - -test.short=SHORT_FLAG
     - -portworx-spec-gen-url=PORTWORX_SPEC_GEN_URL


### PR DESCRIPTION
Remove copy of the whole test dir from Dockerfile to reduce the size of test container. Will be using git source management instead.

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>