### PR TITLE
OPERATOR-264: need to mount /var/lib/osd/driver

### DIFF
--- a/drivers/storage/portworx/testspec/nodeWiper.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiper.yaml
@@ -35,6 +35,8 @@ spec:
           mountPath: /hostproc
         - name: optpwx
           mountPath: /opt/pwx
+        - name: sockpwx
+          mountPath: /var/lib/osd/driver
         - name: dbus
           mountPath: /var/run/dbus
         - name: sysdmount
@@ -62,6 +64,9 @@ spec:
       - name: optpwx
         hostPath:
           path: /opt/pwx
+      - name: sockpwx
+        hostPath:
+          path: /var/lib/osd/driver
       - name: dbus
         hostPath:
           path: /var/run/dbus

--- a/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
@@ -35,6 +35,8 @@ spec:
           mountPath: /hostproc
         - name: optpwx
           mountPath: /opt/pwx
+        - name: sockpwx
+          mountPath: /var/lib/osd/driver
         - name: dbus
           mountPath: /var/run/dbus
         - name: sysdmount
@@ -62,6 +64,9 @@ spec:
       - name: optpwx
         hostPath:
           path: /var/vcap/store/opt/pwx
+      - name: sockpwx
+        hostPath:
+          path: /var/vcap/store/var/lib/osd/driver
       - name: dbus
         hostPath:
           path: /var/run/dbus

--- a/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
@@ -36,6 +36,8 @@ spec:
           mountPath: /hostproc
         - name: optpwx
           mountPath: /opt/pwx
+        - name: sockpwx
+          mountPath: /var/lib/osd/driver
         - name: dbus
           mountPath: /var/run/dbus
         - name: sysdmount
@@ -63,6 +65,9 @@ spec:
       - name: optpwx
         hostPath:
           path: /opt/pwx
+      - name: sockpwx
+        hostPath:
+          path: /var/lib/osd/driver
       - name: dbus
         hostPath:
           path: /var/run/dbus

--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -37,6 +37,7 @@ var (
 
 const (
 	dsOptPwxVolumeName                = "optpwx"
+	dsSockPwxVolumeName               = "sockpwx"
 	dsEtcPwxVolumeName                = "etcpwx"
 	dsHostProcVolumeName              = "hostproc"
 	dsDbusVolumeName                  = "dbus"
@@ -56,6 +57,7 @@ const (
 	pksPersistentStoreRoot            = "/var/vcap/store"
 	pxOptPwx                          = "/opt/pwx"
 	pxEtcPwx                          = "/etc/pwx"
+	pxSockPwx                         = "/var/lib/osd/driver"
 	pxNodeWiperServiceAccountName     = "px-node-wiper"
 	pxNodeWiperClusterRoleName        = "px-node-wiper"
 	pxNodeWiperClusterRoleBindingName = "px-node-wiper"
@@ -249,6 +251,10 @@ func (u *uninstallPortworx) RunNodeWiper(
 									MountPath: pxOptPwx,
 								},
 								{
+									Name:      dsSockPwxVolumeName,
+									MountPath: pxSockPwx,
+								},
+								{
 									Name:      dsDbusVolumeName,
 									MountPath: dbusPath,
 								},
@@ -304,6 +310,14 @@ func (u *uninstallPortworx) RunNodeWiper(
 							VolumeSource: v1.VolumeSource{
 								HostPath: &v1.HostPathVolumeSource{
 									Path: path.Join(pwxHostPathRoot, pxOptPwx),
+								},
+							},
+						},
+						{
+							Name: dsSockPwxVolumeName,
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: path.Join(pwxHostPathRoot + pxSockPwx),
 								},
 							},
 						},


### PR DESCRIPTION
operator uses `px-node-wiper`
  `px-node-wiper` uses `pxctl`, which needs access to Unix DS
  on `/var/lib/osd/driver`
  
related to https://github.com/portworx/talisman/pull/114 