### PR TITLE
Annotation to toggle pod security policies

### DIFF
--- a/drivers/storage/portworx/component/podsecuritypolicies.go
+++ b/drivers/storage/portworx/component/podsecuritypolicies.go
@@ -3,9 +3,9 @@ package component
 import (
 	"context"
 	"fmt"
-	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 
 	"github.com/hashicorp/go-version"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -39,7 +39,7 @@ func (p *podsecuritypolicies) Initialize(k8sClient client.Client, k8sVersion ver
 }
 
 func (p *podsecuritypolicies) IsEnabled(cluster *corev1.StorageCluster) bool {
-	return true
+	return pxutil.PodSecurityPolicyEnabled(cluster)
 }
 
 func (p *podsecuritypolicies) Reconcile(cluster *corev1.StorageCluster) error {

--- a/drivers/storage/portworx/testspec/privilegedPSP.yaml
+++ b/drivers/storage/portworx/testspec/privilegedPSP.yaml
@@ -1,0 +1,21 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: px-privileged
+spec:
+  fsGroup:
+    rule: RunAsAny
+  hostNetwork: true
+  privileged: true
+  readOnlyRootFilesystem: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret
+  - hostPath
+  - emptyDir

--- a/drivers/storage/portworx/testspec/restrictedPSP.yaml
+++ b/drivers/storage/portworx/testspec/restrictedPSP.yaml
@@ -1,0 +1,19 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: px-restricted
+spec:
+  fsGroup:
+    rule: RunAsAny
+  readOnlyRootFilesystem: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - secret
+  - hostPath
+  - emptyDir

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -99,6 +99,9 @@ const (
 	AnnotationRunOnMaster = pxAnnotationPrefix + "/run-on-master"
 	// AnnotationPodDisruptionBudget annotation indicating whether to create pod disruption budgets
 	AnnotationPodDisruptionBudget = pxAnnotationPrefix + "/pod-disruption-budget"
+	// AnnotationPodSecurityPolicy annotation indicating whether to enable creation
+	// of pod security policies
+	AnnotationPodSecurityPolicy = pxAnnotationPrefix + "/pod-security-policy"
 
 	// EnvKeyPXImage key for the environment variable that specifies Portworx image
 	EnvKeyPXImage = "PX_IMAGE"
@@ -238,6 +241,12 @@ func StorageClassEnabled(cluster *corev1.StorageCluster) bool {
 func PodDisruptionBudgetEnabled(cluster *corev1.StorageCluster) bool {
 	enabled, err := strconv.ParseBool(cluster.Annotations[AnnotationPodDisruptionBudget])
 	return err != nil || enabled
+}
+
+// PodSecurityPolicyEnabled returns true if the PSP annotation is present and has true value
+func PodSecurityPolicyEnabled(cluster *corev1.StorageCluster) bool {
+	enabled, err := strconv.ParseBool(cluster.Annotations[AnnotationPodSecurityPolicy])
+	return err == nil && enabled
 }
 
 // ServiceType returns the k8s service type from cluster annotations if present

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -224,6 +225,14 @@ func GetExpectedPrometheusRule(t *testing.T, fileName string) *monitoringv1.Prom
 	prometheusRule, ok := obj.(*monitoringv1.PrometheusRule)
 	assert.True(t, ok, "Expected PrometheusRule object")
 	return prometheusRule
+}
+
+// GetExpectedPSP returns the PodSecurityPolicy object from given yaml spec file
+func GetExpectedPSP(t *testing.T, fileName string) *policyv1beta1.PodSecurityPolicy {
+	obj := getKubernetesObject(t, fileName)
+	psp, ok := obj.(*policyv1beta1.PodSecurityPolicy)
+	assert.True(t, ok, "Expected PodSecurityPolicy object")
+	return psp
 }
 
 // getKubernetesObject returns a generic Kubernetes object from given yaml file


### PR DESCRIPTION
Disable PSPs by default. Expose an annotation to enabled the operator created PSPs.

OPERATOR-279
