### PR TITLE
Allow writing to root file system inside the container

### DIFF
--- a/drivers/storage/portworx/component/podsecuritypolicies.go
+++ b/drivers/storage/portworx/component/podsecuritypolicies.go
@@ -83,7 +83,7 @@ func portworxPodSecurityPolicies() []policyv1beta1.PodSecurityPolicy {
 			Spec: policyv1beta1.PodSecurityPolicySpec{
 				Privileged:             true,
 				HostNetwork:            true,
-				ReadOnlyRootFilesystem: true,
+				ReadOnlyRootFilesystem: false,
 				Volumes: []policyv1beta1.FSType{
 					policyv1beta1.ConfigMap,
 					policyv1beta1.Secret,

--- a/drivers/storage/portworx/testspec/privilegedPSP.yaml
+++ b/drivers/storage/portworx/testspec/privilegedPSP.yaml
@@ -7,7 +7,7 @@ spec:
     rule: RunAsAny
   hostNetwork: true
   privileged: true
-  readOnlyRootFilesystem: true
+  readOnlyRootFilesystem: false
   runAsUser:
     rule: RunAsAny
   seLinux:


### PR DESCRIPTION
This is needed by the node-wiper container as it writes its
done status in a file under /tmp

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>