### PR TITLE
Reconcile components in order of their priority

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -75,6 +75,14 @@ type autopilot struct {
 	k8sClient client.Client
 }
 
+func (c *autopilot) Name() string {
+	return AutopilotComponentName
+}
+
+func (c *autopilot) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *autopilot) Initialize(
 	k8sClient client.Client,
 	_ version.Version,

--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -53,6 +53,14 @@ type csi struct {
 	k8sVersion            version.Version
 }
 
+func (c *csi) Name() string {
+	return CSIComponentName
+}
+
+func (c *csi) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *csi) Initialize(
 	k8sClient client.Client,
 	k8sVersion version.Version,

--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -37,6 +37,14 @@ type disruptionBudget struct {
 	sdkConn   *grpc.ClientConn
 }
 
+func (c *disruptionBudget) Name() string {
+	return DisruptionBudgetComponentName
+}
+
+func (c *disruptionBudget) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *disruptionBudget) Initialize(
 	k8sClient client.Client,
 	_ version.Version,

--- a/drivers/storage/portworx/component/lighthouse.go
+++ b/drivers/storage/portworx/component/lighthouse.go
@@ -60,6 +60,14 @@ type lighthouse struct {
 	k8sClient client.Client
 }
 
+func (c *lighthouse) Name() string {
+	return LighthouseComponentName
+}
+
+func (c *lighthouse) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *lighthouse) Initialize(
 	k8sClient client.Client,
 	_ version.Version,

--- a/drivers/storage/portworx/component/monitoring.go
+++ b/drivers/storage/portworx/component/monitoring.go
@@ -41,6 +41,14 @@ type monitoring struct {
 	recorder  record.EventRecorder
 }
 
+func (c *monitoring) Name() string {
+	return MonitoringComponentName
+}
+
+func (c *monitoring) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *monitoring) Initialize(
 	k8sClient client.Client,
 	_ version.Version,

--- a/drivers/storage/portworx/component/podsecuritypolicies.go
+++ b/drivers/storage/portworx/component/podsecuritypolicies.go
@@ -21,17 +21,16 @@ const (
 	PSPComponentName = "PodSecurityPolicies"
 )
 
-// RegisterPSPComponent registers a component for installing podsecuritypolicies.
-func RegisterPSPComponent() {
-	Register(PSPComponentName, &podsecuritypolicies{})
-}
-
-func init() {
-	RegisterPSPComponent()
-}
-
 type podsecuritypolicies struct {
 	k8sClient client.Client
+}
+
+func (p *podsecuritypolicies) Name() string {
+	return PSPComponentName
+}
+
+func (p *podsecuritypolicies) Priority() int32 {
+	return int32(0)
 }
 
 func (p *podsecuritypolicies) Initialize(k8sClient client.Client, k8sVersion version.Version, scheme *runtime.Scheme, recorder record.EventRecorder) {
@@ -133,4 +132,13 @@ func portworxPodSecurityPolicies() []policyv1beta1.PodSecurityPolicy {
 			},
 		},
 	}
+}
+
+// RegisterPSPComponent registers a component for installing podsecuritypolicies.
+func RegisterPSPComponent() {
+	Register(PSPComponentName, &podsecuritypolicies{})
+}
+
+func init() {
+	RegisterPSPComponent()
 }

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -33,6 +33,14 @@ type portworxAPI struct {
 	k8sClient client.Client
 }
 
+func (c *portworxAPI) Name() string {
+	return PortworxAPIComponentName
+}
+
+func (c *portworxAPI) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *portworxAPI) Initialize(
 	k8sClient client.Client,
 	_ version.Version,

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -37,6 +37,14 @@ type portworxBasic struct {
 	k8sClient client.Client
 }
 
+func (c *portworxBasic) Name() string {
+	return PortworxBasicComponentName
+}
+
+func (c *portworxBasic) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *portworxBasic) Initialize(
 	k8sClient client.Client,
 	_ version.Version,

--- a/drivers/storage/portworx/component/portworx_crd.go
+++ b/drivers/storage/portworx/component/portworx_crd.go
@@ -26,6 +26,14 @@ type portworxCRD struct {
 	isVolumePlacementStrategyCRDCreated bool
 }
 
+func (c *portworxCRD) Name() string {
+	return PortworxCRDComponentName
+}
+
+func (c *portworxCRD) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *portworxCRD) Initialize(
 	_ client.Client,
 	_ version.Version,

--- a/drivers/storage/portworx/component/portworx_proxy.go
+++ b/drivers/storage/portworx/component/portworx_proxy.go
@@ -23,10 +23,10 @@ import (
 )
 
 const (
-	// PortworxProxyComponent name of the Portworx Proxy component. This component
+	// PortworxProxyComponentName name of the Portworx Proxy component. This component
 	// runs in the kube-system namespace if the cluster is running outside. This
 	// ensures that k8s in-tree driver traffic gets routed to the Portworx nodes.
-	PortworxProxyComponent = "Portworx Proxy"
+	PortworxProxyComponentName = "Portworx Proxy"
 	// PxProxyServiceAccountName name of the Portworx proxy service account
 	PxProxyServiceAccountName = "portworx-proxy"
 	// PxProxyClusterRoleBindingName name of the Portworx proxy cluster role binding
@@ -39,6 +39,14 @@ const (
 type portworxProxy struct {
 	isCreated bool
 	k8sClient client.Client
+}
+
+func (c *portworxProxy) Name() string {
+	return PortworxProxyComponentName
+}
+
+func (c *portworxProxy) Priority() int32 {
+	return DefaultComponentPriority
 }
 
 func (c *portworxProxy) Initialize(
@@ -327,7 +335,7 @@ func getPortworxProxyServiceLabels() map[string]string {
 
 // RegisterPortworxProxyComponent registers the Portworx proxy component
 func RegisterPortworxProxyComponent() {
-	Register(PortworxProxyComponent, &portworxProxy{})
+	Register(PortworxProxyComponentName, &portworxProxy{})
 }
 
 func init() {

--- a/drivers/storage/portworx/component/portworx_sc.go
+++ b/drivers/storage/portworx/component/portworx_sc.go
@@ -43,6 +43,14 @@ type portworxStorageClass struct {
 	k8sClient client.Client
 }
 
+func (c *portworxStorageClass) Name() string {
+	return PortworxStorageClassComponentName
+}
+
+func (c *portworxStorageClass) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *portworxStorageClass) Initialize(
 	k8sClient client.Client,
 	_ version.Version,

--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -59,6 +59,14 @@ type prometheus struct {
 	isOperatorCreated bool
 }
 
+func (c *prometheus) Name() string {
+	return PrometheusComponentName
+}
+
+func (c *prometheus) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *prometheus) Initialize(
 	k8sClient client.Client,
 	_ version.Version,

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -47,6 +47,14 @@ type pvcController struct {
 	k8sVersion version.Version
 }
 
+func (c *pvcController) Name() string {
+	return PVCControllerComponentName
+}
+
+func (c *pvcController) Priority() int32 {
+	return DefaultComponentPriority
+}
+
 func (c *pvcController) Initialize(
 	k8sClient client.Client,
 	k8sVersion version.Version,

--- a/drivers/storage/portworx/component/security.go
+++ b/drivers/storage/portworx/component/security.go
@@ -76,6 +76,14 @@ type security struct {
 	resourceVersionCache map[string]string
 }
 
+func (c *security) Name() string {
+	return SecurityComponentName
+}
+
+func (c *security) Priority() int32 {
+	return int32(0)
+}
+
 // Initialize initializes the componenet
 func (c *security) Initialize(
 	k8sClient client.Client,

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -271,19 +271,19 @@ func (p *portworx) PreInstall(cluster *corev1.StorageCluster) error {
 		return err
 	}
 
-	for componentName, comp := range component.GetAll() {
+	for _, comp := range component.GetAll() {
 		if comp.IsEnabled(cluster) {
 			err := comp.Reconcile(cluster)
 			if ce, ok := err.(*component.Error); ok &&
 				ce.Code() == component.ErrCritical {
 				return err
 			} else if err != nil {
-				msg := fmt.Sprintf("Failed to setup %s. %v", componentName, err)
+				msg := fmt.Sprintf("Failed to setup %s. %v", comp.Name(), err)
 				p.warningEvent(cluster, util.FailedComponentReason, msg)
 			}
 		} else {
 			if err := comp.Delete(cluster); err != nil {
-				msg := fmt.Sprintf("Failed to cleanup %v. %v", componentName, err)
+				msg := fmt.Sprintf("Failed to cleanup %v. %v", comp.Name(), err)
 				p.warningEvent(cluster, util.FailedComponentReason, msg)
 			}
 		}
@@ -442,9 +442,9 @@ func (p *portworx) DeleteStorage(
 }
 
 func (p *portworx) deleteComponents(cluster *corev1.StorageCluster) {
-	for componentName, comp := range component.GetAll() {
+	for _, comp := range component.GetAll() {
 		if err := comp.Delete(cluster); err != nil {
-			msg := fmt.Sprintf("Failed to cleanup %v. %v", componentName, err)
+			msg := fmt.Sprintf("Failed to cleanup %v. %v", comp.Name(), err)
 			p.warningEvent(cluster, util.FailedComponentReason, msg)
 		}
 	}


### PR DESCRIPTION
We should install certain components like PSP, security
before other components start to resolve run time
dependencies.

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>