### PR TITLE
OPERATOR-256 rename appliance ID to cluster UUID

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -132,7 +132,7 @@ func (t *telemetry) createConfigMap(
         "controller_sn": "SA-0",
         "component_name": "SA-0",
         "product_name": "portworx",
-        "appliance_id_path": "/etc/pwx/appliance_id"
+        "appliance_id_path": "/etc/pwx/cluster_uuid"
       },
       "proxy": {
         "path": "/dev/null"

--- a/drivers/storage/portworx/testspec/ccmconfig.yaml
+++ b/drivers/storage/portworx/testspec/ccmconfig.yaml
@@ -60,7 +60,7 @@ data:
             "controller_sn": "SA-0",
             "component_name": "SA-0",
             "product_name": "portworx",
-            "appliance_id_path": "/etc/pwx/appliance_id"
+            "appliance_id_path": "/etc/pwx/cluster_uuid"
           },
           "proxy": {
             "path": "/dev/null"


### PR DESCRIPTION
This will help remove confusion since PX has no concept of appliance

Signed-off-by: Harsh Desai <hadesai@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

