### PR TITLE
[OPERATOR-311] Allow volume expansion for stork-snapshot-sc storageclass

### DIFF
--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -208,13 +208,15 @@ func (c *Controller) createStorkConfigMap(
 }
 
 func (c *Controller) createStorkSnapshotStorageClass() error {
+	allowVolumeExpansion := true
 	return k8sutil.CreateStorageClass(
 		c.client,
 		&storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: storkSnapshotStorageClassName,
 			},
-			Provisioner: "stork-snapshot",
+			Provisioner:          "stork-snapshot",
+			AllowVolumeExpansion: &allowVolumeExpansion,
 		},
 	)
 }

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -246,6 +246,7 @@ func TestStorkInstallation(t *testing.T) {
 	require.Equal(t, storkSnapshotStorageClassName, storkStorageClass.Name)
 	require.Empty(t, storkStorageClass.OwnerReferences)
 	require.Equal(t, "stork-snapshot", storkStorageClass.Provisioner)
+	require.True(t, *storkStorageClass.AllowVolumeExpansion)
 }
 
 func TestStorkWithoutImage(t *testing.T) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
add `AllowVolumeExpansion` flag to `stork-snapshot-sc` storageclass, tested result shown as:
```
# kubectl get sc stork-snapshot-sc -o yaml
allowVolumeExpansion: true
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  creationTimestamp: "2021-04-14T20:57:39Z"
  managedFields:
  - apiVersion: storage.k8s.io/v1
    fieldsType: FieldsV1
    fieldsV1:
      f:allowVolumeExpansion: {}
      f:provisioner: {}
      f:reclaimPolicy: {}
      f:volumeBindingMode: {}
    manager: operator
    operation: Update
    time: "2021-04-14T20:57:39Z"
  name: stork-snapshot-sc
  resourceVersion: "2486"
  selfLink: /apis/storage.k8s.io/v1/storageclasses/stork-snapshot-sc
  uid: 4154fd84-179b-46d2-b4b9-dbf26811d3ec
provisioner: stork-snapshot
reclaimPolicy: Delete
volumeBindingMode: Immediate
```

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-311](https://portworx.atlassian.net/browse/OPERATOR-311)

**Special notes for your reviewer**:

