### PR TITLE
OPERATOR-304: Add BottleRocket AMI support

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -223,12 +223,6 @@ func (p *portworx) GetKVDBPodSpec(
 		return v1.PodSpec{}, err
 	}
 
-	if node, err := p.getNodeByName(nodeName); err != nil {
-		logrus.WithError(err).Warnf("Could not get OSImage for node %s", nodeName)
-	} else {
-		t.setOSImage(node.Status.NodeInfo.OSImage)
-	}
-
 	containers := t.kvdbContainer()
 	podSpec := v1.PodSpec{
 		HostNetwork:        true,
@@ -1318,7 +1312,7 @@ func (t *template) isBottleRocketOS() bool {
 		return false
 	}
 	lc := strings.ToLower(t.osImage)
-	return strings.HasPrefix(lc, "bottlerocket os")
+	return strings.HasPrefix(lc, "bottlerocket")
 }
 
 func stringPtr(val string) *string {


### PR DESCRIPTION
* will collect the OSImage before generating template (i.e. "Bottlerocket OS 1.0.8" or "Ubuntu 18.04.5 LTS")
* based on OSImage, turns on Bottlerocket AMI customizations

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # OPERATOR-304

**Special notes for your reviewer**:

