### PR TITLE
Mount Unix DS location on oci-mon pod

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1455,6 +1455,14 @@ func getDefaultVolumeInfoList() []volumeInfo {
 			},
 		},
 		{
+			name:      "osddriver",
+			hostPath:  "/var/lib/osd/driver",
+			mountPath: "/var/lib/osd/driver",
+			pks: &pksVolumeInfo{
+				hostPath: "/var/vcap/store/lib/osd/driver",
+			},
+		},
+		{
 			name:      "procmount",
 			hostPath:  "/proc",
 			mountPath: "/host_proc",

--- a/drivers/storage/portworx/testspec/openshift_runc.yaml
+++ b/drivers/storage/portworx/testspec/openshift_runc.yaml
@@ -87,6 +87,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -124,6 +126,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/pks.yaml
+++ b/drivers/storage/portworx/testspec/pks.yaml
@@ -85,6 +85,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -124,6 +126,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /var/vcap/store/opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/vcap/store/lib/osd/driver            
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
@@ -75,6 +75,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -112,6 +114,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
@@ -72,6 +72,9 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
+
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -109,6 +112,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/px_csi_0.3.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_0.3.yaml
@@ -74,6 +74,9 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
+
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -141,6 +144,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/px_csi_1.0.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_1.0.yaml
@@ -72,6 +72,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -138,6 +140,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -84,6 +84,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -155,6 +157,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
@@ -76,6 +76,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -130,6 +132,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: kvdbcerts
           secret:
             secretName: kvdb-auth-secret

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
@@ -75,6 +75,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -129,6 +131,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: kvdbcerts
           secret:
             secretName: kvdb-auth-secret

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
@@ -74,6 +74,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -136,6 +138,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: kvdbcerts
           secret:
             secretName: kvdb-auth-secret

--- a/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
@@ -72,6 +72,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -132,3 +134,6 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            

--- a/drivers/storage/portworx/testspec/px_master.yaml
+++ b/drivers/storage/portworx/testspec/px_master.yaml
@@ -86,6 +86,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -147,6 +149,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
+++ b/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
@@ -73,6 +73,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -133,6 +135,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /var/vcap/store/opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/vcap/store/lib/osd/driver            
         - name: registration-dir
           hostPath:
             path: /var/vcap/data/kubelet/plugins_registry

--- a/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
@@ -85,6 +85,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -162,6 +164,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -85,6 +85,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -162,6 +164,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/runc.yaml
+++ b/drivers/storage/portworx/testspec/runc.yaml
@@ -89,6 +89,8 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
+            - name: osddriver
+              mountPath: /var/lib/osd/driver
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -141,6 +143,9 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: osddriver
+          hostPath:
+            path: /var/lib/osd/driver            
         - name: registration-dir
           hostPath:
             path: /var/lib/kubelet/plugins


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
pxctl fails when running on oci-mon pod because Unix DS at `/var/lib/osd/driver/pwx-legacy.sock` is not available. Solution is to mount `/var/lib/osd' on the oci-mon pod.

Why not mount `/var/lib/osd/driver`? Because px-runc already mounts `/var/lib/osd` to the runc container and also mounts any mounts from oci-mon pod, causing illegal overlapping mounts. Adding `/var/lib/osd` to oci-mon is fine because px-runc de-dups them.
  See github.com/portworx/porx/cmd/px-runc/px-runc.go
```
                pxDefaultMounts = [][]string{
                        {"/dev", ""},
                        {"/var/lib/osd", "", "shared"},
```

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-19004

**Special notes for your reviewer**:
** This is dependent on https://github.com/portworx/px-installer/pull/998 merging before it can be merged **