### PR TITLE
[CSI] Install by default when Portworx is enabled

### DIFF
--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -82,6 +82,7 @@ func TestBasicRuncPodSpec(t *testing.T) {
 	}
 
 	driver := portworx{}
+
 	actual, err := driver.GetStoragePodSpec(cluster, nodeName)
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 
@@ -124,7 +125,7 @@ func TestPodSpecWithImagePullSecrets(t *testing.T) {
 
 	assert.Len(t, actual.ImagePullSecrets, 1)
 	assert.Equal(t, expectedPullSecret, actual.ImagePullSecrets[0])
-	assert.Len(t, actual.Containers[0].Env, 6)
+	assert.Len(t, actual.Containers[0].Env, 7)
 	var regConfigEnv *v1.EnvVar
 	var regSecretEnv *v1.EnvVar
 	for _, env := range actual.Containers[0].Env {
@@ -145,7 +146,7 @@ func TestPodSpecWithImagePullSecrets(t *testing.T) {
 
 	assert.Len(t, actual.ImagePullSecrets, 1)
 	assert.Equal(t, expectedPullSecret, actual.ImagePullSecrets[0])
-	assert.Len(t, actual.Containers[0].Env, 6)
+	assert.Len(t, actual.Containers[0].Env, 8)
 	regConfigEnv = nil
 	for _, env := range actual.Containers[0].Env {
 		if env.Name == "REGISTRY_CONFIG" {
@@ -2174,6 +2175,9 @@ func TestPodWithTelemetry(t *testing.T) {
 					Image:   "portworx/px-telemetry:2.1.2",
 				},
 			},
+			FeatureGates: map[string]string{
+				string(pxutil.FeatureCSI): "false",
+			},
 		},
 	}
 	driver := portworx{}
@@ -3261,7 +3265,7 @@ func TestIKSEnvVariables(t *testing.T) {
 	actual, err := driver.GetStoragePodSpec(cluster, nodeName)
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 
-	assert.Len(t, actual.Containers[0].Env, 5)
+	assert.Len(t, actual.Containers[0].Env, 7)
 	var podIPEnv *v1.EnvVar
 	for _, env := range actual.Containers[0].Env {
 		if env.Name == "PX_POD_IP" {
@@ -3276,7 +3280,7 @@ func TestIKSEnvVariables(t *testing.T) {
 	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 
-	assert.Len(t, actual.Containers[0].Env, 4)
+	assert.Len(t, actual.Containers[0].Env, 6)
 	podIPEnv = nil
 	for _, env := range actual.Containers[0].Env {
 		if env.Name == "PX_POD_IP" {

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -158,6 +158,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 				Enabled: true,
 			}
 		}
+
 		setPortworxDefaults(toUpdate)
 	}
 
@@ -211,7 +212,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			toUpdate.Status.DesiredImages.Telemetry = release.Components.Telemetry
 		}
 
-		if pxutil.FeatureCSI.IsEnabled(toUpdate.Spec.FeatureGates) &&
+		if pxutil.IsCSIEnabled(toUpdate) &&
 			(toUpdate.Status.DesiredImages.CSIProvisioner == "" ||
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
@@ -257,7 +258,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 		toUpdate.Status.DesiredImages.Telemetry = ""
 	}
 
-	if !pxutil.FeatureCSI.IsEnabled(toUpdate.Spec.FeatureGates) {
+	if !pxutil.IsCSIEnabled(toUpdate) {
 		toUpdate.Status.DesiredImages.CSIProvisioner = ""
 		toUpdate.Status.DesiredImages.CSINodeDriverRegistrar = ""
 		toUpdate.Status.DesiredImages.CSIDriverRegistrar = ""
@@ -566,14 +567,12 @@ func setPortworxDefaults(toUpdate *corev1.StorageCluster) {
 		}
 	}
 
-	if t.isK3s {
-		// Enable CSI if running in k3s environment
-		if _, ok := toUpdate.Spec.FeatureGates[string(pxutil.FeatureCSI)]; !ok {
-			if toUpdate.Spec.FeatureGates == nil {
-				toUpdate.Spec.FeatureGates = make(map[string]string)
-			}
-			toUpdate.Spec.FeatureGates[string(pxutil.FeatureCSI)] = "true"
+	// Enable CSI flag by default
+	if _, ok := toUpdate.Spec.FeatureGates[string(pxutil.FeatureCSI)]; !ok {
+		if toUpdate.Spec.FeatureGates == nil {
+			toUpdate.Spec.FeatureGates = make(map[string]string)
 		}
+		toUpdate.Spec.FeatureGates[string(pxutil.FeatureCSI)] = "true"
 	}
 
 	setSecuritySpecDefaults(toUpdate)
@@ -797,7 +796,7 @@ func hasLighthouseChanged(cluster *corev1.StorageCluster) bool {
 }
 
 func hasCSIChanged(cluster *corev1.StorageCluster) bool {
-	return pxutil.FeatureCSI.IsEnabled(cluster.Spec.FeatureGates) &&
+	return pxutil.IsCSIEnabled(cluster) &&
 		cluster.Status.DesiredImages.CSIProvisioner == ""
 }
 

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -845,16 +845,16 @@ func TestStorageClusterDefaultsForCSI(t *testing.T) {
 		},
 	}
 
-	// Don't enable CSI if not enabled
+	// Enable CSI by default
 	driver.SetDefaultsOnStorageCluster(cluster)
-	require.Empty(t, cluster.Status.DesiredImages.CSIProvisioner)
+	require.NotEmpty(t, cluster.Status.DesiredImages.CSIProvisioner)
 
 	// Enable CSI if running in k3s cluster
 	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{
 		GitVersion: "v1.18.4+k3s",
 	}
 	driver.SetDefaultsOnStorageCluster(cluster)
-	require.True(t, pxutil.FeatureCSI.IsEnabled(cluster.Spec.FeatureGates))
+	require.True(t, pxutil.IsCSIEnabled(cluster))
 	require.NotEmpty(t, cluster.Status.DesiredImages.CSIProvisioner)
 
 	// Use images from release manifest if enabled

--- a/drivers/storage/portworx/testspec/openshift_runc.yaml
+++ b/drivers/storage/portworx/testspec/openshift_runc.yaml
@@ -52,6 +52,8 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/lib/kubelet/csi-plugins/com.openstorage.pxd/csi.sock"
             - name: "PRE-EXEC"
               value: "if [ -f /etc/pwx/.private.json ] && [ -d /ostree/deploy/rhcos/deploy ]; then chattr -i /etc/pwx/.private.json /ostree/deploy/rhcos/deploy/*/etc/pwx/.private.json || /bin/true; fi"
           livenessProbe:
@@ -137,3 +139,11 @@ spec:
         - name: dbusmount
           hostPath:
             path: /var/run/dbus
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
+            type: DirectoryOrCreate

--- a/drivers/storage/portworx/testspec/pks.yaml
+++ b/drivers/storage/portworx/testspec/pks.yaml
@@ -50,6 +50,8 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/vcap/data/kubelet/csi-plugins/com.openstorage.pxd/csi.sock"
             - name: "PRE-EXEC"
               value: "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi"
           livenessProbe:
@@ -140,3 +142,11 @@ spec:
         - name: pxlogs
           hostPath:
             path: /var/vcap/store/lib/osd/log
+        - name: registration-dir
+          hostPath:
+            path: /var/vcap/data/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/vcap/data/kubelet/csi-plugins/com.openstorage.pxd
+            type: DirectoryOrCreate

--- a/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
@@ -31,6 +31,10 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/lib/kubelet/csi-plugins/com.openstorage.pxd/csi.sock"
+            - name: "PORTWORX_CSIVERSION"
+              value: "0.3"
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"
@@ -123,3 +127,11 @@ spec:
         - name: dbusmount
           hostPath:
             path: /var/run/dbus
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
+            type: DirectoryOrCreate

--- a/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
@@ -28,6 +28,10 @@ spec:
               value: "300"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/lib/kubelet/csi-plugins/com.openstorage.pxd/csi.sock"
+            - name: "PORTWORX_CSIVERSION"
+              value: "0.3"
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"
@@ -120,3 +124,11 @@ spec:
         - name: dbusmount
           hostPath:
             path: /var/run/dbus
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
+            type: DirectoryOrCreate

--- a/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
@@ -41,6 +41,10 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/lib/kubelet/csi-plugins/com.openstorage.pxd/csi.sock"
+            - name: "PORTWORX_CSIVERSION"
+              value: "0.3"
           livenessProbe:
             periodSeconds: 30
             initialDelaySeconds: 840 # allow image pull in slow networks
@@ -136,3 +140,11 @@ spec:
               path: kvdb-ca.crt
             - key: kvdb.key
               path: kvdb.key
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
+            type: DirectoryOrCreate

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
@@ -40,6 +40,10 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/lib/kubelet/csi-plugins/com.openstorage.pxd/csi.sock"
+            - name: "PORTWORX_CSIVERSION"
+              value: "0.3"
           livenessProbe:
             periodSeconds: 30
             initialDelaySeconds: 840 # allow image pull in slow networks
@@ -133,3 +137,11 @@ spec:
               path: kvdb.crt
             - key: kvdb.key
               path: kvdb.key
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
+            type: DirectoryOrCreate

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
@@ -39,6 +39,10 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/lib/kubelet/csi-plugins/com.openstorage.pxd/csi.sock"
+            - name: "PORTWORX_CSIVERSION"
+              value: "0.3"
           livenessProbe:
             periodSeconds: 30
             initialDelaySeconds: 840 # allow image pull in slow networks
@@ -103,6 +107,14 @@ spec:
           hostPath:
             path: /etc/crictl.yaml
             type: FileOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
+            type: DirectoryOrCreate
         - name: etcpwx
           hostPath:
             path: /etc/pwx

--- a/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
@@ -37,6 +37,10 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/lib/kubelet/csi-plugins/com.openstorage.pxd/csi.sock"
+            - name: "PORTWORX_CSIVERSION"
+              value: "0.3"
           livenessProbe:
             periodSeconds: 30
             initialDelaySeconds: 840 # allow image pull in slow networks
@@ -99,6 +103,14 @@ spec:
           hostPath:
             path: /etc/crictl.yaml
             type: FileOrCreate
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
+            type: DirectoryOrCreate
         - name: etcpwx
           hostPath:
             path: /etc/pwx

--- a/drivers/storage/portworx/testspec/px_master.yaml
+++ b/drivers/storage/portworx/testspec/px_master.yaml
@@ -51,6 +51,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/lib/kubelet/csi-plugins/pxd.portworx.com/csi.sock"
+            - name: "PORTWORX_CSIVERSION"
+              value: "0.3"
           livenessProbe:
             periodSeconds: 30
             initialDelaySeconds: 840 # allow image pull in slow networks
@@ -94,6 +98,27 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
+        - name: csi-node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.3
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=/var/lib/kubelet/csi-plugins/pxd.portworx.com/csi.sock"
+          imagePullPolicy: Always
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: csi-driver-path
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
       restartPolicy: Always
       tolerations:
         - key: node-role.kubernetes.io/master
@@ -137,3 +162,11 @@ spec:
         - name: dbusmount
           hostPath:
             path: /var/run/dbus
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/csi-plugins/pxd.portworx.com
+            type: DirectoryOrCreate

--- a/drivers/storage/portworx/testspec/runc.yaml
+++ b/drivers/storage/portworx/testspec/runc.yaml
@@ -54,6 +54,8 @@ spec:
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
+            - name: "CSI_ENDPOINT"
+              value: "unix:///var/lib/kubelet/csi-plugins/com.openstorage.pxd/csi.sock"
             - name: "TEST_KEY"
               value: "TEST_VALUE"
           livenessProbe:
@@ -139,3 +141,11 @@ spec:
         - name: optpwx
           hostPath:
             path: /opt/pwx
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
+            type: DirectoryOrCreate

--- a/drivers/storage/portworx/util/feature.go
+++ b/drivers/storage/portworx/util/feature.go
@@ -15,5 +15,5 @@ const (
 // IsEnabled checks if the feature is enabled in the given feature map
 func (feature Feature) IsEnabled(featureMap map[string]string) bool {
 	enabled, err := strconv.ParseBool(featureMap[string(feature)])
-	return err == nil && enabled
+	return err != nil || enabled
 }

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -199,8 +199,7 @@ const (
 	DefaultCASecretKey = "root-ca"
 
 	// EnvKeyPortworxEnableTLS is a flag for enabling operator TLS with PX
-	EnvKeyPortworxEnableTLS = "PX_ENABLE_TLS"
-	// EnvKeyPortworxEnforceTLS is a flag for enabling operator TLS with PX. TODO: temporary
+	EnvKeyPortworxEnableTLS  = "PX_ENABLE_TLS"
 	EnvKeyPortworxEnforceTLS = "PX_ENFORCE_TLS"
 )
 
@@ -214,6 +213,11 @@ var (
 func IsPortworxEnabled(cluster *corev1.StorageCluster) bool {
 	disabled, err := strconv.ParseBool(cluster.Annotations[constants.AnnotationDisableStorage])
 	return err != nil || !disabled
+}
+
+// IsCSIEnabled returns true if CSI is not disabled by the feature flag
+func IsCSIEnabled(cluster *corev1.StorageCluster) bool {
+	return IsPortworxEnabled(cluster) && FeatureCSI.IsEnabled(cluster.Spec.FeatureGates)
 }
 
 // IsPKS returns true if the annotation has a PKS annotation and is true value


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>

**What this PR does / why we need it**:
* Installs CSI by default unless explicitly disabled.
* Fixes many unit tests that assumed CSI was disabled by default.

**Which issue(s) this PR fixes** (optional)
n/a

**Special notes for your reviewer**:
n/a

