### PR TITLE
OPERATOR-256 Add subscription section to use appliance ID

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -135,6 +135,9 @@ func (t *telemetry) createConfigMap(
         "product_name": "portworx",
         "appliance_id_path": "/etc/pwx/cluster_uuid"
       },
+      "subscription": {
+        "use_appliance_id": "true",
+      },
       "proxy": {
         "path": "/dev/null"
       }

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -136,7 +136,7 @@ func (t *telemetry) createConfigMap(
         "appliance_id_path": "/etc/pwx/cluster_uuid"
       },
       "subscription": {
-        "use_appliance_id": "true",
+        "use_appliance_id": "true"
       },
       "proxy": {
         "path": "/dev/null"

--- a/drivers/storage/portworx/testspec/ccmconfig.yaml
+++ b/drivers/storage/portworx/testspec/ccmconfig.yaml
@@ -63,6 +63,9 @@ data:
             "product_name": "portworx",
             "appliance_id_path": "/etc/pwx/cluster_uuid"
           },
+          "subscription": {
+           "use_appliance_id": "true",
+          },
           "proxy": {
             "path": "/dev/null"
           }

--- a/drivers/storage/portworx/testspec/ccmconfig.yaml
+++ b/drivers/storage/portworx/testspec/ccmconfig.yaml
@@ -64,7 +64,7 @@ data:
             "appliance_id_path": "/etc/pwx/cluster_uuid"
           },
           "subscription": {
-           "use_appliance_id": "true",
+            "use_appliance_id": "true"
           },
           "proxy": {
             "path": "/dev/null"


### PR DESCRIPTION
Needed as per CCM change: https://jira.purestorage.com/browse/CLOUD-58502

This allows CCM to just use the appliance ID (cluster uuid for PX) for subscription
and does not require to specify it again in the spec

Signed-off-by: Harsh Desai <hadesai@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

