### PR TITLE
Operator 268 - Block installing portworx from StorageCluster when Por…

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -78,6 +78,29 @@ func TestInit(t *testing.T) {
 	require.Equal(t, k8sClient, driver.k8sClient)
 }
 
+func TestValidate(t *testing.T) {
+	driver := portworx{}
+	k8sClient := testutil.FakeK8sClient()
+	scheme := runtime.NewScheme()
+	recorder := record.NewFakeRecorder(0)
+
+	err := driver.Init(k8sClient, scheme, recorder)
+	require.NoError(t, err)
+
+	err = driver.Validate()
+	require.NoError(t, err)
+
+	// Create portworx daemonset
+	daemonSet := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "portworx",
+		},
+	}
+	k8sClient.Create(context.TODO(), &daemonSet)
+	err = driver.Validate()
+	require.NotNil(t, err)
+}
+
 func TestGetSelectorLabels(t *testing.T) {
 	driver := portworx{}
 	expectedLabels := map[string]string{"name": pxutil.DriverName}

--- a/drivers/storage/storage.go
+++ b/drivers/storage/storage.go
@@ -25,6 +25,8 @@ type UpdateDriverInfo struct {
 type Driver interface {
 	// Init initializes the storage driver
 	Init(client.Client, *runtime.Scheme, record.EventRecorder) error
+	// Validate validates if the driver is correctly configured
+	Validate() error
 	// String returns the string name of the driver
 	String() string
 	// UpdateDriver updates the driver with the current cluster and node conditions.

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
 	"testing"
@@ -499,21 +500,28 @@ func TestStorageClusterDefaultsWithDriverOverrides(t *testing.T) {
 
 // When DaemonSet is present (old installation method), the reconcile loop should not proceed with installation.
 func TestReconcileWithDaemonSet(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	recorder := record.NewFakeRecorder(10)
 	cluster := createStorageCluster()
 	daemonSet := appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: portworxDaemonSetName,
+			Name: "portworx",
 		},
 	}
 	daemonSetList := &appsv1.DaemonSetList{Items: []appsv1.DaemonSet{daemonSet}}
 
 	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+	driver := testutil.MockDriver(mockCtrl)
 	controller := Controller{
 		client:            testutil.FakeK8sClient(cluster, daemonSetList),
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
+		Driver:            driver,
 	}
+
+	driver.EXPECT().Validate().Return(fmt.Errorf("daemonset is present"))
 
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -570,6 +578,7 @@ func TestFailureDuringStorkInstallation(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorkDriverName().Return("mock", nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
@@ -615,6 +624,7 @@ func TestFailureDuringDriverPreInstall(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(fmt.Errorf("preinstall error"))
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
@@ -665,6 +675,7 @@ func TestStoragePodsShouldNotBeScheduledIfDisabled(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -736,6 +747,7 @@ func TestStoragePodGetsScheduled(t *testing.T) {
 		Spec: expectedPodSpec,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -806,6 +818,7 @@ func TestStorageNodeGetsCreated(t *testing.T) {
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 	storageLabels := map[string]string{"foo": "bar"}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(storageLabels).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -1117,6 +1130,7 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 		*expectedPodTemplate.DeepCopy(),
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -1226,6 +1240,7 @@ func TestFailedStoragePodsGetRemoved(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -1320,6 +1335,7 @@ func TestExtraStoragePodsGetRemoved(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -1439,6 +1455,7 @@ func TestStoragePodsAreRemovedIfDisabled(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -1519,6 +1536,7 @@ func TestStoragePodFailureDueToNodeSelectorNotMatch(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
@@ -1609,6 +1627,7 @@ func TestStoragePodSchedulingWithTolerations(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).Times(3)
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
@@ -1739,6 +1758,7 @@ func TestFailureDuringPodTemplateCreation(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
@@ -1766,6 +1786,7 @@ func TestFailureDuringPodTemplateCreation(t *testing.T) {
 	require.Contains(t, eventMsg, fmt.Sprintf("%v %v", v1.EventTypeWarning, util.FailedSyncReason))
 	require.Contains(t, eventMsg, "pod template error for k8s-node-1")
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	// When pod template creation passes for some and fails for others
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
@@ -1816,6 +1837,7 @@ func TestFailureDuringCreateDeletePods(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -1885,6 +1907,7 @@ func TestTimeoutFailureDuringCreatePods(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -1932,6 +1955,7 @@ func TestUpdateClusterStatusFromDriver(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -1982,6 +2006,7 @@ func TestUpdateClusterStatusErrorFromDriver(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -2034,6 +2059,7 @@ func TestFailedPreInstallFromDriver(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -2083,6 +2109,7 @@ func TestUpdateDriverWithInstanceInformation(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -2161,6 +2188,7 @@ func TestDeleteStorageClusterWithoutFinalizers(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 
@@ -2234,6 +2262,7 @@ func TestDeleteStorageClusterWithFinalizers(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	// Empty delete condition should not remove finalizer
 	driver.EXPECT().DeleteStorage(gomock.Any()).Return(nil, nil)
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
@@ -2378,6 +2407,7 @@ func TestDeleteStorageClusterShouldDeleteStork(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return("pxd").AnyTimes()
@@ -2501,6 +2531,7 @@ func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -2646,6 +2677,7 @@ func TestUpdateStorageClusterShouldNotExceedMaxUnavailable(t *testing.T) {
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -2840,6 +2872,7 @@ func TestUpdateStorageClusterWithPercentageMaxUnavailable(t *testing.T) {
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -2990,6 +3023,7 @@ func TestUpdateStorageClusterWithInvalidMaxUnavailableValue(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3047,6 +3081,7 @@ func TestUpdateStorageClusterWhenDriverReportsPodNotUpdated(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3110,6 +3145,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItDoesNotHaveAnyHash(t *testing.T
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3167,6 +3203,7 @@ func TestUpdateStorageClusterImagePullSecret(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3271,6 +3308,7 @@ func TestUpdateStorageClusterCustomImageRegistry(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3372,6 +3410,7 @@ func TestUpdateStorageClusterKvdbSpec(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3477,6 +3516,7 @@ func TestUpdateStorageClusterCloudStorageSpec(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3670,6 +3710,7 @@ func TestUpdateStorageClusterStorageSpec(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3824,6 +3865,7 @@ func TestUpdateStorageClusterNetworkSpec(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3908,6 +3950,7 @@ func TestUpdateStorageClusterEnvVariables(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -3994,6 +4037,7 @@ func TestUpdateStorageClusterRuntimeOptions(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -4077,6 +4121,7 @@ func TestUpdateStorageClusterVolumes(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -4298,6 +4343,7 @@ func TestUpdateStorageClusterSecretsProvider(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -4380,6 +4426,7 @@ func TestUpdateStorageClusterStartPort(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -4462,6 +4509,7 @@ func TestUpdateStorageClusterFeatureGates(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -4555,6 +4603,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -5013,6 +5062,7 @@ func TestUpdateStorageClusterK8sNodeChanges(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -5101,6 +5151,7 @@ func TestUpdateStorageClusterShouldNotRestartPodsForSomeOptions(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -5245,6 +5296,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItsHistoryHasInvalidSpec(t *testi
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -5323,6 +5375,7 @@ func TestUpdateStorageClusterSecurity(t *testing.T) {
 		kubernetesVersion: k8sVersion,
 	}
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -5621,6 +5674,7 @@ func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -5769,6 +5823,7 @@ func TestUpdateClusterShouldHandleHashCollisions(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	operatorops.SetInstance(operatorops.New(fakeClient))
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -5922,6 +5977,7 @@ func TestUpdateClusterShouldDedupRevisionsAnywhereInHistory(t *testing.T) {
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -6065,6 +6121,7 @@ func TestHistoryCleanup(t *testing.T) {
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -6432,6 +6489,7 @@ func TestDoesTelemetryMatch(t *testing.T) {
 			kubernetesVersion: k8sVersion,
 		}
 
+		driver.EXPECT().Validate().Return(nil).AnyTimes()
 		driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 		driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 		driver.EXPECT().String().Return(driverName).AnyTimes()

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -77,6 +77,8 @@ const (
 	crdBasePath                         = "/crds"
 	storageClusterCRDFile               = "core_v1_storagecluster_crd.yaml"
 	minSupportedK8sVersion              = "1.12.0"
+	// portworxDaemonSetName is the name of DaemonSet when portworx is installed by DaemonSet.
+	portworxDaemonSetName = "portworx"
 )
 
 var _ reconcile.Reconciler = &Controller{}
@@ -308,6 +310,22 @@ func (c *Controller) RegisterCRD() error {
 	return nil
 }
 
+func (c *Controller) isDaemonSetPresent(name string) (bool, error) {
+	daemonSetList := &apps.DaemonSetList{}
+	if err := c.client.List(context.TODO(), daemonSetList, &client.ListOptions{}); err != nil {
+		logrus.Errorf("Failed to list DaemonSet: %v", err)
+		return false, err
+	}
+
+	for _, daemonSet := range daemonSetList.Items {
+		if daemonSet.Name == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 func (c *Controller) syncStorageCluster(
 	cluster *corev1.StorageCluster,
 ) error {
@@ -315,6 +333,19 @@ func (c *Controller) syncStorageCluster(
 		logrus.Infof("Storage cluster %v/%v has been marked for deletion",
 			cluster.Namespace, cluster.Name)
 		return c.deleteStorageCluster(cluster)
+	}
+
+	// If portworx has been installed by daemonset, before it's uninstalled, operator
+	// should not proceed with installation.
+	if exists, err := c.isDaemonSetPresent(portworxDaemonSetName); err != nil || exists {
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			return fmt.Errorf("daemonset %s exists, please delete it first. Operator will not proceed with installation",
+				portworxDaemonSetName)
+		}
 	}
 
 	// Set defaults in the storage cluster object if not set

--- a/pkg/mock/storagedriver.mock.go
+++ b/pkg/mock/storagedriver.mock.go
@@ -141,6 +141,20 @@ func (mr *MockDriverMockRecorder) Init(arg0, arg1, arg2 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockDriver)(nil).Init), arg0, arg1, arg2)
 }
 
+// Validate mocks driver validation.
+func (m *MockDriver) Validate() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Validate")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Validate indicates an expected call of Validate.
+func (mr *MockDriverMockRecorder) Validate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockDriver)(nil).Validate))
+}
+
 // IsPodUpdated mocks base method.
 func (m *MockDriver) IsPodUpdated(arg0 *v1.StorageCluster, arg1 *v10.Pod) bool {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
…tworx Daemonset is present

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fix https://portworx.atlassian.net/browse/OPERATOR-268?src=confmacro

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
The installation is blocked, and you will see a k8s event attached to StorageCluster object, also visible in operator log.

Events:
  Type     Reason      Age               From                       Message
  ----     ------      ----              ----                       -------
  Warning  FailedSync  7s (x16 over 1m)  storagecluster-controller  daemonset portworx exists, please delete it first. Operator will not proceed with installation
