### PR TITLE
Remove github_api_url from labeler action

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -28,4 +28,3 @@ jobs:
             'This PR exceeds the recommended size of 1000 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.’
-          github_api_url: 'api.github.com'


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes github_api_url variable - seems like this action was either misconfigured or they removed this variable.

Has no effect other than removing a warning from the logs.

**Which issue(s) this PR fixes** (optional)
n/a

**Special notes for your reviewer**:
n/a
