### PR TITLE
[cherry-pick] Operator 268 - Block installing portworx from StorageCluster when Por…

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -77,6 +77,29 @@ func TestInit(t *testing.T) {
 	require.Equal(t, k8sClient, driver.k8sClient)
 }
 
+func TestValidate(t *testing.T) {
+	driver := portworx{}
+	k8sClient := testutil.FakeK8sClient()
+	scheme := runtime.NewScheme()
+	recorder := record.NewFakeRecorder(0)
+
+	err := driver.Init(k8sClient, scheme, recorder)
+	require.NoError(t, err)
+
+	err = driver.Validate()
+	require.NoError(t, err)
+
+	// Create portworx daemonset
+	daemonSet := appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "portworx",
+		},
+	}
+	k8sClient.Create(context.TODO(), &daemonSet)
+	err = driver.Validate()
+	require.NotNil(t, err)
+}
+
 func TestGetSelectorLabels(t *testing.T) {
 	driver := portworx{}
 	expectedLabels := map[string]string{"name": pxutil.DriverName}

--- a/drivers/storage/storage.go
+++ b/drivers/storage/storage.go
@@ -25,6 +25,8 @@ type UpdateDriverInfo struct {
 type Driver interface {
 	// Init initializes the storage driver
 	Init(client.Client, *runtime.Scheme, record.EventRecorder) error
+	// Validate validates if the driver is correctly configured
+	Validate() error
 	// String returns the string name of the driver
 	String() string
 	// UpdateDriver updates the driver with the current cluster and node conditions.

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -221,6 +221,9 @@ func (c *Controller) validate(cluster *corev1.StorageCluster) error {
 	if err := c.validateSingleCluster(cluster); err != nil {
 		return err
 	}
+	if err := c.Driver.Validate(); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/mock/storagedriver.mock.go
+++ b/pkg/mock/storagedriver.mock.go
@@ -141,6 +141,20 @@ func (mr *MockDriverMockRecorder) Init(arg0, arg1, arg2 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockDriver)(nil).Init), arg0, arg1, arg2)
 }
 
+// Validate mocks driver validation.
+func (m *MockDriver) Validate() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Validate")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Validate indicates an expected call of Validate.
+func (mr *MockDriverMockRecorder) Validate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockDriver)(nil).Validate))
+}
+
 // IsPodUpdated mocks base method.
 func (m *MockDriver) IsPodUpdated(arg0 *v1.StorageCluster, arg1 *v10.Pod) bool {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
…… (#295)

* add unit test

* Operator 268 - Block installing portworx from StorageCluster when Portworx Daemonset is present

* Move DaemonSet validation to portworx driver

Co-authored-by: root <root@d676eba9a356>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

