### PR TITLE
OPERATOR-305: Add memory limits and requests (#316)

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -565,6 +566,14 @@ func (t *template) telemetryContainer() *v1.Container {
 			t.getDesiredTelemetryImage(t.cluster),
 		),
 		ImagePullPolicy: t.imagePullPolicy,
+		Resources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			Limits: v1.ResourceList{
+				v1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
 		Env: []v1.EnvVar{
 			{
 				Name:  "configFile",

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -114,6 +114,11 @@ spec:
               path: /1.0/status
               port: 1970
           name: telemetry
+          resources:
+            requests:
+              memory: "256Mi"
+            limits:
+              memory: "512Mi"
           readinessProbe:
             httpGet:
               host: 127.0.0.1


### PR DESCRIPTION
Signed-off-by: Paul Theunis <ptheunis@purestorage.com>

Co-authored-by: Paul Theunis <ptheunis@purestorage.com>

Cherry-pick from 1.5.0  master image doesn't work for me with 2.8 so development happened on 1.5.0

**What this PR does / why we need it**:
Adds limits to the memory of the container


