### PR TITLE
[CSI] Update CSIDriver to v1 for k8s 1.18+

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -4457,9 +4457,10 @@ func TestCSIInstallWithk8s1_20(t *testing.T) {
 	require.Equal(t, expectedDeployment.Spec, deployment.Spec)
 
 	// CSIDriver object should be created for k8s 1.20
-	csiDriver := &storagev1beta1.CSIDriver{}
+	csiDriver := &storagev1.CSIDriver{}
 	err = testutil.Get(k8sClient, csiDriver, pxutil.CSIDriverName, "")
 	require.False(t, errors.IsNotFound(err))
+	require.Equal(t, "storage.k8s.io/v1", csiDriver.TypeMeta.APIVersion)
 	err = testutil.Get(k8sClient, csiDriver, pxutil.DeprecatedCSIDriverName, "")
 	require.True(t, errors.IsNotFound(err))
 }
@@ -4495,15 +4496,15 @@ func TestCSIInstallEphemeralWithK8s1_20VersionAndPX2_5(t *testing.T) {
 	err := driver.PreInstall(cluster)
 	require.NoError(t, err)
 
-	csiDriver := &storagev1beta1.CSIDriver{}
+	csiDriver := &storagev1.CSIDriver{}
 	err = testutil.Get(k8sClient, csiDriver, pxutil.CSIDriverName, "")
 	require.NoError(t, err)
 	require.Empty(t, csiDriver.OwnerReferences)
 	require.False(t, *csiDriver.Spec.AttachRequired)
 	require.True(t, *csiDriver.Spec.PodInfoOnMount)
 	require.Equal(t, len(csiDriver.Spec.VolumeLifecycleModes), 2)
-	require.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1beta1.VolumeLifecyclePersistent)
-	require.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1beta1.VolumeLifecycleEphemeral)
+	require.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecyclePersistent)
+	require.Contains(t, csiDriver.Spec.VolumeLifecycleModes, storagev1.VolumeLifecycleEphemeral)
 
 	expectedDeployment := testutil.GetExpectedDeployment(t, "csiDeployment_1.0_k8s120.yaml")
 	deployment := &appsv1.Deployment{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates CSIDriver object to v1 for k8s 1.18+. The CSI Driver object is v1 for k8s 1.18+:
https://kubernetes-csi.github.io/docs/csi-driver-object.html

In future k8s versions, v1beta1 CSI driver will be removed. 

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
I've tested this change on K8s 1.17 and 1.20. Specifically, I've tested the upgrade path from operator 1.4.5 to my dev image with this change.

I've also delete and re-recreated the CSIDriver object to make sure the right CSIDriver object version is created.