### PR TITLE
OPERATOR-349 AKS crash due to port conflict

### DIFF
--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -40,8 +40,12 @@ const (
 	defaultPVCControllerCPU = "200m"
 
 	defaultPVCControllerInsecurePort = "10252"
-	aksPVCControllerInsecurePort     = "10260"
-	aksPVCControllerSecurePort       = "10261"
+
+	// AksPVCControllerInsecurePort is the PVC controller port and health check port, due to the default port
+	// is already used on AKS we use different port for AKS.
+	AksPVCControllerInsecurePort = "10260"
+	// AksPVCControllerSecurePort is the PVC controller secure port.
+	AksPVCControllerSecurePort = "10261"
 )
 
 type pvcController struct {
@@ -297,13 +301,13 @@ func (c *pvcController) createDeployment(
 	if port, ok := cluster.Annotations[pxutil.AnnotationPVCControllerPort]; ok && port != "" {
 		command = append(command, "--port="+port)
 	} else if pxutil.IsAKS(cluster) {
-		command = append(command, "--port="+aksPVCControllerInsecurePort)
+		command = append(command, "--port="+AksPVCControllerInsecurePort)
 	}
 
 	if securePort, ok := cluster.Annotations[pxutil.AnnotationPVCControllerSecurePort]; ok && securePort != "" {
 		command = append(command, "--secure-port="+securePort)
 	} else if pxutil.IsAKS(cluster) {
-		command = append(command, "--secure-port="+aksPVCControllerSecurePort)
+		command = append(command, "--secure-port="+AksPVCControllerSecurePort)
 	}
 
 	existingDeployment := &appsv1.Deployment{}
@@ -362,7 +366,7 @@ func getPVCControllerDeploymentSpec(
 	if port, ok := cluster.Annotations[pxutil.AnnotationPVCControllerPort]; ok && port != "" {
 		healthCheckPort = port
 	} else if pxutil.IsAKS(cluster) {
-		healthCheckPort = aksPVCControllerInsecurePort
+		healthCheckPort = AksPVCControllerInsecurePort
 	}
 
 	labels := map[string]string{

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakek8sclient "k8s.io/client-go/kubernetes/fake"
@@ -1377,7 +1378,16 @@ func TestPVCControllerInstallForAKS(t *testing.T) {
 	require.NoError(t, err)
 
 	verifyPVCControllerInstall(t, cluster, k8sClient)
-	verifyPVCControllerDeployment(t, cluster, k8sClient, "pvcControllerDeployment.yaml")
+
+	specFileName := "pvcControllerDeployment.yaml"
+	pvcControllerDeployment := testutil.GetExpectedDeployment(t, specFileName)
+	command := pvcControllerDeployment.Spec.Template.Spec.Containers[0].Command
+	command = append(command, "--port="+component.AksPVCControllerInsecurePort)
+	command = append(command, "--secure-port="+component.AksPVCControllerSecurePort)
+	pvcControllerDeployment.Spec.Template.Spec.Containers[0].Command = command
+	pvcControllerDeployment.Spec.Template.Spec.Containers[0].LivenessProbe.Handler.HTTPGet.Port = intstr.Parse(component.AksPVCControllerInsecurePort)
+
+	verifyPVCControllerDeploymentObject(t, cluster, k8sClient, pvcControllerDeployment)
 
 	// Despite invalid pvc controller annotation, install for AKS
 	cluster.Annotations[pxutil.AnnotationPVCController] = "invalid"
@@ -1386,7 +1396,7 @@ func TestPVCControllerInstallForAKS(t *testing.T) {
 	require.NoError(t, err)
 
 	verifyPVCControllerInstall(t, cluster, k8sClient)
-	verifyPVCControllerDeployment(t, cluster, k8sClient, "pvcControllerDeployment.yaml")
+	verifyPVCControllerDeploymentObject(t, cluster, k8sClient, pvcControllerDeployment)
 }
 
 func TestPVCControllerWhenPVCControllerDisabledExplicitly(t *testing.T) {
@@ -1528,13 +1538,25 @@ func verifyPVCControllerDeployment(
 	k8sClient client.Client,
 	specFileName string,
 ) {
+	verifyPVCControllerDeploymentObject(
+		t, cluster,
+		k8sClient,
+		testutil.GetExpectedDeployment(t, specFileName))
+
+}
+
+func verifyPVCControllerDeploymentObject(
+	t *testing.T,
+	cluster *corev1.StorageCluster,
+	k8sClient client.Client,
+	expectedDeployment *appsv1.Deployment,
+) {
 	// PVC Controller Deployment
 	deploymentList := &appsv1.DeploymentList{}
 	err := testutil.List(k8sClient, deploymentList)
 	require.NoError(t, err)
 	require.Len(t, deploymentList.Items, 1)
 
-	expectedDeployment := testutil.GetExpectedDeployment(t, specFileName)
 	actualDeployment := deploymentList.Items[0]
 	require.Equal(t, expectedDeployment.Name, actualDeployment.Name)
 	require.Equal(t, expectedDeployment.Namespace, actualDeployment.Namespace)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
https://portworx.atlassian.net/browse/OPERATOR-349

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
use different port for aks so customers do not need to configure it in storagecluster.
