### PR TITLE
OPERATOR-262 fix to not add -cloud_provider parameter for px version …

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -769,9 +769,13 @@ func (t *template) getArguments() []string {
 		}
 
 	} else if t.cluster.Spec.CloudStorage != nil {
-		cloudProvider := t.getCloudProvider()
-		if len(cloudProvider) > 0 {
-			args = append(args, "-cloud_provider", cloudProvider)
+		pxVer, _ := version.NewVersion("2.8")
+		// Cloud provider parameter was added in newer version.
+		if t.pxVersion.GreaterThanOrEqual(pxVer) {
+			cloudProvider := t.getCloudProvider()
+			if len(cloudProvider) > 0 {
+				args = append(args, "-cloud_provider", cloudProvider)
+			}
 		}
 
 		if t.cloudConfig != nil && len(t.cloudConfig.CloudStorage) > 0 {

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -1310,12 +1310,18 @@ func TestPodSpecWithCloudStorageSpec(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error on GetStorageNodeList")
 	assert.Equal(t, 1, len(list), "expected storage nodes in list")
 
-	// Test cloud provider is provided
+	// Test cloud provider is provided, px version is less than 2.8.0, cloud provider parameter should not be specified.
+	cluster.Spec.Image = "portworx/oci-monitor:2.7.0"
 	cloudProvider := "AWS"
-	argsWithCloudProvider := append(expectedArgs, "-cloud_provider", cloudProvider)
 	cluster.Spec.CloudStorage.Provider = &cloudProvider
 	actual, _ = driver.GetStoragePodSpec(cluster, nodeName)
-	assert.ElementsMatch(t, argsWithCloudProvider, actual.Containers[0].Args)
+	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
+
+	// Test cloud provider is provided, px version is 2.8.0, cloud provider parameter should be specified.
+	cluster.Spec.Image = "portworx/oci-monitor:2.8.0"
+	expectedArgs = append(expectedArgs, "-cloud_provider", cloudProvider)
+	actual, _ = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
 
 	cluster.Spec.CloudStorage.Provider = nil
 }


### PR DESCRIPTION
…less than 2.8

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
-cloud_provider parameter does not exist before px 2.8.0, we should not add the parameter in this case

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

