### PR TITLE
CLOUD-59607 restrict server core pool size to 2

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -610,10 +610,11 @@ func (t *template) telemetryContainer() *v1.Container {
 		VolumeMounts: t.mountsFromVolInfo(t.getTelemetryVolumeInfoList()),
 	}
 
+	container.Args = []string{
+		"-Dserver.rest_server.core_pool_size=2",
+	}
 	if len(t.nodeName) > 0 {
-		container.Args = []string{
-			fmt.Sprintf("-Dstandalone.controller_sn=%s", t.nodeName),
-		}
+		container.Args = append(container.Args, fmt.Sprintf("-Dstandalone.controller_sn=%s", t.nodeName))
 	}
 	return &container
 }

--- a/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
@@ -107,6 +107,7 @@ spec:
           image: portworx/px-telemetry:2.1.2
           imagePullPolicy: Always
           args:
+            - "-Dserver.rest_server.core_pool_size=2"
             - "-Dstandalone.controller_sn=testNode"
           livenessProbe:
             periodSeconds: 30

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -107,6 +107,7 @@ spec:
           image: portworx/px-telemetry:2.1.2
           imagePullPolicy: Always
           args:
+            - "-Dserver.rest_server.core_pool_size=2"
             - "-Dstandalone.controller_sn=testNode"
           livenessProbe:
             periodSeconds: 30


### PR DESCRIPTION
Per Brian Pan, the default is 8 but 2 should suffice and it reduces memory usage by 40MB

Pasting slack thread

```
bpan There will be 2 changes you should make on your side:
Add an environment variable export controller_sn=123
Add a parameter to the docker run command: -Dserver.rest_server.core_pool_size=2


11:54 AM
-Dserver.rest_server.core_pool_size=2 reduces the resources used for listening on 1970.
11:56 AM
Harsh Desai 
export controller_sn=123
yup, we already did this and it works great !
Add a parameter to the docker run command: -Dserver.rest_server.core_pool_size=2
didn't know about that. let me do that today.
11:56 AM
reduces the resources used for listening on 1970.
by how much?
11:59 AM
bpan Pool defaults to 8 which is what is used for FA. I saw 2 saving up to 40MB.
12:01 PM
In all I saw 300MB->220MB, although sometimes I saw the memory higher.
```

Signed-off-by: Harsh Desai <hadesai@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

