### PR TITLE
[cherry-pick] CLOUD-59607 restrict server core pool size to 2 (#332)

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -608,10 +608,11 @@ func (t *template) telemetryContainer() *v1.Container {
 		VolumeMounts: t.mountsFromVolInfo(t.getTelemetryVolumeInfoList()),
 	}
 
+	container.Args = []string{
+		"-Dserver.rest_server.core_pool_size=2",
+	}
 	if len(t.nodeName) > 0 {
-		container.Args = []string{
-			fmt.Sprintf("-Dstandalone.controller_sn=%s", t.nodeName),
-		}
+		container.Args = append(container.Args, fmt.Sprintf("-Dstandalone.controller_sn=%s", t.nodeName))
 	}
 	return &container
 }

--- a/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
@@ -105,6 +105,7 @@ spec:
           image: portworx/px-telemetry:2.1.2
           imagePullPolicy: Always
           args:
+            - "-Dserver.rest_server.core_pool_size=2"
             - "-Dstandalone.controller_sn=testNode"
           livenessProbe:
             periodSeconds: 30

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -105,6 +105,7 @@ spec:
           image: portworx/px-telemetry:2.1.2
           imagePullPolicy: Always
           args:
+            - "-Dserver.rest_server.core_pool_size=2"
             - "-Dstandalone.controller_sn=testNode"
           livenessProbe:
             periodSeconds: 30


### PR DESCRIPTION
Per Brian Pan, the default is 8 but 2 should suffice and it reduces memory usage by 40MB

Signed-off-by: Harsh Desai <hadesai@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

