### PR TITLE
PWX-20490 default to external location for arcus

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -151,6 +151,8 @@ func (t *telemetry) createConfigMap(
 
 	if location, present := cluster.Annotations[pxutil.AnnotationTelemetryArcusLocation]; present && len(location) > 0 {
 		data[TelemetryArcusLocationFilename] = location
+	} else {
+		data[TelemetryArcusLocationFilename] = "external"
 	}
 
 	return k8sutil.CreateOrUpdateConfigMap(

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -10241,7 +10241,7 @@ func TestTelemetryEnable(t *testing.T) {
 
 	// without location
 	delete(cluster.Annotations, "portworx.io/arcus-location")
-	delete(expectedConfigMap.Data, "location")
+	expectedConfigMap.Data["location"] = "external"
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Signed-off-by: Harsh Desai <hadesai@purestorage.com>

Slack thread

```

11:30 AM
I am seeing an issue where after removing all staging config, on a fresh install, CCM is still talking to staging arcus
11:30 AM
what is the default?
12:39 PM
Harsh Desai 
2021-06-09 19:38:54.851 [taskScheduler-2] ERROR com.purestorage.core.transport.HttpClient Received error response from <REDACTED>. Status code: 400, request_uuid: 692d835c-f02e-48a4-81a0-c06c6bdda9b8.
12:40 PM
 But you can try changing CCM to ‘external’.
Is this required? I was assuming that if location is not specified, the default would be external
1:51 PM
bpan If the array_loc is set, CCM will use it. If it’s not set, CCM will try a DNS lookup to preflight-rest.purestorage.com. In our VPN, that DNS resolves to 127.0.0.1 so CCM will cache ‘internal’ in array_loc. If the DNS doesn’t resolve, CCM will cache ‘external’ in array_loc.
1:52 PM
"cloud": {
  "internal_only_hostname": "<REDACTED>,
  "internal_only_ip": "127.0.0.1",
  "array_loc_file_path": "/cache/network/array_loc",
^ You could also test by changing these properties.
1:53 PM
If the ‘internal’ hostname doesn’t resolve to the ‘internal’ IP, CCM will assume production.
1:53 PM
Don’t forget to delete certs moving between Staging/Prod.
1:55 PM
Harsh Desai I am thinking of explicitly setting the location as internal or external instead of enabling any auto-detection logic
1:56 PM
bpan Sounds good
1:58 PM
Harsh Desai the preflight check caused one of our test folks to file a bug thinking something is wrong.. trying to reduce all red herrings
https://portworx.atlassian.net/browse/PWX-20490
2:20 PM
bpan Yup, once in a while a customer somehow has a DNS that resolves preflight-rest. So making it deterministic is a good thing.
```

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

