### PR TITLE
PWX-20544-pt2 / OPERATOR-362: BottleRocket v1.1.1 support

### DIFF
--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2180,6 +2180,20 @@ func TestPodSpecForBottleRocketAMI(t *testing.T) {
 		Name:      "containerd-br",
 		MountPath: "/run/containerd/containerd.sock",
 	})
+
+	// double-check permissions
+	expectedCapabilities := []v1.Capability{
+		"SYS_ADMIN", "SYS_PTRACE", "SYS_RAWIO", "SYS_MODULE", "LINUX_IMMUTABLE",
+	}
+	require.NotNil(t, actual.Containers[0].SecurityContext.Privileged)
+	assert.False(t, *actual.Containers[0].SecurityContext.Privileged)
+
+	require.NotNil(t, actual.Containers[0].SecurityContext.Capabilities)
+	assert.ElementsMatch(t, expectedCapabilities, actual.Containers[0].SecurityContext.Capabilities.Add)
+
+	require.NotNil(t, actual.SecurityContext)
+	require.NotNil(t, actual.SecurityContext.SELinuxOptions)
+	assert.Equal(t, "super_t", actual.SecurityContext.SELinuxOptions.Type)
 }
 
 func TestPodWithTelemetry(t *testing.T) {


### PR DESCRIPTION
Fixing security settings for BottleRocket AMI deployments:
* replaced "privileged" flag with specific capabilities
* activating `super_t` SELinux type

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Have to use slightly different security for BottleRocket v1.1.1:
* explicitly setting SELInux context, to activate `super_t` SELinux type
* using `prvileged: true` will strip the `super_t` SELinux type, so have to use capabilities instead

**Which issue(s) this PR fixes** (optional)
Closes # PWX-20544 , OPERATOR-362

**Special notes for your reviewer**:
Note that one still needs the pvc-controller to run on BottleRocket AMI, e.g.
```
metadata:
  annotations:
    portworx.io/pvc-controller: "true"
```

However, the determination if PVC-controller is needed seems to be ran long before we get Node's MetaData, and detect the BottleRocket OS.