### PR TITLE
PWX-20585 disable scheduled log uploader

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -83,7 +83,7 @@ func (t *telemetry) createConfigMap(
          "cert_store": "k8s",
          "config_reload": "file",
          "env_info": "file",
-         "scheduled_log_uploader":"enabled",
+         "scheduled_log_uploader":"disabled",
          "upload": "enabled"
        },
       "cert": {

--- a/drivers/storage/portworx/testspec/ccmconfig.yaml
+++ b/drivers/storage/portworx/testspec/ccmconfig.yaml
@@ -11,7 +11,7 @@ data:
              "cert_store": "k8s",
              "config_reload": "file",
              "env_info": "file",
-             "scheduled_log_uploader":"enabled",
+             "scheduled_log_uploader":"disabled",
              "upload": "enabled"
            },
           "cert": {


### PR DESCRIPTION
For 2.8.0, we only support on-demand and on-crash. No scheduled cadence

Signed-off-by: Harsh Desai <hadesai@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

