### PR TITLE
Avoid updating CSI driver object repeatedly

### DIFF
--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -610,6 +610,9 @@ func CreateOrUpdateCSIDriver(
 		return err
 	}
 
+	// Copy the fsGroupPolicy as it is automatically populated by k8s
+	driver.Spec.FSGroupPolicy = existingDriver.Spec.FSGroupPolicy
+
 	// Cluster scoped objects should not have owner references
 	if !reflect.DeepEqual(driver.Spec, existingDriver.Spec) ||
 		len(existingDriver.OwnerReferences) > 0 {


### PR DESCRIPTION
Our input object does not set the fs group policy but
k8s will set it on the object. This fails the diff check
we use to decide whether to call the update or not.

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

