### PR TITLE
Adding 'Create StorageCluster' button on operator creation in openshift UI

### DIFF
--- a/deploy/olm-catalog/portworx/1.6.0/portworxoperator.v1.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/1.6.0/portworxoperator.v1.6.0.clusterserviceversion.yaml
@@ -12,6 +12,17 @@ metadata:
     createdAt: 2021-09-22T08:00:00Z
     support: Portworx, Inc
     certified: "true"
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "core.libopenstorage.org/v1",
+        "kind": "StorageCluster",
+        "metadata": {
+          "name": "portworx",
+          "annotations": {
+            "portworx.io/is-openshift": "true"
+          }
+        }
+      }
     alm-examples: |-
       [
         {
@@ -23,19 +34,6 @@ metadata:
             "annotations": {
               "portworx.io/is-openshift": "true"
             }
-          },
-          "spec": {
-            "autopilot": {
-              "enabled": false
-            }
-          }
-        },
-        {
-          "apiVersion": "core.libopenstorage.org/v1",
-          "kind": "StorageNode",
-          "metadata": {
-            "name": "example",
-            "namespace": "test-operator"
           }
         }
       ]

--- a/deploy/olm-catalog/portworx/2.0.0/portworxoperator.v2.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/2.0.0/portworxoperator.v2.0.0.clusterserviceversion.yaml
@@ -12,6 +12,17 @@ metadata:
     createdAt: 2020-04-22T08:00:00Z
     support: Portworx, Inc
     certified: "true"
+    operatorframework.io/initialization-resource: |-
+      {
+        "apiVersion": "core.libopenstorage.org/v1",
+        "kind": "StorageCluster",
+        "metadata": {
+          "name": "portworx",
+          "annotations": {
+            "portworx.io/is-openshift": "true"
+          }
+        }
+      }
     alm-examples: |-
       [
         {
@@ -23,19 +34,6 @@ metadata:
             "annotations": {
               "portworx.io/is-openshift": "true"
             }
-          },
-          "spec": {
-            "autopilot": {
-              "enabled": false
-            }
-          }
-        },
-        {
-          "apiVersion": "core.libopenstorage.org/v1",
-          "kind": "StorageNode",
-          "metadata": {
-            "name": "example",
-            "namespace": "test-operator"
           }
         }
       ]
@@ -381,6 +379,11 @@ spec:
       - description: Node pool label.
         displayName: Node pool label
         path: cloudStorage.nodePoolLabel
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:hidden'
+      - description: Cloud provider
+        displayName: Cloud provider
+        path: cloudStorage.provider
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:hidden'
       - description: The network configuration used by storage nodes


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- After this, openshift UI shows a 'Create StorageCluster' button immediately after operator installation is complete. This will directly take the user to portworx cluster creation.
- Remove the autopilot disabling section as it is not longer needed.
- Making the 2.0.0 CSV similar to the 1.6.0

![image](https://user-images.githubusercontent.com/313758/130271231-a87e0007-41e4-4bb6-929b-055e45c7a8f3.png)

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-418](https://portworx.atlassian.net/browse/OPERATOR-418)

**Special notes for your reviewer**:

