### PR TITLE
OPERATOR-439: Adding RKE2 support

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1624,7 +1624,7 @@ func getDefaultVolumeInfoList() []volumeInfo {
 
 func isK3sCluster(ext string) bool {
 	if len(ext) > 0 {
-		return strings.HasPrefix(ext[1:], "k3s")
+		return strings.HasPrefix(ext[1:], "k3s") || strings.HasPrefix(ext[1:], "rke2")
 	}
 	return false
 }

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2120,6 +2120,15 @@ func TestPodSpecForK3s(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 
 	assertPodSpecEqual(t, expected, &actual)
+
+	// retry w/ RKE2 version identifier0 -- should also default to K3s distro tweaks
+	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.21.4+rke2r2",
+	}
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+
+	assertPodSpecEqual(t, expected, &actual)
 }
 
 func TestPodSpecForBottleRocketAMI(t *testing.T) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

**What this PR does / why we need it**:
This PR adds the automatic support for RKE2 clusters
* the latest Rancher RKE2 has switched to using K3s distribution
* based on the K8s version (e.g. `1.21.4+rke2r2`), we will automatically add the K3s mounts and turn on the CSI support -- same as we do w/ our K3s installs

**Which issue(s) this PR fixes** (optional)
Closes # OPERATOR-439

**Special notes for your reviewer**:
Parallel fix for YAML generator @ https://github.com/portworx/px-installer/pull/1119

**Testing notes**:
Using hybrid RKE2 cluster (different host-types):
```
# kubectl get nodes -o wide

NAME    STATUS   ROLES                       AGE   VERSION          INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                KERNEL-VERSION                CONTAINER-RUNTIME
rke21   Ready    control-plane,etcd,master   12h   v1.21.4+rke2r2   70.0.91.200   <none>        Ubuntu 16.04.7 LTS      4.4.0-210-generic             containerd://1.4.8-k3s1
rke22   Ready    <none>                      12h   v1.21.4+rke2r2   70.0.91.199   <none>        Ubuntu 20.04.2 LTS      5.4.0-74-generic              containerd://1.4.8-k3s1
rke23   Ready    <none>                      12h   v1.21.4+rke2r2   70.0.91.197   <none>        CentOS Linux 7 (Core)   3.10.0-1127.el7.x86_64        containerd://1.4.8-k3s1
rke24   Ready    <none>                      12h   v1.21.4+rke2r2   70.0.91.196   <none>        CentOS Linux 8          4.18.0-240.1.1.el8_3.x86_64   containerd://1.4.8-k3s1
```
Portworx now installs correctly:
```
# kubectl get pods -o wide -A --sort-by='{.spec.nodeName}' -l 'name in (portworx,portworx-operator)' 

NAMESPACE     NAME                                  READY   STATUS    RESTARTS   AGE     IP            NODE    NOMINATED NODE   READINESS GATES
kube-system   portworx-operator-7f9d5cd764-vvh7r    1/1     Running   0          3h57m   10.42.1.8     rke22   <none>           <none>
kube-system   px-cluster-eks2-oper-9940f97d-4f6g6   3/3     Running   0          3h56m   70.0.91.199   rke22   <none>           <none>
kube-system   px-cluster-eks2-oper-9940f97d-pd2kc   3/3     Running   0          3h56m   70.0.91.197   rke23   <none>           <none>
kube-system   px-cluster-eks2-oper-9940f97d-272vq   3/3     Running   0          3h56m   70.0.91.196   rke24   <none>           <none>
```
* NOTE: Before this fix, the Portworx deployment was **failing**  (OCI-Monitor could not "talk to" the container-runtime)