### PR TITLE
[OPERATOR-378] Allow adding portworx container resources requirements

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -55,6 +55,20 @@ spec:
                       storage cluster components. The key specifies component in format of "kind/component",
                       e.g. "deployment/stork" to pass custom annotations to stork deployment. The value is a map of
                       string that contains custom annotation key and value pairs.
+              resources:
+                type: object
+                description: Specifies the compute resource requirements for the storage pod.
+                properties:
+                  requests:
+                    type: object
+                    description: Requested resources for the storage pod.
+                    properties:
+                      memory:
+                        type: string
+                        description: Requested memory for the storage pod.
+                      cpu:
+                        type: string
+                        description: Requested cpu for the storage pod.
               image:
                 type: string
                 description: Docker image of the storage driver.

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -297,7 +297,7 @@ func (p *portworx) GetStoragePodSpec(
 		t.cloudConfig = cloudConfig
 	}
 
-	containers := t.portworxContainer()
+	containers := t.portworxContainer(cluster)
 	podSpec := v1.PodSpec{
 		HostNetwork:        true,
 		RestartPolicy:      v1.RestartPolicyAlways,
@@ -484,7 +484,7 @@ func configureStorageNodeSpec(node *corev1.StorageNode, config *cloudstorage.Con
 	}
 }
 
-func (t *template) portworxContainer() v1.Container {
+func (t *template) portworxContainer(cluster *corev1.StorageCluster) v1.Container {
 	pxImage := util.GetImageURN(t.cluster, t.cluster.Spec.Image)
 	sc := &v1.SecurityContext{
 		Privileged: boolPtr(true),
@@ -497,7 +497,7 @@ func (t *template) portworxContainer() v1.Container {
 			},
 		}
 	}
-	return v1.Container{
+	container := v1.Container{
 		Name:            pxContainerName,
 		Image:           pxImage,
 		ImagePullPolicy: t.imagePullPolicy,
@@ -528,6 +528,10 @@ func (t *template) portworxContainer() v1.Container {
 		SecurityContext:        sc,
 		VolumeMounts:           t.getVolumeMounts(),
 	}
+	if cluster.Spec.Resources != nil {
+		container.Resources = *cluster.Spec.Resources
+	}
+	return container
 }
 
 func (t *template) kvdbContainer() v1.Container {

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -204,6 +205,40 @@ func TestPodSpecWithTolerations(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, kvdbPodSpec)
 	require.ElementsMatch(t, tolerations, kvdbPodSpec.Tolerations)
+}
+
+func TestPodSpecWithPortworxContainerResources(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	nodeName := "testNode"
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-system",
+		},
+		Spec: corev1.StorageClusterSpec{},
+	}
+
+	// Case 1: Empty resources during deployment
+	driver := portworx{}
+	podSpec, err := driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+	assert.Len(t, podSpec.Containers, 1)
+	assert.Equal(t, v1.ResourceRequirements{}, podSpec.Containers[0].Resources)
+
+	// Case 2: Add resources during deployment
+	resources := v1.ResourceRequirements{
+		Requests: map[v1.ResourceName]resource.Quantity{
+			v1.ResourceMemory: resource.MustParse("4Gi"),
+			v1.ResourceCPU:    resource.MustParse("4"),
+		},
+	}
+	cluster.Spec.Resources = &resources
+
+	podSpec, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+	assert.Len(t, podSpec.Containers, 1)
+	assert.Equal(t, resources, podSpec.Containers[0].Resources)
 }
 
 func TestPodSpecWithEnvOverrides(t *testing.T) {

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -107,6 +107,8 @@ type StorageClusterSpec struct {
 	// Nodes node level configurations that will override the ones at cluster
 	// level. These configurations can be grouped based on label selectors.
 	Nodes []NodeSpec `json:"nodes,omitempty"`
+	// Resource requirements for portworx container in a storage cluster pod, e.g. CPU and memory requests or limits
+	Resources *v1.ResourceRequirements `json:"resources,omitempty"`
 }
 
 // VolumeSpec describes a volume that needs to be mounted inside a container

--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -698,6 +698,8 @@ func matchSelectedFields(
 		return false, nil
 	} else if !reflect.DeepEqual(oldSpec.RuntimeOpts, currentSpec.RuntimeOpts) {
 		return false, nil
+	} else if !reflect.DeepEqual(oldSpec.Resources, currentSpec.Resources) {
+		return false, nil
 	} else if !elementsMatch(oldSpec.Env, currentSpec.Env) {
 		return false, nil
 	} else if !elementsMatch(oldSpec.Volumes, currentSpec.Volumes) {


### PR DESCRIPTION
Signed-off-by: Jiafeng Liao <jliao@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Add resource requirements to portworx container in storage cluster pods

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-378](https://portworx.atlassian.net/browse/OPERATOR-378)

**Special notes for your reviewer**:

