### PR TITLE
[OPERATOR-440] Add portworx-kvdb-service for internal kvdb monitoring

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -199,6 +199,18 @@ func TestBasicComponentsInstall(t *testing.T) {
 	require.Equal(t, expectedPXService.Labels, pxService.Labels)
 	require.Equal(t, expectedPXService.Spec, pxService.Spec)
 
+	// Portworx KVDB Service
+	expectedPXKVDBService := testutil.GetExpectedService(t, "portworxKVDBService.yaml")
+	pxKVDBService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedPXKVDBService.Name, pxKVDBService.Name)
+	require.Equal(t, expectedPXKVDBService.Namespace, pxKVDBService.Namespace)
+	require.Len(t, pxKVDBService.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, pxKVDBService.OwnerReferences[0].Name)
+	require.Equal(t, expectedPXKVDBService.Labels, pxKVDBService.Labels)
+	require.Equal(t, expectedPXKVDBService.Spec, pxKVDBService.Spec)
+
 	// Portworx API Service
 	expectedPxAPIService := testutil.GetExpectedService(t, "portworxAPIService.yaml")
 	pxAPIService := &v1.Service{}
@@ -387,6 +399,37 @@ func TestBasicInstallWithPortworxDisabled(t *testing.T) {
 	err = testutil.List(k8sClient, dsList)
 	require.NoError(t, err)
 	require.Empty(t, dsList.Items)
+}
+
+func TestBasicInstallWithInternalKVDBDisabled(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "false",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Kvdb: &corev1.KvdbSpec{
+				Internal: false,
+			},
+		},
+	}
+
+	err := driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Portworx KVDB Services should not be created when internal KVDB is disabled
+	pxKVDBService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
 }
 
 func TestPortworxWithCustomSecretsNamespace(t *testing.T) {
@@ -1092,6 +1135,11 @@ func TestPortworxServiceTypeWithOverride(t *testing.T) {
 				pxutil.AnnotationServiceType: "ClusterIP",
 			},
 		},
+		Spec: corev1.StorageClusterSpec{
+			Kvdb: &corev1.KvdbSpec{
+				Internal: true,
+			},
+		},
 	}
 
 	err := driver.PreInstall(cluster)
@@ -1118,6 +1166,11 @@ func TestPortworxServiceTypeWithOverride(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, v1.ServiceTypeLoadBalancer, pxService.Spec.Type)
 
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeLoadBalancer, pxService.Spec.Type)
+
 	pxAPIService = &v1.Service{}
 	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
 	require.NoError(t, err)
@@ -1134,6 +1187,11 @@ func TestPortworxServiceTypeWithOverride(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, v1.ServiceTypeNodePort, pxService.Spec.Type)
 
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeNodePort, pxService.Spec.Type)
+
 	pxAPIService = &v1.Service{}
 	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
 	require.NoError(t, err)
@@ -1147,6 +1205,11 @@ func TestPortworxServiceTypeWithOverride(t *testing.T) {
 
 	pxService = &v1.Service{}
 	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxService.Spec.Type)
+
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t, v1.ServiceTypeClusterIP, pxService.Spec.Type)
 
@@ -4337,7 +4400,7 @@ func TestCSIInstall(t *testing.T) {
 	serviceList := &v1.ServiceList{}
 	err = testutil.List(k8sClient, serviceList)
 	require.NoError(t, err)
-	require.Len(t, serviceList.Items, 3)
+	require.Len(t, serviceList.Items, 4)
 
 	expectedService := testutil.GetExpectedService(t, "csiService.yaml")
 	service := &v1.Service{}

--- a/drivers/storage/portworx/testspec/portworxKVDBService.yaml
+++ b/drivers/storage/portworx/testspec/portworxKVDBService.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-kvdb-service
+  namespace: kube-test
+  labels:
+    name: portworx
+spec:
+  selector:
+    kvdb: "true"
+  type: ClusterIP
+  ports:
+    - name: px-kvdb
+      protocol: TCP
+      port: 9019
+      targetPort: 10016

--- a/drivers/storage/portworx/testspec/portworxService.yaml
+++ b/drivers/storage/portworx/testspec/portworxService.yaml
@@ -14,10 +14,6 @@ spec:
       protocol: TCP
       port: 9001
       targetPort: 10001
-    - name: px-kvdb
-      protocol: TCP
-      port: 9019
-      targetPort: 10016
     - name: px-sdk
       protocol: TCP
       port: 9020

--- a/drivers/storage/portworx/testspec/pxProxyService.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyService.yaml
@@ -14,10 +14,6 @@ spec:
       protocol: TCP
       port: 9001
       targetPort: 10001
-    - name: px-kvdb
-      protocol: TCP
-      port: 9019
-      targetPort: 10016
     - name: px-sdk
       protocol: TCP
       port: 9020

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -42,6 +42,8 @@ const (
 	DefaultPortworxServiceAccountName = "portworx"
 	// PortworxServiceName name of the Portworx Kubernetes service
 	PortworxServiceName = "portworx-service"
+	// PortworxKVDBServiceName name of the Portworx KVDB Kubernetes service
+	PortworxKVDBServiceName = "portworx-kvdb-service"
 	// PortworxRESTPortName name of the Portworx API port
 	PortworxRESTPortName = "px-api"
 	// PortworxSDKPortName name of the Portworx SDK port


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Add portworx-kvdb-service for internal kvdb monitoring

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-440](https://portworx.atlassian.net/browse/OPERATOR-440)

**Special notes for your reviewer**:

