### PR TITLE
[OPERATOR-440] Add portworx-kvdb-service for internal kvdb monitoring

### DIFF
--- a/drivers/storage/portworx/testspec/portworxKVDBService.yaml
+++ b/drivers/storage/portworx/testspec/portworxKVDBService.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-kvdb-service
+  namespace: kube-test
+  labels:
+    name: portworx
+spec:
+  selector:
+    kvdb: "true"
+  type: ClusterIP
+  ports:
+    - name: px-kvdb
+      protocol: TCP
+      port: 9019
+      targetPort: 10016

--- a/drivers/storage/portworx/testspec/portworxService.yaml
+++ b/drivers/storage/portworx/testspec/portworxService.yaml
@@ -14,10 +14,6 @@ spec:
       protocol: TCP
       port: 9001
       targetPort: 10001
-    - name: px-kvdb
-      protocol: TCP
-      port: 9019
-      targetPort: 10016
     - name: px-sdk
       protocol: TCP
       port: 9020

--- a/drivers/storage/portworx/testspec/pxProxyService.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyService.yaml
@@ -14,10 +14,6 @@ spec:
       protocol: TCP
       port: 9001
       targetPort: 10001
-    - name: px-kvdb
-      protocol: TCP
-      port: 9019
-      targetPort: 10016
     - name: px-sdk
       protocol: TCP
       port: 9020

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -41,6 +41,8 @@ const (
 	DefaultPortworxServiceAccountName = "portworx"
 	// PortworxServiceName name of the Portworx Kubernetes service
 	PortworxServiceName = "portworx-service"
+	// PortworxKVDBServiceName name of the Portworx KVDB Kubernetes service
+	PortworxKVDBServiceName = "portworx-kvdb-service"
 	// PortworxRESTPortName name of the Portworx API port
 	PortworxRESTPortName = "px-api"
 	// PortworxSDKPortName name of the Portworx SDK port


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Cherry-pick to px-rel-1.6.0 branch https://github.com/libopenstorage/operator/pull/394

**Which issue(s) this PR fixes** (optional)
Closes # OPERATOR-440

**Special notes for your reviewer**: Verified manually

