### PR TITLE
Added FlashArray/FlashBlade matrix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ test:
 
 integration-test:
 	@echo "Building operator integration tests"
-	@cd test/integration_test && go test -tags integrationtest -v -c -o operator.test
+	@cd test/integration_test && go test -tags integrationtest,fafb -v -c -o operator.test
 
 integration-test-container:
 	@echo "Building container: docker build --tag $(STORAGE_OPERATOR_TEST_IMG) -f Dockerfile ."

--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ cleanconfigs:
 	rm -f "bin/configs/portworx-prometheus-rule.yaml"
 
 getconfigs: cleanconfigs
-	wget -q '$(PX_DOC_HOST)/samples/k8s/pxc/portworx-prometheus-rule.yaml' -P bin/configs
+	wget -q '$(PX_DOC_HOST)/samples/k8s/pxc/portworx-prometheus-rule.yaml' -P bin/configs --no-check-certificate
 
 clean-release-manifest:
 	rm -rf manifests

--- a/drivers/storage/portworx/testspec/prometheusRule.yaml
+++ b/drivers/storage/portworx/testspec/prometheusRule.yaml
@@ -148,7 +148,7 @@ spec:
       annotations:
         description: Pool {{$labels.POOL}} from node {{$labels.instance}}, from Portworx cluster {{$labels.clusterid}} successfully expanded.
         summary: Portworx pool {{$labels.POOL}} successfully expanded.
-      expr: px_alerts_poolexpandsuccessful == 1
+      expr: px_alerts_poolexpandsuccessful > 1
       labels:
         issue: Portworx pool expand successful.
         severity: warning
@@ -156,7 +156,7 @@ spec:
       annotations:
         description: Pool expansion for pool {{$labels.POOL}} from node {{$labels.instance}}, from Portworx cluster {{$labels.clusterid}} failed. Please check Portworx alerts for more details.
         summary: Pool expansion for pool {{$labels.POOL}} failed.
-      expr: px_alerts_poolexpandfailed == 1
+      expr: px_alerts_poolexpandfailed > 1
       labels:
         issue: Portworx pool expand failure.
         severity: critical

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -453,6 +453,9 @@ func validateStorageNodes(pxImageList map[string]string, cluster *corev1.Storage
 	return nil
 }
 
+// nodeSpecsToMaps takes the given node spec list and converts it to a map of node names to
+// cloud storage specs. Note that this will not work for label selectors at the moment, only
+// node names.
 func nodeSpecsToMaps(nodes []corev1.NodeSpec) map[string]*corev1.CloudStorageNodeSpec {
 	toReturn := map[string]*corev1.CloudStorageNodeSpec{}
 

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -453,12 +453,6 @@ func validateStorageNodes(pxImageList map[string]string, cluster *corev1.Storage
 	return nil
 }
 
-func sortNodesByNodeName(nodes []corev1.NodeSpec) func(i, j int) bool {
-	return func(i, j int) bool {
-		return nodes[i].Selector.NodeName < nodes[j].Selector.NodeName
-	}
-}
-
 func nodeSpecsToMaps(nodes []corev1.NodeSpec) map[string]*corev1.CloudStorageNodeSpec {
 	toReturn := map[string]*corev1.CloudStorageNodeSpec{}
 

--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -33,7 +33,7 @@ func testBasicInstallWithAllDefaults(t *testing.T) {
 
 	// Validate cluster deployment
 	logrus.Infof("Validate StorageCluster %s", cluster.Name)
-	err = testutil.ValidateStorageCluster(imageListMap, cluster, defaultValidateDeployTimeout, defaultValidateDeployRetryInterval, "")
+	err = testutil.ValidateStorageCluster(imageListMap, cluster, defaultValidateDeployTimeout, defaultValidateDeployRetryInterval, true, "")
 	require.NoError(t, err)
 
 	// Delete cluster

--- a/test/integration_test/common_test.go
+++ b/test/integration_test/common_test.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"os"
 	"path"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -175,4 +176,30 @@ func validateStorageClusterComponents(cluster *corev1.StorageCluster) error {
 	// TODO: Validate expected components are deployed and running
 	// TODO: Validate the components are running with expected configuration
 	return nil
+}
+
+// makeDNS1123Compatible will make the given string a valid DNS1123 name, which is the same
+// validation that Kubernetes uses for its object names.
+// Borrowed from
+// https://gitlab.com/gitlab-org/gitlab-runner/-/blob/0e2ae0001684f681ff901baa85e0d63ec7838568/executors/kubernetes/util.go#L268
+func makeDNS1123Compatible(name string) string {
+	const (
+		DNS1123NameMaximumLength         = 63
+		DNS1123NotAllowedCharacters      = "[^-a-z0-9]"
+		DNS1123NotAllowedStartCharacters = "^[^a-z0-9]+"
+	)
+
+	name = strings.ToLower(name)
+
+	nameNotAllowedChars := regexp.MustCompile(DNS1123NotAllowedCharacters)
+	name = nameNotAllowedChars.ReplaceAllString(name, "")
+
+	nameNotAllowedStartChars := regexp.MustCompile(DNS1123NotAllowedStartCharacters)
+	name = nameNotAllowedStartChars.ReplaceAllString(name, "")
+
+	if len(name) > DNS1123NameMaximumLength {
+		name = name[0:DNS1123NameMaximumLength]
+	}
+
+	return name
 }

--- a/test/integration_test/fafb_config_test.go
+++ b/test/integration_test/fafb_config_test.go
@@ -49,6 +49,19 @@ type BackendRequirements struct {
 	InvalidArrays, InvalidBlades int
 }
 
+// PureTestrailCase is a TestrailCase with additional
+// information to construct a px-pure-secret.
+type PureTestrailCase struct {
+	TestrailCase
+	BackendRequirements BackendRequirements
+}
+
+// DiscoveryConfig represents a single pure.json file
+type DiscoveryConfig struct {
+	Arrays []FlashArrayEntry `json:"FlashArrays,omitempty"`
+	Blades []FlashBladeEntry `json:"FlashBlades,omitempty"`
+}
+
 // FlashArrayEntry represents a single FlashArray in a pure.json file
 type FlashArrayEntry struct {
 	APIToken     string            `json:"APIToken,omitempty"`
@@ -62,12 +75,6 @@ type FlashBladeEntry struct {
 	NFSEndPoint  string            `json:"NFSEndPoint,omitempty"`
 	APIToken     string            `json:"APIToken,omitempty"`
 	Labels       map[string]string `json:"Labels,omitempty"`
-}
-
-// DiscoveryConfig represents a single pure.json file
-type DiscoveryConfig struct {
-	Arrays []FlashArrayEntry `json:"FlashArrays,omitempty"`
-	Blades []FlashBladeEntry `json:"FlashBlades,omitempty"`
 }
 
 // DumpJSON returns this DiscoveryConfig in a JSON byte array,

--- a/test/integration_test/fafb_config_util.go
+++ b/test/integration_test/fafb_config_util.go
@@ -1,0 +1,197 @@
+// +build fafb
+
+package integrationtest
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// SourceConfigSecretName is the name of the secret that contains the superset of all credentials
+	// we may select from for these tests.
+	SourceConfigSecretName = "px-pure-secret-source"
+	// OutputSecretName is the name of the secret we will output chosen credential subsets to.
+	OutputSecretName = "px-pure-secret"
+)
+
+var (
+	sourceConfig          DiscoveryConfig
+	sourceConfigPresent   bool
+	sourceConfigLoadError error
+	sourceConfigLoadOnce  sync.Once
+)
+
+// AllAvailableBackends can be used in a BackendRequirements struct
+// to indicate that all available FlashArrays or FlashBlades should be used
+const AllAvailableBackends = -1
+
+// BackendRequirements is used to describe what backends are required for
+// a given test, including how many should be invalid.
+type BackendRequirements struct {
+	// RequiredArrays and RequiredBlades indicate how many FlashArrays and
+	// FlashBlades are required respectively. If not enough are present in
+	// the source secret, this test will instead be skipped. If set to
+	// AllAvailableBackends, all backends of that type will be used.
+	RequiredArrays, RequiredBlades int
+	// InvalidArrays and InvalidBlades indicate how many FlashArrays and
+	// FlashBlades respectively should have invalid credentials supplied.
+	// If set to AllAvailableBackends, all backends will have their
+	// credentials set invalid.
+	InvalidArrays, InvalidBlades int
+}
+
+// FlashArrayEntry represents a single FlashArray in a pure.json file
+type FlashArrayEntry struct {
+	APIToken     string            `json:"APIToken,omitempty"`
+	MgmtEndPoint string            `json:"MgmtEndPoint,omitempty"`
+	Labels       map[string]string `json:"Labels,omitempty"`
+}
+
+// FlashBladeEntry represents a single FlashBlade in a pure.json file
+type FlashBladeEntry struct {
+	MgmtEndPoint string            `json:"MgmtEndPoint,omitempty"`
+	NFSEndPoint  string            `json:"NFSEndPoint,omitempty"`
+	APIToken     string            `json:"APIToken,omitempty"`
+	Labels       map[string]string `json:"Labels,omitempty"`
+}
+
+// DiscoveryConfig represents a single pure.json file
+type DiscoveryConfig struct {
+	Arrays []FlashArrayEntry `json:"FlashArrays,omitempty"`
+	Blades []FlashBladeEntry `json:"FlashBlades,omitempty"`
+}
+
+// DumpJSON returns this DiscoveryConfig in a JSON byte array,
+// the correct format for use in the k8s Secret API
+func (dc *DiscoveryConfig) DumpJSON() ([]byte, error) {
+	return json.Marshal(*dc)
+}
+
+func loadSourceConfig(namespace string) func() {
+	return func() {
+		sourceConfigPresent = false
+
+		secret, err := coreops.Instance().GetSecret(SourceConfigSecretName, namespace)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				// Not present, but no error either
+				return
+			}
+
+			// Store error and return
+			sourceConfigLoadError = err
+			return
+		}
+
+		// At this point we know the secret is present, any errors will be parsing errors
+		sourceConfigPresent = true
+		pureJSON, ok := secret.Data["pure.json"]
+		if !ok {
+			sourceConfigLoadError = fmt.Errorf("secret %s is missing key pure.json", SourceConfigSecretName)
+			return
+		}
+
+		err = json.Unmarshal(pureJSON, &sourceConfig)
+		if err != nil {
+			sourceConfigLoadError = fmt.Errorf("failed to parse secret %s: %v", SourceConfigSecretName, err)
+		}
+	}
+}
+
+func loadSourceConfigOrFail(t *testing.T, namespace string) {
+	sourceConfigLoadOnce.Do(loadSourceConfig(namespace))
+
+	require.NoError(t, sourceConfigLoadError, "Failed to load source configuration for backend credentials (other than not found error)")
+	if !sourceConfigPresent {
+		t.Skip("Source config not present, skipping")
+	}
+}
+
+// GenerateFleetOrSkip will attempt to create a fleet of devices matching the given
+// requirements, consisting of devices from the source config.
+// If not enough devices exist to meet the requirements or the source secret does not
+// exist, the test will be skipped.
+func GenerateFleetOrSkip(t *testing.T, namespace string,
+	req BackendRequirements) DiscoveryConfig {
+	loadSourceConfigOrFail(t, namespace)
+
+	logrus.WithFields(logrus.Fields{
+		"RequiredArrays": req.RequiredArrays,
+		"RequiredBlades": req.RequiredBlades,
+		"InvalidArrays":  req.InvalidArrays,
+		"InvalidBlades":  req.InvalidBlades,
+	}).Info("Backend requirements for FA/FB test")
+
+	// Check that we don't require more invalid backends than required ones
+	if req.RequiredArrays != AllAvailableBackends {
+		require.LessOrEqual(t, req.InvalidArrays, req.RequiredArrays)
+	}
+	if req.RequiredBlades != AllAvailableBackends {
+		require.LessOrEqual(t, req.InvalidBlades, req.RequiredBlades)
+	}
+
+	// Check that we have enough devices to meet the requirements
+	if req.RequiredArrays > 0 && len(sourceConfig.Arrays) < req.RequiredArrays {
+		t.Skipf("Test requires %d FlashArrays but only %d provided, skipping", req.RequiredArrays, len(sourceConfig.Arrays))
+	}
+	if req.RequiredBlades > 0 && len(sourceConfig.Blades) < req.RequiredBlades {
+		t.Skipf("Test requires %d FlashBlades but only %d provided, skipping", req.RequiredBlades, len(sourceConfig.Blades))
+	}
+
+	// We have enough devices for this test, let's make a fleet and give it back for testing
+	newFleet := DiscoveryConfig{}
+
+	addedArrays := 0
+	for _, value := range sourceConfig.Arrays {
+		// If we have enough arrays, stop now
+		if req.RequiredArrays != AllAvailableBackends && addedArrays >= req.RequiredArrays {
+			break
+		}
+
+		// Copy the value over
+		entry := FlashArrayEntry{
+			APIToken:     value.APIToken,
+			MgmtEndPoint: value.MgmtEndPoint,
+			Labels:       value.Labels,
+		}
+		// Invalid backends are in effectively random order because golang map order is not guaranteed
+		if req.InvalidArrays == AllAvailableBackends || addedArrays < req.InvalidArrays {
+			entry.APIToken = "invalid"
+		}
+		newFleet.Arrays = append(newFleet.Arrays, entry)
+		addedArrays++
+	}
+
+	addedBlades := 0
+	for _, value := range sourceConfig.Blades {
+		// If we have enough blades, stop now
+		if req.RequiredBlades != AllAvailableBackends && addedBlades >= req.RequiredBlades {
+			break
+		}
+
+		// Copy the value over
+		entry := FlashBladeEntry{
+			APIToken:     value.APIToken,
+			MgmtEndPoint: value.MgmtEndPoint,
+			NFSEndPoint:  value.NFSEndPoint,
+			Labels:       value.Labels,
+		}
+		// Invalid backends are in effectively random order because golang map order is not guaranteed
+		if req.InvalidBlades == AllAvailableBackends || addedBlades < req.InvalidBlades {
+			entry.APIToken = "invalid"
+		}
+		newFleet.Blades = append(newFleet.Blades, entry)
+		addedBlades++
+	}
+
+	return newFleet
+}

--- a/test/integration_test/fafb_matrix_test.go
+++ b/test/integration_test/fafb_matrix_test.go
@@ -1,0 +1,352 @@
+// +build fafb
+
+package integrationtest
+
+import (
+	"fmt"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	k8sv1 "k8s.io/api/core/v1"
+
+	v1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// node* is to be used in the Node section of the StorageCluster spec. node0 will select the
+// alphabetically 1st PX node, node1 will select the 2nd, and so on
+const (
+	nodeReplacePrefix = "replaceWithNodeNumber"
+
+	node0 = nodeReplacePrefix + "0"
+	node1 = nodeReplacePrefix + "1"
+	node2 = nodeReplacePrefix + "2"
+)
+
+var (
+	auto    = "auto"    // Used for things like auto-journal drives
+	size3   = "size=3"  // Recommended journal drive size, more than this is useless: https://docs.portworx.com/install-with-other/operate-and-maintain/performance-and-tuning/tuning/
+	size32  = "size=32" // Default kvdb size from spec gen
+	size50  = "size=50"
+	size100 = "size=100"
+	size200 = "size=200"
+
+	disks100 = []string{size100}
+	disks200 = []string{size200}
+
+	threeStorageNodes = uint32(3)
+
+	internalKVDB     = v1.KvdbSpec{Internal: true}
+	autoJournalDrive = &v1.CloudStorageSpec{
+		CloudStorageCommon: v1.CloudStorageCommon{
+			KvdbDeviceSpec:    &size32,
+			JournalDeviceSpec: &auto, // TODO: Once PWX-21364 is fixed, add this back in!
+			DeviceSpecs:       &disks100,
+		},
+	}
+
+	// simpleClusterSpec is a StorageCluster with internal KVDB and auto journal drives
+	simpleClusterSpec = v1.StorageClusterSpec{
+		Kvdb:         &internalKVDB,
+		CloudStorage: autoJournalDrive,
+	}
+)
+
+type TestrailCase struct {
+	ID                      string
+	Spec                    v1.StorageClusterSpec
+	BackendRequirements     BackendRequirements
+	ShouldStartSuccessfully bool
+}
+
+func (trc *TestrailCase) PopulateStorageCluster(cluster *v1.StorageCluster) error {
+	cluster.Name = makeDNS1123Compatible(trc.ID)
+	cluster.Spec.CloudStorage = trc.Spec.CloudStorage
+	cluster.Spec.Kvdb = trc.Spec.Kvdb
+
+	names, err := testutil.GetExpectedPxNodeNameList(cluster)
+	if err != nil {
+		return err
+	}
+	// Sort for consistent order between multiple tests
+	sort.Strings(names)
+
+	// For each node, if the selector looks like "replaceWithNodeNumberN", replace it with
+	// the name of the Nth eligible Portworx node
+	for i := range trc.Spec.Nodes {
+		if !strings.HasPrefix(trc.Spec.Nodes[i].Selector.NodeName, nodeReplacePrefix) {
+			continue
+		}
+
+		num := strings.TrimPrefix(trc.Spec.Nodes[i].Selector.NodeName, nodeReplacePrefix)
+		parsedNum, err := strconv.Atoi(num)
+		if err != nil {
+			return err
+		}
+
+		if parsedNum >= len(names) {
+			return fmt.Errorf("requested node index %d is larger than eligible worker node count %d", parsedNum, len(names))
+		}
+
+		trc.Spec.Nodes[i].Selector.NodeName = names[parsedNum]
+	}
+
+	cluster.Spec.Nodes = trc.Spec.Nodes
+
+	return nil
+}
+
+var flashArrayPositiveInstallTests = []TestrailCase{
+	// C55129: https://portworx.testrail.net/index.php?/cases/view/55129
+	// Install PX through operator with internal KVDB on FlashArray
+	//    and
+	// C56411: https://portworx.testrail.net/index.php?/cases/view/56411
+	// Install PX through operator with one valid FlashArray
+	{
+		ID:                      "C55129-C56411",
+		ShouldStartSuccessfully: true,
+		BackendRequirements: BackendRequirements{
+			RequiredArrays: 1,
+		},
+		Spec: v1.StorageClusterSpec{
+			Kvdb: &internalKVDB,
+			CloudStorage: &v1.CloudStorageSpec{
+				CloudStorageCommon: v1.CloudStorageCommon{
+					KvdbDeviceSpec: &size32,
+					DeviceSpecs:    &disks100,
+				},
+			},
+		},
+	},
+	//// C55130: https://portworx.testrail.net/index.php?/cases/view/55130
+	// Install PX through operator with internal KVDB and journal drive on FlashArray
+	// TODO: Blocked due to PWX-21364, retest
+	{
+		ID:                      "C55130",
+		ShouldStartSuccessfully: true,
+		BackendRequirements: BackendRequirements{
+			RequiredArrays: 1,
+		},
+		Spec: v1.StorageClusterSpec{
+			Kvdb: &internalKVDB,
+			CloudStorage: &v1.CloudStorageSpec{
+				CloudStorageCommon: v1.CloudStorageCommon{
+					KvdbDeviceSpec:    &size32,
+					JournalDeviceSpec: &size3,
+					DeviceSpecs:       &disks100,
+				},
+			},
+		},
+	},
+	// C56414: https://portworx.testrail.net/index.php?/cases/view/56414
+	// Install PX through operator with internal KVDB and auto journal drive on FlashArray
+	//    and
+	// C55003: https://portworx.testrail.net/index.php?/cases/view/55003
+	// Uninstall PX through operator with Pure arrays, after clean install
+	// TODO: Blocked due to PWX-21364, retest
+	{
+		ID:                      "C56414-C55003", // TODO: handle multiple test IDs cleanly(?) (or just have multiple tests)
+		ShouldStartSuccessfully: true,
+		BackendRequirements: BackendRequirements{
+			RequiredArrays: 1,
+		},
+		Spec: simpleClusterSpec,
+	},
+	// C55133: https://portworx.testrail.net/index.php?/cases/view/55133
+	// Install PX through operator with heterogeneous cluster, with different nodes having different capacity drives
+	{
+		ID:                      "C55133",
+		ShouldStartSuccessfully: true,
+		BackendRequirements: BackendRequirements{
+			RequiredArrays: 1,
+		},
+		Spec: v1.StorageClusterSpec{
+			Kvdb:         &internalKVDB,
+			CloudStorage: autoJournalDrive,
+			Nodes: []v1.NodeSpec{
+				{
+					Selector: v1.NodeSelector{
+						NodeName: node0,
+					},
+					CloudStorage: &v1.CloudStorageNodeSpec{
+						CloudStorageCommon: v1.CloudStorageCommon{
+							DeviceSpecs:       &disks200,
+							JournalDeviceSpec: &auto,
+							KvdbDeviceSpec:    &size32,
+						},
+					},
+				},
+			},
+		},
+	},
+	// C55134: https://portworx.testrail.net/index.php?/cases/view/55134
+	// Install PX through operator on FlashArray with storage and storageless nodes
+	// TODO: Needs to remove prereqs from storageless node before running test
+	//{
+	//	ID:                      "C55134",
+	//	ShouldStartSuccessfully: true,
+	//	BackendRequirements: BackendRequirements{
+	//		RequiredArrays: 1,
+	//	},
+	//	Spec: v1.StorageClusterSpec{
+	//		Kvdb: &internalKVDB,
+	//		CloudStorage: &v1.CloudStorageSpec{
+	//			CloudStorageCommon: v1.CloudStorageCommon{
+	//				DeviceSpecs: &disks100,
+	//				KvdbDeviceSpec:    &size32,
+	//				// TODO: re-enable journal drives
+	//			},
+	//			MaxStorageNodes: &threeStorageNodes, // TODO: change this to using the node selector
+	//		},
+	//	},
+	//},
+	//C56412: https://portworx.testrail.net/index.php?/cases/view/56412
+	//Install PX through operator with multiple FlashArrays (all valid)
+	{
+		ID:                      "C56412",
+		ShouldStartSuccessfully: true,
+		BackendRequirements: BackendRequirements{
+			RequiredArrays: 2,
+			InvalidArrays:  0,
+		},
+		Spec: simpleClusterSpec,
+	},
+	//C56413: https://portworx.testrail.net/index.php?/cases/view/56413
+	//Install PX through operator with both valid and invalid FlashArrays
+	{
+		ID:                      "C56413",
+		ShouldStartSuccessfully: true,
+		BackendRequirements: BackendRequirements{
+			RequiredArrays: 2,
+			InvalidArrays:  1,
+		},
+		Spec: simpleClusterSpec,
+	},
+}
+
+/*var flashArrayNegativeInstallTests = []TestrailCase{
+	// C54982: https://portworx.testrail.net/index.php?/cases/view/54982
+	// Install PX with invalid credentials
+	// C55004: https://portworx.testrail.net/index.php?/cases/view/55004
+	// Uninstall PX through operators with Pure arrays, after failed install
+	{
+		ID:                      "C54982-C55004",
+		ShouldStartSuccessfully: false,
+		// TODO: needs invalid credentials
+		Spec:     simpleClusterSpec,
+	},
+	// C54981: https://portworx.testrail.net/index.php?/cases/view/54981
+	// Install PX with only FlashBlades w/o iSCSI packages installed.
+	{
+		ID:                      "C54981",
+		ShouldStartSuccessfully: false, // assuming running with no other cloud provider creds
+		// TODO: needs some way to uninstall and reinstall iSCSI
+		// TODO: needs only FlashBlades
+		Spec:     simpleClusterSpec,
+	},
+	// C54983: https://portworx.testrail.net/index.php?/cases/view/54983
+	// Install PX on node with missing required utilities
+	{
+		ID:                      "C54983",
+		ShouldStartSuccessfully: false,
+		// TODO: needs some way to uninstall utilities or files and add them back afterwards
+		Spec:     simpleClusterSpec,
+	},
+}*/
+
+func TestFAFBPositiveInstallation(t *testing.T) {
+	for _, testCase := range flashArrayPositiveInstallTests {
+		t.Run(testCase.ID, matrixTest(testCase))
+	}
+}
+
+func matrixTest(c TestrailCase) func(*testing.T) {
+	return func(t *testing.T) {
+		// Check that we have enough backends to support this test: skip early
+		fleetBackends := GenerateFleetOrSkip(t, pxNamespace, c.BackendRequirements)
+
+		// Get versions from URL
+		logrus.Infof("Get component images from versions URL")
+		imageListMap, err := testutil.GetImagesFromVersionURL(pxSpecGenURL)
+		require.NoError(t, err)
+
+		// Construct Portworx StorageCluster object
+		cluster, err := constructStorageCluster(pxSpecGenURL, imageListMap)
+		require.NoError(t, err)
+
+		c.PopulateStorageCluster(cluster)
+
+		// Add extra env variables
+		releaseManifestURL := pxSpecGenURL
+		if !strings.HasSuffix(releaseManifestURL, "/") {
+			releaseManifestURL += "/"
+		}
+		releaseManifestURL += "version"
+
+		cluster.Spec.Env = append(cluster.Spec.Env, []k8sv1.EnvVar{
+			{
+				Name:  "PX_RELEASE_MANIFEST_URL",
+				Value: releaseManifestURL,
+			},
+			{
+				Name:  "PX_LOGLEVEL",
+				Value: "debug",
+			},
+		}...)
+
+		// Create px-pure-secret
+		logrus.Infof("Create or update %s in %s", OutputSecretName, pxNamespace)
+		err = createPureSecret(fleetBackends, pxNamespace)
+		require.NoError(t, err)
+
+		// Deploy cluster
+		logrus.Infof("Create StorageCluster %s in %s", cluster.Name, cluster.Namespace)
+		cluster, err = createStorageCluster(cluster)
+		require.NoError(t, err)
+
+		// Validate cluster deployment
+		logrus.Infof("Validate StorageCluster %s", cluster.Name)
+		err = testutil.ValidateStorageCluster(imageListMap, cluster, defaultValidateDeployTimeout, defaultValidateDeployRetryInterval, c.ShouldStartSuccessfully, "")
+		require.NoError(t, err)
+
+		// Delete cluster
+		logrus.Infof("Delete StorageCluster %s", cluster.Name)
+		err = testutil.UninstallStorageCluster(cluster)
+		require.NoError(t, err)
+
+		// Validate cluster deletion
+		logrus.Infof("Validate StorageCluster %s deletion", cluster.Name)
+		err = testutil.ValidateUninstallStorageCluster(cluster, defaultValidateUninstallTimeout, defaultValidateUninstallRetryInterval)
+		require.NoError(t, err)
+
+		// Delete px-pure-secret
+		logrus.Infof("Delete Secret %s", OutputSecretName)
+		err = deletePureSecretIfExists(cluster.Namespace)
+		require.NoError(t, err)
+	}
+}
+
+func createPureSecret(config DiscoveryConfig, namespace string) error {
+	pureJSON, err := config.DumpJSON()
+	if err != nil {
+		return err
+	}
+
+	_, err = coreops.Instance().UpdateSecretData(OutputSecretName, namespace, map[string][]byte{
+		"pure.json": pureJSON,
+	})
+	return err
+}
+
+func deletePureSecretIfExists(namespace string) error {
+	if err := coreops.Instance().DeleteSecret(OutputSecretName, namespace); !errors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}

--- a/test/integration_test/node_affinity_test.go
+++ b/test/integration_test/node_affinity_test.go
@@ -80,7 +80,7 @@ func testNodeAffinityLabels(t *testing.T) {
 
 	// Validate cluster deployment
 	logrus.Infof("Validate StorageCluster %s", cluster.Name)
-	err = testutil.ValidateStorageCluster(imageListMap, cluster, defaultValidateDeployTimeout, defaultValidateDeployRetryInterval, "")
+	err = testutil.ValidateStorageCluster(imageListMap, cluster, defaultValidateDeployTimeout, defaultValidateDeployRetryInterval, true, "")
 	require.NoError(t, err)
 
 	// Delete cluster

--- a/test/integration_test/operator-test-pod.yaml
+++ b/test/integration_test/operator-test-pod.yaml
@@ -51,6 +51,7 @@ spec:
     - -t
     - /operator.test
     - -test.v
+    - -test.failfast
     - -test.short=SHORT_FLAG
     - -portworx-spec-gen-url=PORTWORX_SPEC_GEN_URL
     - -portworx-docker-username=PORTWORX_DOCKER_USERNAME

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -126,13 +126,12 @@ done
 
 kubectl -n kube-system logs -f operator-test
 for i in $(seq 1 100) ; do
-	sleep 5  # Give the test pod a chance to finish first after the logs stop
+    sleep 5  # Give the test pod a chance to finish first after the logs stop
     test_status=$(kubectl -n kube-system get pod operator-test -o json | jq ".status.phase" -r)
     if [ "$test_status" == "Running" ]; then
         echo "Test is still running, status: $test_status"
         kubectl -n kube-system logs -f operator-test
     else
-        sleep 5
         break
     fi
 done

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -110,8 +110,14 @@ kubectl create -f /testspecs/operator-test-pod.yaml
 
 for i in $(seq 1 100) ; do
     test_status=$(kubectl -n kube-system get pod operator-test -o json | jq ".status.phase" -r)
-    if [ "$test_status" == "Running" ] || [ "$test_status" == "Completed" ]; then
+    if [ "$test_status" == "Running" ] || [ "$test_status" == "Succeeded" ]; then
         break
+    elif [ "$test_status" == "Failed" ]; then
+        kubectl -n kube-system logs operator-test
+
+        echo ""
+        echo "Tests failed"
+        exit 1
     else
         echo "Test hasn't started yet, status: $test_status"
         sleep 5
@@ -120,6 +126,7 @@ done
 
 kubectl -n kube-system logs -f operator-test
 for i in $(seq 1 100) ; do
+	sleep 5  # Give the test pod a chance to finish first after the logs stop
     test_status=$(kubectl -n kube-system get pod operator-test -o json | jq ".status.phase" -r)
     if [ "$test_status" == "Running" ]; then
         echo "Test is still running, status: $test_status"

--- a/test/integration_test/upgrade_test.go
+++ b/test/integration_test/upgrade_test.go
@@ -57,7 +57,7 @@ func testUpgradeStorageCluster(t *testing.T) {
 
 		// Validate cluster deployment
 		logrus.Infof("Validate StorageCluster %s", cluster.Name)
-		err = testutil.ValidateStorageCluster(imageListMap, cluster, defaultValidateUpgradeTimeout, defaultValidateUpgradeRetryInterval, "")
+		err = testutil.ValidateStorageCluster(imageListMap, cluster, defaultValidateUpgradeTimeout, defaultValidateUpgradeRetryInterval, true, "")
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This adds a functional testing framework that will test various `StorageCluster` specs and validate that Portworx does (or doesn't) come up successfully. It also adds some framework improvements to detect when Portworx fails to start, rather than always starting successfully, enabling for negative testing.

**Notes for your reviewer**:
Most tests are commented out right now, I have just one test enabled. I will uncomment more as I validate they work as expected, either in this PR or in future PRs.