### PR TITLE
Set max supported openshift version to 4.8

### DIFF
--- a/deploy/olm-catalog/portworx/1.5.2/portworxoperator.v1.5.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/1.5.2/portworxoperator.v1.5.2.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   name: portworx-operator.v1.5.2
   namespace: placeholder
   annotations:
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
     capabilities: Auto Pilot
     categories: "Storage"
     description: Cloud native storage solution for production workloads


### PR DESCRIPTION
Openshift 4.9 will use Kubernetes 1.22 which does not support
CRD v1beta1. We are adding support for 4.9 in operator 1.6.0.

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

