### PR TITLE
OPERATOR-443 Close portworx sdk connection on uninstall

### DIFF
--- a/drivers/storage/portworx/component/auth.go
+++ b/drivers/storage/portworx/component/auth.go
@@ -160,6 +160,7 @@ func (a *auth) Delete(cluster *corev1.StorageCluster) error {
 		return err
 	}
 
+	a.closeSdkConn()
 	return nil
 }
 

--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -87,6 +87,7 @@ func (c *disruptionBudget) Delete(cluster *corev1.StorageCluster) error {
 	); err != nil {
 		return err
 	}
+	c.closeSdkConn()
 	return nil
 }
 

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -440,6 +440,14 @@ func (p *portworx) DeleteStorage(
 ) (*corev1.ClusterCondition, error) {
 	p.deleteComponents(cluster)
 
+	// Close connection to Portworx GRPC server
+	if p.sdkConn != nil {
+		if err := p.sdkConn.Close(); err != nil {
+			logrus.Warnf("Failed to close sdk connection: %v", err)
+		}
+		p.sdkConn = nil
+	}
+
 	if cluster.Spec.DeleteStrategy == nil || !pxutil.IsPortworxEnabled(cluster) {
 		// No Delete strategy provided or Portworx not installed through the operator,
 		// then do not wipe Portworx


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-443

**Special notes for your reviewer**:

