### PR TITLE
[OPERATOR-454] Upgrade prometheus operator to a newer version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ STORAGE_OPERATOR_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORAGE_OPERATOR_IMAGE):$(D
 STORAGE_OPERATOR_TEST_IMG=$(DOCKER_HUB_REPO)/$(DOCKER_HUB_STORAGE_OPERATOR_TEST_IMAGE):$(DOCKER_HUB_STORAGE_OPERATOR_TEST_TAG)
 PX_DOC_HOST ?= https://docs.portworx.com
 PX_INSTALLER_HOST ?= https://install.portworx.com
+PROMETHEUS_OPERATOR_HELM_CHARTS_TAG ?= kube-prometheus-stack-19.0.1
+PROMETHEUS_OPERATOR_CRD_URL_PREFIX ?= https://raw.githubusercontent.com/prometheus-community/helm-charts/$(PROMETHEUS_OPERATOR_HELM_CHARTS_TAG)/charts/kube-prometheus-stack/crds
 
 HAS_GOMODULES := $(shell go help mod why 2> /dev/null)
 
@@ -175,10 +177,18 @@ verify-catalog:
 downloads: getconfigs get-release-manifest
 
 cleanconfigs:
-	rm -f "bin/configs/portworx-prometheus-rule.yaml"
+	rm -rf bin/configs
 
 getconfigs: cleanconfigs
 	wget -q '$(PX_DOC_HOST)/samples/k8s/pxc/portworx-prometheus-rule.yaml' -P bin/configs --no-check-certificate
+	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-alertmanagerconfigs.yaml' -O bin/configs/prometheus-crd-alertmanagerconfigs.yaml
+	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-alertmanagers.yaml' -O bin/configs/prometheus-crd-alertmanagers.yaml
+	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-podmonitors.yaml' -O bin/configs/prometheus-crd-podmonitors.yaml
+	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-probes.yaml' -O bin/configs/prometheus-crd-probes.yaml
+	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-prometheuses.yaml' -O bin/configs/prometheus-crd-prometheuses.yaml
+	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-prometheusrules.yaml' -O bin/configs/prometheus-crd-prometheusrules.yaml
+	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-servicemonitors.yaml' -O bin/configs/prometheus-crd-servicemonitors.yaml
+	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-thanosrulers.yaml' -O bin/configs/prometheus-crd-thanosrulers.yaml
 
 clean-release-manifest:
 	rm -rf manifests

--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -47,10 +47,6 @@ const (
 	csiResizerContainerName     = "csi-resizer"
 )
 
-var (
-	k8sVer1_18, _ = version.NewVersion("1.18")
-)
-
 type csi struct {
 	isCreated             bool
 	csiNodeInfoCRDCreated bool
@@ -154,7 +150,7 @@ func (c *csi) Delete(cluster *corev1.StorageCluster) error {
 	pxVersion := pxutil.GetPortworxVersion(cluster)
 	csiConfig := c.getCSIConfiguration(cluster, pxVersion)
 	if csiConfig.IncludeCsiDriverInfo {
-		if c.k8sVersion.GreaterThanOrEqual(k8sVer1_18) {
+		if c.k8sVersion.GreaterThanOrEqual(k8sutil.K8sVer1_18) {
 			if err := k8sutil.DeleteCSIDriver(c.k8sClient, csiConfig.DriverName); err != nil {
 				return err
 			}
@@ -844,7 +840,7 @@ func (c *csi) createCSIDriver(
 	csiConfig *pxutil.CSIConfiguration,
 ) error {
 	// For k8s 1.18 and later, use the GA CSI Driver
-	if c.k8sVersion.GreaterThanOrEqual(k8sVer1_18) {
+	if c.k8sVersion.GreaterThanOrEqual(k8sutil.K8sVer1_18) {
 		volumeLifecycleModes := []storagev1.VolumeLifecycleMode{
 			storagev1.VolumeLifecyclePersistent,
 		}

--- a/drivers/storage/portworx/testspec/prometheusClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/prometheusClusterRole.yaml
@@ -7,6 +7,7 @@ rules:
   - apiGroups: [""]
     resources:
       - nodes
+      - nodes/metrics
       - services
       - endpoints
       - pods
@@ -15,7 +16,11 @@ rules:
     resources:
       - configmaps
     verbs: ["get"]
-  - nonResourceURLs: ["/metrics", "/federate"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics", "/metrics/cadvisor", "/federate"]
     verbs: ["get"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]

--- a/drivers/storage/portworx/testspec/prometheusOperatorClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/prometheusOperatorClusterRole.yaml
@@ -18,11 +18,16 @@ rules:
       - monitoring.coreos.com
     resources:
       - alertmanagers
+      - alertmanagers/finalizers
+      - alertmanagerconfigs
       - prometheuses
       - prometheuses/finalizers
+      - thanosrulers
+      - thanosrulers/finalizers
       - servicemonitors
-      - prometheusrules
       - podmonitors
+      - probes
+      - prometheusrules
     verbs: ["*"]
   - apiGroups:
       - apps
@@ -41,8 +46,9 @@ rules:
   - apiGroups: [""]
     resources:
       - services
+      - services/finalizers
       - endpoints
-    verbs: ["get", "create", "update"]
+    verbs: ["get", "create", "update", "delete"]
   - apiGroups: [""]
     resources:
       - nodes
@@ -50,6 +56,10 @@ rules:
   - apiGroups: [""]
     resources:
       - namespaces
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
     verbs: ["get", "list", "watch"]
   - apiGroups: ["security.openshift.io"]
     resources:

--- a/drivers/storage/portworx/testspec/prometheusOperatorDeployment_v0.50.0.yaml
+++ b/drivers/storage/portworx/testspec/prometheusOperatorDeployment_v0.50.0.yaml
@@ -1,3 +1,4 @@
+# For k8s 1.22+ with newer version Prometheus operator
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,9 +20,8 @@ spec:
         - args:
             - -namespaces=kube-test
             - --kubelet-service=kube-test/kubelet
-            - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v1.2.3
-            - --config-reloader-image=quay.io/coreos/configmap-reload:v1.2.3
-          image: quay.io/coreos/prometheus-operator:v1.2.3
+            - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.50.0
+          image: quay.io/prometheus-operator/prometheus-operator:v0.50.0
           imagePullPolicy: Always
           name: px-prometheus-operator
           ports:


### PR DESCRIPTION
Signed-off-by: Jiafeng Liao <jliao@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Upgrade Prometheus operator and related images to newer version and allow operator to create required CRDs for k8s 1.22 and above

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-454](https://portworx.atlassian.net/browse/OPERATOR-454)

**Special notes for your reviewer**:

