### PR TITLE
OPERATOR-468 Preserve contents of matchLabels under node selector

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -1185,6 +1185,7 @@ spec:
                           properties:
                             matchLabels:
                               type: object
+                              x-kubernetes-preserve-unknown-fields: true
                               description: It is a map of key-value pairs. A single key-value in the matchLabels
                                 map is equivalent to an element of matchExpressions, whose key field is "key", the
                                 operator is "In", and the values array contains only "value". The requirements are ANDed.

--- a/deploy/crds/deprecated/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/deprecated/core_v1_storagecluster_crd.yaml
@@ -1171,6 +1171,7 @@ spec:
                         properties:
                           matchLabels:
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                             description: It is a map of key-value pairs. A single key-value in the matchLabels
                               map is equivalent to an element of matchExpressions, whose key field is "key", the
                               operator is "In", and the values array contains only "value". The requirements are ANDed.


### PR DESCRIPTION
- With CRD v1 api validations, contents on blank map are pruned by default.
  We need to add the x-kubernetes-preserve-unknown-fields field to avoid
  deleting the contents of matchLabels

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

