### PR TITLE
[OPERATOR-466] Update pvc controller deployment spec for k8s 1.22+

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -1335,6 +1335,67 @@ func TestPVCControllerInstall(t *testing.T) {
 	verifyPVCControllerDeployment(t, cluster, k8sClient, "pvcControllerDeployment.yaml")
 }
 
+func TestPVCControllerInstallWithK8s1_22(t *testing.T) {
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.22.0",
+	}
+	fakeExtClient := fakeextclient.NewSimpleClientset()
+	apiextensionsops.SetInstance(apiextensionsops.New(fakeExtClient))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "true",
+			},
+		},
+	}
+
+	// TestCase: Simple install on k8s 1.22
+	expectedDeployment := testutil.GetExpectedDeployment(t, "pvcControllerDeployment.yaml")
+	expectedContainer := expectedDeployment.Spec.Template.Spec.Containers[0]
+	expectedContainer.Command = expectedContainer.Command[0:5]
+	expectedContainer.Image = "k8s.gcr.io/kube-controller-manager-amd64:v1.22.0"
+	expectedContainer.LivenessProbe.HTTPGet.Port = intstr.FromInt(10257)
+	expectedContainer.LivenessProbe.HTTPGet.Scheme = v1.URISchemeHTTPS
+	expectedDeployment.Spec.Template.Spec.Containers[0] = expectedContainer
+	err := driver.PreInstall(cluster)
+	require.NoError(t, err)
+	verifyPVCControllerInstall(t, cluster, k8sClient)
+	verifyPVCControllerDeploymentObject(t, cluster, k8sClient, expectedDeployment)
+
+	// TestCase: Add both port and secure port annotations
+	cluster.Annotations[pxutil.AnnotationPVCControllerPort] = "12345"
+	cluster.Annotations[pxutil.AnnotationPVCControllerSecurePort] = "12346"
+	expectedContainer.Command = append(expectedContainer.Command, "--secure-port=12346")
+	expectedContainer.LivenessProbe.HTTPGet.Port = intstr.FromInt(12346)
+	expectedDeployment.Spec.Template.Spec.Containers[0] = expectedContainer
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	verifyPVCControllerInstall(t, cluster, k8sClient)
+	verifyPVCControllerDeploymentObject(t, cluster, k8sClient, expectedDeployment)
+
+	// TestCase: Simple install on AKS
+	cluster.Annotations = map[string]string{
+		pxutil.AnnotationIsAKS: "true",
+	}
+	expectedContainer = expectedDeployment.Spec.Template.Spec.Containers[0]
+	expectedContainer.Command[5] = "--secure-port=10261"
+	expectedContainer.LivenessProbe.HTTPGet.Port = intstr.FromInt(10261)
+	expectedDeployment.Spec.Template.Spec.Containers[0] = expectedContainer
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	verifyPVCControllerInstall(t, cluster, k8sClient)
+	verifyPVCControllerDeploymentObject(t, cluster, k8sClient, expectedDeployment)
+}
+
 func TestPVCControllerWithInvalidValue(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()

--- a/drivers/storage/portworx/testspec/pvcControllerDeployment.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerDeployment.yaml
@@ -30,10 +30,10 @@ spec:
       - command:
         - kube-controller-manager
         - --leader-elect=true
-        - --address=0.0.0.0
         - --controllers=persistentvolume-binder,persistentvolume-expander
         - --use-service-account-credentials=true
         - --leader-elect-resource-lock=configmaps
+        - --address=0.0.0.0
         image: gcr.io/google_containers/kube-controller-manager-amd64:v0.0.0
         imagePullPolicy: Always
         livenessProbe:

--- a/drivers/storage/portworx/testspec/pvcControllerDeploymentOpenshift.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerDeploymentOpenshift.yaml
@@ -30,10 +30,10 @@ spec:
       - command:
         - kube-controller-manager
         - --leader-elect=true
-        - --address=0.0.0.0
         - --controllers=persistentvolume-binder,persistentvolume-expander
         - --use-service-account-credentials=true
         - --leader-elect-resource-lock=endpoints
+        - --address=0.0.0.0
         image: gcr.io/google_containers/kube-controller-manager-amd64:v0.0.0
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: For k8s 1.22+
* remove `--address` and `--port` flags
* use https for liveness probe and 10257 port instead of 10252

**Which issue(s) this PR fixes** (optional)
Closes # OPERATOR-466

**Special notes for your reviewer**:

