### PR TITLE
Added PX_IMAGE variable to operator tests

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -62,6 +62,8 @@ const (
 	PxRegistryUserEnvVarName = "REGISTRY_USER"
 	// PxRegistryPasswordEnvVarName is a Docker password Env variable name
 	PxRegistryPasswordEnvVarName = "REGISTRY_PASS"
+	// PxImageEnvVarName is the env variable to specify a specific Portworx image to install
+	PxImageEnvVarName = "PX_IMAGE"
 )
 
 // MockDriver creates a mock storage driver

--- a/test/integration_test/fafb_matrix_test.go
+++ b/test/integration_test/fafb_matrix_test.go
@@ -123,21 +123,32 @@ var flashArrayPositiveInstallTests = []PureTestrailCase{
 	// Install PX through operator on FlashArray with storage and storageless nodes
 	// TODO: Needs to remove prereqs from storageless node before running test
 	//{
-	//	ID:                      "C55134",
-	//	ShouldStartSuccessfully: true,
+	//	TestrailCase: TestrailCase{
+	//		CaseIDs: []string{
+	//			"C55134",
+	//		},
+	//		Spec: v1.StorageClusterSpec{
+	//			Kvdb: &internalKVDB,
+	//			CloudStorage: &v1.CloudStorageSpec{
+	//				CloudStorageCommon: v1.CloudStorageCommon{
+	//					DeviceSpecs: &disks100,
+	//					KvdbDeviceSpec:    &size32,
+	//					JournalDeviceSpec: &auto,
+	//				},
+	//			},
+	//			Nodes: []v1.NodeSpec{
+	//				{
+	//					Selector: v1.NodeSelector{
+	//						NodeName: node0,
+	//					},
+	//					CloudStorage: nil,
+	//				},
+	//			},
+	//		},
+	//		ShouldStartSuccessfully: true,
+	//	},
 	//	BackendRequirements: BackendRequirements{
 	//		RequiredArrays: 1,
-	//	},
-	//	Spec: v1.StorageClusterSpec{
-	//		Kvdb: &internalKVDB,
-	//		CloudStorage: &v1.CloudStorageSpec{
-	//			CloudStorageCommon: v1.CloudStorageCommon{
-	//				DeviceSpecs: &disks100,
-	//				KvdbDeviceSpec:    &size32,
-	//				// TODO: re-enable journal drives
-	//			},
-	//			MaxStorageNodes: &threeStorageNodes, // TODO: change this to using the node selector
-	//		},
 	//	},
 	//},
 	//C56412: https://portworx.testrail.net/index.php?/cases/view/56412

--- a/test/integration_test/operator-test-pod-template.yaml
+++ b/test/integration_test/operator-test-pod-template.yaml
@@ -56,6 +56,7 @@ spec:
     - -portworx-spec-gen-url=PORTWORX_SPEC_GEN_URL
     - -portworx-docker-username=PORTWORX_DOCKER_USERNAME
     - -portworx-docker-password=PORTWORX_DOCKER_PASSWORD
+    - -portworx-image-override=PX_IMAGE_OVERRIDE
     - -upgrade-hops-url-list=UPGRADE_HOPS_URL_LIST
     - -log-level=LOG_LEVEL
     - -test.run=FOCUS_TESTS

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -10,6 +10,7 @@ focus_tests=""
 short_test=false
 portworx_docker_username=""
 portworx_docker_password=""
+portworx_image_override=""
 log_level="debug"
 for i in "$@"
 do
@@ -35,6 +36,12 @@ case $i in
     --portworx-spec-gen-url)
         echo "Portworx Spec Generator URL to use to for test: $2"
         portworx_spec_gen_url=$2
+        shift
+        shift
+        ;;
+    --portworx-image-override)
+        echo "Portworx Image to use for test: %2"
+        portworx_image_override=$2
         shift
         shift
         ;;
@@ -111,6 +118,7 @@ fi
 
 # Set test image
 sed -i 's|'openstorage/px-operator-test:.*'|'"$test_image_name"'|g' $test_pod_spec
+sed -i 's/'PX_IMAGE_OVERRIDE'/'"$portworx_image_override"'/g' $test_pod_spec
 
 kubectl delete -f $test_pod_template
 kubectl create -f $test_pod_spec


### PR DESCRIPTION
**What this PR does / why we need it**:
To use these functional tests for PX PRs, we need to be able to specify development images. This will enable us to use any image specified with the operator tests.
