### PR TITLE
OPERATOR-457 Create equivalent storagecluster object for existing PX

### DIFF
--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
 	"github.com/libopenstorage/operator/pkg/controller/storagenode"
 	_ "github.com/libopenstorage/operator/pkg/log"
+	"github.com/libopenstorage/operator/pkg/migration"
 	"github.com/libopenstorage/operator/pkg/operator-sdk/metrics"
 	"github.com/libopenstorage/operator/pkg/version"
 	ocp_configv1 "github.com/openshift/api/config/v1"
@@ -187,6 +188,9 @@ func run(c *cli.Context) {
 	if err := storageNodeController.StartWatch(); err != nil {
 		log.Fatalf("Error starting watch on storage node controller: %v", err)
 	}
+
+	migrationHandler := migration.New(&storageClusterController)
+	go migrationHandler.Start()
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		log.Fatalf("Manager exited non-zero error: %v", err)

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -35,6 +35,10 @@ const (
 	// the custom registry, there is a list of hardcoded common registries, however the list
 	// may not be complete, users can use this annotation to add more.
 	AnnotationCommonImageRegistries = OperatorPrefix + "/common-image-registries"
+
+	// AnnotationMigrationApproved is used to take user's approval for portworx migration from
+	// old installation method to the operator managed method.
+	AnnotationMigrationApproved = "portworx.io/migration-approved"
 )
 
 const (

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -189,6 +189,12 @@ func (c *Controller) GetKubernetesClient() client.Client {
 	return c.client
 }
 
+// SetKubernetesClient sets the kubernetes client to be used by the controller.
+// This method is only used for testing.
+func (c *Controller) SetKubernetesClient(client client.Client) {
+	c.client = client
+}
+
 // Reconcile reads that state of the cluster for a StorageCluster object and makes changes based on
 // the state read and what is in the StorageCluster.Spec
 // Note:

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -1,0 +1,558 @@
+package migration
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/libopenstorage/operator/drivers/storage"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	portworxDaemonSetName  = "portworx"
+	portworxContainerName  = "portworx"
+	migrationRetryInterval = 30 * time.Second
+	phaseAwaitingApproval  = "AwaitingMigrationApproval"
+)
+
+// Handler object that carries out migration of Portworx Daemonset
+// and it's components to operator managed StorageCluster object
+type Handler struct {
+	client client.Client
+	driver storage.Driver
+}
+
+// New creates a new instance of migration handler
+func New(ctrl *storagecluster.Controller) *Handler {
+	return &Handler{
+		client: ctrl.GetKubernetesClient(),
+		driver: ctrl.Driver,
+	}
+}
+
+// Start starts the migration
+func (h *Handler) Start() {
+	var pxDaemonSet *appsv1.DaemonSet
+
+	wait.PollImmediateInfinite(migrationRetryInterval, func() (bool, error) {
+		var err error
+		pxDaemonSet, err = h.getPortworxDaemonSet(pxDaemonSet)
+		if errors.IsNotFound(err) {
+			logrus.Infof("Migration is not needed")
+			return true, nil
+		} else if err != nil {
+			logrus.Errorf("Failed to get portworx DaemonSet. %v", err)
+			return false, nil
+		}
+
+		cluster, err := h.createStorageClusterIfAbsent(pxDaemonSet)
+		if err != nil {
+			logrus.Errorf("Migration failed to create StorageCluster. %v", err)
+			return false, nil
+		}
+
+		if !h.isMigrationApproved(cluster) {
+			return false, nil
+		}
+
+		if err := h.processMigration(cluster); err != nil {
+			return false, nil
+		}
+
+		logrus.Infof("Migration completed successfully")
+		return true, nil
+	})
+}
+
+func (h *Handler) createStorageClusterIfAbsent(ds *appsv1.DaemonSet) (*corev1.StorageCluster, error) {
+	clusterName := getPortworxClusterName(ds)
+	stc := &corev1.StorageCluster{}
+	err := h.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      clusterName,
+			Namespace: ds.Namespace,
+		},
+		stc,
+	)
+	if err == nil {
+		return stc, nil
+	} else if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	stc, err = h.createStorageCluster(ds)
+	// TODO: Create dry run specs
+	return stc, err
+}
+
+func (h *Handler) processMigration(cluster *corev1.StorageCluster) error {
+	// TODO: Implement this
+	// 1. Backup existing specs
+	// 2. Migrate daemonset pods
+	// 3. Migrate components
+	// 4. Delete daemonset and components
+	return nil
+}
+
+func (h *Handler) createStorageCluster(
+	ds *appsv1.DaemonSet,
+) (*corev1.StorageCluster, error) {
+	stc := h.constructStorageCluster(ds)
+
+	// TODO: Handle enable stork
+	// TODO: Handle enable autopilot
+	// TODO: Handle enable monitoring
+
+	err := h.client.Create(context.TODO(), stc)
+	if err == nil {
+		stc.Status.Phase = phaseAwaitingApproval
+		err = h.client.Status().Update(context.TODO(), stc)
+	}
+	return stc, err
+}
+
+func (h *Handler) constructStorageCluster(ds *appsv1.DaemonSet) *corev1.StorageCluster {
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ds.Namespace,
+			Annotations: map[string]string{
+				constants.AnnotationMigrationApproved: "false",
+			},
+		},
+	}
+
+	c := getPortworxContainer(ds)
+	cluster.Spec.Image = c.Image
+	cluster.Spec.ImagePullPolicy = c.ImagePullPolicy
+	if len(ds.Spec.Template.Spec.ImagePullSecrets) > 0 {
+		cluster.Spec.ImagePullSecret = stringPtr(ds.Spec.Template.Spec.ImagePullSecrets[0].Name)
+	}
+
+	envMap := map[string]*v1.EnvVar{}
+	kvdbSecret := struct {
+		ca       string
+		cert     string
+		key      string
+		aclToken string
+		userpwd  string
+	}{}
+	miscArgs := ""
+
+	for i := 0; i < len(c.Args); i++ {
+		arg := c.Args[i]
+		if arg == "-c" {
+			cluster.Name = c.Args[i+1]
+			i++
+		} else if arg == "-x" {
+			i++
+		} else if arg == "-a" || arg == "-A" || arg == "-f" {
+			initStorageSpec(cluster)
+			if arg == "-a" {
+				cluster.Spec.Storage.UseAll = boolPtr(true)
+			}
+			if arg == "-A" {
+				cluster.Spec.Storage.UseAllWithPartitions = boolPtr(true)
+			}
+			if arg == "-f" {
+				cluster.Spec.Storage.ForceUseDisks = boolPtr(true)
+			}
+		} else if arg == "-s" && strings.HasPrefix(c.Args[i+i], "/") {
+			initStorageSpec(cluster)
+			devices := []string{}
+			if cluster.Spec.Storage.Devices != nil {
+				devices = *cluster.Spec.Storage.Devices
+			}
+			devices = append(devices, c.Args[i+1])
+			cluster.Spec.Storage.Devices = &devices
+			i++
+		} else if arg == "-j" && strings.HasPrefix(c.Args[i+1], "/") {
+			initStorageSpec(cluster)
+			cluster.Spec.Storage.JournalDevice = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-metadata" && strings.HasPrefix(c.Args[i+1], "/") {
+			initStorageSpec(cluster)
+			cluster.Spec.Storage.SystemMdDevice = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-kvdb_dev" && strings.HasPrefix(c.Args[i+1], "/") {
+			initStorageSpec(cluster)
+			cluster.Spec.Storage.KvdbDevice = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-cache" && strings.HasPrefix(c.Args[i+1], "/") {
+			initStorageSpec(cluster)
+			devices := []string{}
+			if cluster.Spec.Storage.CacheDevices != nil {
+				devices = *cluster.Spec.Storage.CacheDevices
+			}
+			devices = append(devices, c.Args[i+1])
+			cluster.Spec.Storage.CacheDevices = &devices
+			i++
+		} else if arg == "-s" && !strings.HasPrefix(c.Args[i+i], "/") {
+			initCloudStorageSpec(cluster)
+			devices := []string{}
+			if cluster.Spec.CloudStorage.DeviceSpecs != nil {
+				devices = *cluster.Spec.CloudStorage.DeviceSpecs
+			}
+			devices = append(devices, c.Args[i+1])
+			cluster.Spec.CloudStorage.DeviceSpecs = &devices
+			i++
+		} else if arg == "-j" && !strings.HasPrefix(c.Args[i+1], "/") {
+			initCloudStorageSpec(cluster)
+			cluster.Spec.CloudStorage.JournalDeviceSpec = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-metadata" && !strings.HasPrefix(c.Args[i+1], "/") {
+			initCloudStorageSpec(cluster)
+			cluster.Spec.CloudStorage.SystemMdDeviceSpec = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-kvdb_dev" && !strings.HasPrefix(c.Args[i+1], "/") {
+			initCloudStorageSpec(cluster)
+			cluster.Spec.CloudStorage.KvdbDeviceSpec = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-max_drive_set_count" {
+			initCloudStorageSpec(cluster)
+			cluster.Spec.CloudStorage.MaxStorageNodes = uint32Ptr(c.Args[i+1])
+			i++
+		} else if arg == "-max_storage_nodes_per_zone" {
+			initCloudStorageSpec(cluster)
+			cluster.Spec.CloudStorage.MaxStorageNodesPerZone = uint32Ptr(c.Args[i+1])
+			i++
+		} else if arg == "-max_storage_nodes_per_zone_per_nodegroup" {
+			initCloudStorageSpec(cluster)
+			cluster.Spec.CloudStorage.MaxStorageNodesPerZonePerNodeGroup = uint32Ptr(c.Args[i+1])
+			i++
+		} else if arg == "-node_pool_label" {
+			initCloudStorageSpec(cluster)
+			cluster.Spec.CloudStorage.NodePoolLabel = c.Args[i+1]
+			i++
+		} else if arg == "-cloud_provider" {
+			initCloudStorageSpec(cluster)
+			cluster.Spec.CloudStorage.Provider = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-b" {
+			initKvdbSpec(cluster)
+			cluster.Spec.Kvdb.Internal = true
+		} else if arg == "-k" {
+			initKvdbSpec(cluster)
+			cluster.Spec.Kvdb.Endpoints = strings.Split(c.Args[i+1], ",")
+			i++
+		} else if arg == "-ca" {
+			kvdbSecret.ca = c.Args[i+1]
+			i++
+		} else if arg == "-cert" {
+			kvdbSecret.cert = c.Args[i+1]
+			i++
+		} else if arg == "-key" {
+			kvdbSecret.key = c.Args[i+1]
+			i++
+		} else if arg == "-acltoken" {
+			kvdbSecret.aclToken = c.Args[i+1]
+			i++
+		} else if arg == "-userpwd" {
+			kvdbSecret.userpwd = c.Args[i+1]
+			i++
+		} else if arg == "-d" {
+			initNetworkSpec(cluster)
+			cluster.Spec.Network.DataInterface = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-m" {
+			initNetworkSpec(cluster)
+			cluster.Spec.Network.MgmtInterface = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-secret_type" {
+			cluster.Spec.SecretsProvider = stringPtr(c.Args[i+1])
+			i++
+		} else if arg == "-r" {
+			cluster.Spec.StartPort = uint32Ptr(c.Args[i+1])
+			i++
+		} else if arg == "-rt_opts" {
+			initRuntimeOptions(cluster)
+			rtOpts := strings.Split(c.Args[i+1], ",")
+			for _, opt := range rtOpts {
+				s := strings.Split(opt, "=")
+				cluster.Spec.RuntimeOpts[s[0]] = s[1]
+			}
+			i++
+		} else if arg == "-marketplace_name" {
+			envMap["MARKETPLACE_NAME"] = &v1.EnvVar{
+				Name:  "MARKETPLACE_NAME",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-csi_endpoint" {
+			envMap["CSI_ENDPOINT"] = &v1.EnvVar{
+				Name:  "CSI_ENDPOINT",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-csiversion" {
+			envMap["PORTWORX_CSIVERSION"] = &v1.EnvVar{
+				Name:  "PORTWORX_CSIVERSION",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-oidc_issuer" {
+			envMap["PORTWORX_AUTH_OIDC_ISSUER"] = &v1.EnvVar{
+				Name:  "PORTWORX_AUTH_OIDC_ISSUER",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-oidc_client_id" {
+			envMap["PORTWORX_AUTH_OIDC_CLIENTID"] = &v1.EnvVar{
+				Name:  "PORTWORX_AUTH_OIDC_CLIENTID",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-oidc_custom_claim_namespace" {
+			envMap["PORTWORX_AUTH_OIDC_CUSTOM_NAMESPACE"] = &v1.EnvVar{
+				Name:  "PORTWORX_AUTH_OIDC_CUSTOM_NAMESPACE",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-jwt_issuer" {
+			envMap["PORTWORX_AUTH_JWT_ISSUER"] = &v1.EnvVar{
+				Name:  "PORTWORX_AUTH_JWT_ISSUER",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-jwt_shared_secret" {
+			envMap["PORTWORX_AUTH_JWT_SHAREDSECRET"] = &v1.EnvVar{
+				Name:  "PORTWORX_AUTH_JWT_SHAREDSECRET",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-jwt_rsa_pubkey_file" {
+			envMap["PORTWORX_AUTH_JWT_RSA_PUBKEY"] = &v1.EnvVar{
+				Name:  "PORTWORX_AUTH_JWT_RSA_PUBKEY",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-jwt_ecds_pubkey_file" {
+			envMap["PORTWORX_AUTH_JWT_ECDS_PUBKEY"] = &v1.EnvVar{
+				Name:  "PORTWORX_AUTH_JWT_ECDS_PUBKEY",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-username_claim" {
+			envMap["PORTWORX_AUTH_USERNAME_CLAIM"] = &v1.EnvVar{
+				Name:  "PORTWORX_AUTH_USERNAME_CLAIM",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "-auth_system_key" {
+			envMap["PORTWORX_AUTH_SYSTEM_KEY"] = &v1.EnvVar{
+				Name:  "PORTWORX_AUTH_SYSTEM_KEY",
+				Value: c.Args[i+1],
+			}
+			i++
+		} else if arg == "--log" {
+			cluster.Annotations[pxutil.AnnotationLogFile] = c.Args[i+1]
+			i++
+		} else {
+			miscArgs += arg + " "
+		}
+	}
+
+	// Populate env variables from args and env vars of portworx container
+	for _, env := range c.Env {
+		if env.Name == "PX_TEMPLATE_VERSION" {
+			continue
+		}
+		envMap[env.Name] = env.DeepCopy()
+	}
+	if len(envMap) > 0 {
+		cluster.Spec.Env = []v1.EnvVar{}
+	}
+	for _, env := range envMap {
+		cluster.Spec.Env = append(cluster.Spec.Env, *env)
+	}
+
+	if len(miscArgs) > 0 {
+		cluster.Annotations[pxutil.AnnotationMiscArgs] = strings.TrimSpace(miscArgs)
+	}
+
+	// Fill the placement strategy based on node affinity and tolerations
+	if ds.Spec.Template.Spec.Affinity != nil &&
+		ds.Spec.Template.Spec.Affinity.NodeAffinity != nil {
+		cluster.Spec.Placement = &corev1.PlacementSpec{
+			NodeAffinity: ds.Spec.Template.Spec.Affinity.NodeAffinity.DeepCopy(),
+		}
+	}
+	if len(ds.Spec.Template.Spec.Tolerations) > 0 {
+		if cluster.Spec.Placement == nil {
+			cluster.Spec.Placement = &corev1.PlacementSpec{
+				Tolerations: []v1.Toleration{},
+			}
+		}
+		for _, t := range ds.Spec.Template.Spec.Tolerations {
+			cluster.Spec.Placement.Tolerations = append(cluster.Spec.Placement.Tolerations, *(t.DeepCopy()))
+		}
+	}
+
+	// Populate the update strategy
+	if ds.Spec.UpdateStrategy.Type == appsv1.RollingUpdateDaemonSetStrategyType {
+		cluster.Spec.UpdateStrategy.Type = corev1.RollingUpdateStorageClusterStrategyType
+		maxUnavailable := intstr.FromInt(1)
+		if ds.Spec.UpdateStrategy.RollingUpdate != nil {
+			maxUnavailable = *ds.Spec.UpdateStrategy.RollingUpdate.MaxUnavailable
+		}
+		cluster.Spec.UpdateStrategy.RollingUpdate = &corev1.RollingUpdateStorageCluster{
+			MaxUnavailable: &maxUnavailable,
+		}
+	} else if ds.Spec.UpdateStrategy.Type == appsv1.OnDeleteDaemonSetStrategyType {
+		cluster.Spec.UpdateStrategy.Type = corev1.OnDeleteStorageClusterStrategyType
+	}
+
+	// Enable CSI
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name == "csi-node-driver-registrar" {
+			cluster.Spec.FeatureGates = map[string]string{
+				"CSI": "true",
+			}
+			break
+		}
+	}
+
+	_, hasSystemKey := envMap["PORTWORX_AUTH_SYSTEM_KEY"]
+	_, hasJWTIssuer := envMap["PORTWORX_AUTH_JWT_ISSUER"]
+	if hasSystemKey && hasJWTIssuer {
+		// We don't support OIDC mode of authentication in the security spec.
+		// User who are using OIDC will continue to use the env variables and
+		// won't need to enable security through spec.security in StorageCluster.
+		cluster.Spec.Security = &corev1.SecuritySpec{
+			Enabled: true,
+			Auth: &corev1.AuthSpec{
+				GuestAccess: guestAccessTypePtr(corev1.GuestRoleManaged),
+			},
+		}
+	}
+
+	// TODO: Handle kvdb secret
+	// TODO: Handle volumes
+	// TODO: Handle custom annotations
+	// TODO: Handle custom image registry
+
+	return cluster
+}
+
+func (h *Handler) isMigrationApproved(cluster *corev1.StorageCluster) bool {
+	approved, err := strconv.ParseBool(cluster.Annotations[constants.AnnotationMigrationApproved])
+	return err == nil && approved
+}
+
+func (h *Handler) getPortworxDaemonSet(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+	if ds == nil {
+		return h.findPortworxDaemonSet()
+	}
+
+	pxDaemonSet := &appsv1.DaemonSet{}
+	err := h.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      portworxDaemonSetName,
+			Namespace: ds.Namespace,
+		},
+		pxDaemonSet,
+	)
+	return pxDaemonSet, err
+}
+
+func (h *Handler) findPortworxDaemonSet() (*appsv1.DaemonSet, error) {
+	dsList := &appsv1.DaemonSetList{}
+	if err := h.client.List(context.TODO(), dsList, &client.ListOptions{}); err != nil {
+		return nil, fmt.Errorf("failed to list daemonsets: %v", err)
+	}
+
+	for _, ds := range dsList.Items {
+		if ds.Name == portworxDaemonSetName {
+			return ds.DeepCopy(), nil
+		}
+	}
+
+	return nil, errors.NewNotFound(appsv1.Resource("DaemonSet"), portworxDaemonSetName)
+}
+
+func getPortworxClusterName(ds *appsv1.DaemonSet) string {
+	c := getPortworxContainer(ds)
+	for i, arg := range c.Args {
+		if arg == "-c" {
+			return c.Args[i+1]
+		}
+	}
+	return ""
+}
+
+func getPortworxContainer(ds *appsv1.DaemonSet) *v1.Container {
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name == portworxContainerName {
+			return c.DeepCopy()
+		}
+	}
+	return nil
+}
+
+func initStorageSpec(cluster *corev1.StorageCluster) {
+	if cluster.Spec.Storage == nil {
+		cluster.Spec.Storage = &corev1.StorageSpec{}
+	}
+}
+
+func initCloudStorageSpec(cluster *corev1.StorageCluster) {
+	if cluster.Spec.CloudStorage == nil {
+		cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+	}
+}
+
+func initNetworkSpec(cluster *corev1.StorageCluster) {
+	if cluster.Spec.Network == nil {
+		cluster.Spec.Network = &corev1.NetworkSpec{}
+	}
+}
+
+func initKvdbSpec(cluster *corev1.StorageCluster) {
+	if cluster.Spec.Kvdb == nil {
+		cluster.Spec.Kvdb = &corev1.KvdbSpec{}
+	}
+}
+
+func initRuntimeOptions(cluster *corev1.StorageCluster) {
+	if cluster.Spec.RuntimeOpts == nil {
+		cluster.Spec.RuntimeOpts = map[string]string{}
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func stringSlicePtr(value []string) *[]string {
+	return &value
+}
+
+func uint32Ptr(strValue string) *uint32 {
+	v, _ := strconv.Atoi(strValue)
+	value := uint32(v)
+	return &value
+}
+
+func guestAccessTypePtr(value corev1.GuestAccessType) *corev1.GuestAccessType {
+	return &value
+}

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -1,0 +1,463 @@
+package migration
+
+import (
+	"testing"
+	"time"
+
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestStorageClusterIsCreatedFromOnPremDaemonset(t *testing.T) {
+	clusterName := "px-cluster"
+	maxUnavailable := intstr.FromInt(3)
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx",
+			Namespace: "portworx",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					ImagePullSecrets: []v1.LocalObjectReference{
+						{
+							Name: "pull-secret",
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:            "portworx",
+							Image:           "portworx/test:version",
+							ImagePullPolicy: v1.PullIfNotPresent,
+							Args: []string{
+								"-c", clusterName,
+								"-x", "k8s",
+								"-a", "-A", "-f",
+								"-s", "/dev/sda1", "-s", "/dev/sda2",
+								"-j", "/dev/sdb",
+								"-metadata", "/dev/sdc",
+								"-kvdb_dev", "/dev/sdd",
+								"-cache", "/dev/sde1", "-cache", "/dev/sde2",
+								"-b",
+								"-d", "eth1",
+								"-m", "eth2",
+								"-secret_type", "vault",
+								"-r", "10001",
+								"-rt_opts", "opt1=100,opt2=999",
+								"-marketplace_name", "OperatorHub",
+								"-csi_endpoint", "csi/endpoint",
+								"-csiversion", "0.3",
+								"-oidc_issuer", "OIDC_ISSUER",
+								"-oidc_client_id", "OIDC_CLIENT_ID",
+								"-oidc_custom_claim_namespace", "OIDC_CUSTOM_NS",
+								"--log", "/tmp/log/location",
+								"-extra_arg1",
+								"-extra_arg2", "value2",
+								"-extra_arg3", "value3",
+							},
+							Env: []v1.EnvVar{
+								{
+									Name:  "PX_TEMPLATE_VERSION",
+									Value: "v3",
+								},
+								{
+									Name:  "TEST_ENV_1",
+									Value: "value1",
+								},
+							},
+						},
+					},
+					Affinity: &v1.Affinity{
+						NodeAffinity: &v1.NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+								NodeSelectorTerms: []v1.NodeSelectorTerm{
+									{
+										MatchExpressions: []v1.NodeSelectorRequirement{
+											{
+												Key:      "px/enabled",
+												Operator: v1.NodeSelectorOpNotIn,
+												Values:   []string{"false"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+					Tolerations: []v1.Toleration{
+						{
+							Key:      "taint_key",
+							Operator: v1.TolerationOpExists,
+							Effect:   v1.TaintEffectNoExecute,
+						},
+					},
+				},
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(ds)
+	ctrl := &storagecluster.Controller{}
+	ctrl.SetKubernetesClient(k8sClient)
+	migrator := New(ctrl)
+
+	go migrator.Start()
+	time.Sleep(2 * time.Second)
+
+	expectedCluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: ds.Namespace,
+			Annotations: map[string]string{
+				constants.AnnotationMigrationApproved: "false",
+				pxutil.AnnotationMiscArgs:             "-extra_arg1 -extra_arg2 value2 -extra_arg3 value3",
+				pxutil.AnnotationLogFile:              "/tmp/log/location",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image:           "portworx/test:version",
+			ImagePullPolicy: v1.PullIfNotPresent,
+			ImagePullSecret: stringPtr("pull-secret"),
+			SecretsProvider: stringPtr("vault"),
+			StartPort:       uint32Ptr("10001"),
+			Kvdb: &corev1.KvdbSpec{
+				Internal: true,
+			},
+			CommonConfig: corev1.CommonConfig{
+				Storage: &corev1.StorageSpec{
+					UseAll:               boolPtr(true),
+					UseAllWithPartitions: boolPtr(true),
+					ForceUseDisks:        boolPtr(true),
+					Devices:              stringSlicePtr([]string{"/dev/sda1", "/dev/sda2"}),
+					CacheDevices:         stringSlicePtr([]string{"/dev/sde1", "/dev/sde2"}),
+					JournalDevice:        stringPtr("/dev/sdb"),
+					SystemMdDevice:       stringPtr("/dev/sdc"),
+					KvdbDevice:           stringPtr("/dev/sdd"),
+				},
+				Network: &corev1.NetworkSpec{
+					DataInterface: stringPtr("eth1"),
+					MgmtInterface: stringPtr("eth2"),
+				},
+				RuntimeOpts: map[string]string{
+					"opt1": "100",
+					"opt2": "999",
+				},
+				Env: []v1.EnvVar{
+					{
+						Name:  "PORTWORX_AUTH_OIDC_ISSUER",
+						Value: "OIDC_ISSUER",
+					},
+					{
+						Name:  "PORTWORX_AUTH_OIDC_CLIENTID",
+						Value: "OIDC_CLIENT_ID",
+					},
+					{
+						Name:  "PORTWORX_AUTH_OIDC_CUSTOM_NAMESPACE",
+						Value: "OIDC_CUSTOM_NS",
+					},
+					{
+						Name:  "MARKETPLACE_NAME",
+						Value: "OperatorHub",
+					},
+					{
+						Name:  "CSI_ENDPOINT",
+						Value: "csi/endpoint",
+					},
+					{
+						Name:  "PORTWORX_CSIVERSION",
+						Value: "0.3",
+					},
+					{
+						Name:  "TEST_ENV_1",
+						Value: "value1",
+					},
+				},
+			},
+			Placement: &corev1.PlacementSpec{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "px/enabled",
+										Operator: v1.NodeSelectorOpNotIn,
+										Values:   []string{"false"},
+									},
+								},
+							},
+						},
+					},
+				},
+				Tolerations: []v1.Toleration{
+					{
+						Key:      "taint_key",
+						Operator: v1.TolerationOpExists,
+						Effect:   v1.TaintEffectNoExecute,
+					},
+				},
+			},
+			UpdateStrategy: corev1.StorageClusterUpdateStrategy{
+				Type: corev1.RollingUpdateStorageClusterStrategyType,
+				RollingUpdate: &corev1.RollingUpdateStorageCluster{
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			Phase: phaseAwaitingApproval,
+		},
+	}
+	cluster := &corev1.StorageCluster{}
+	err := testutil.Get(k8sClient, cluster, clusterName, ds.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedCluster.Annotations, cluster.Annotations)
+	require.ElementsMatch(t, expectedCluster.Spec.Env, cluster.Spec.Env)
+	expectedCluster.Spec.Env = nil
+	cluster.Spec.Env = nil
+	require.Equal(t, expectedCluster.Spec, cluster.Spec)
+	require.Equal(t, expectedCluster.Status, cluster.Status)
+
+	// Stop the migration process by removing the daemonset
+	err = testutil.Delete(k8sClient, ds)
+	require.NoError(t, err)
+}
+
+func TestStorageClusterIsCreatedFromCloudDaemonset(t *testing.T) {
+	clusterName := "px-cluster"
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx",
+			Namespace: "kube-system",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            "portworx",
+							Image:           "portworx/test:version",
+							ImagePullPolicy: v1.PullNever,
+							Args: []string{
+								"-c", clusterName,
+								"-s", "type=disk", "-s", "type=disk",
+								"-j", "type=journal",
+								"-metadata", "type=md",
+								"-kvdb_dev", "type=kvdb",
+								"-max_drive_set_count", "10",
+								"-max_storage_nodes_per_zone", "5",
+								"-max_storage_nodes_per_zone_per_nodegroup", "1",
+								"-node_pool_label", "px/storage",
+								"-cloud_provider", "aws",
+								"-k", "etcd:http://etcd-1.com:1111,etcd:http://etcd-2.com:1111",
+								"-ca", "/etc/pwx/ca",
+								"-cert", "/etc/pwx/cert",
+								"-key", "/etc/pwx/key",
+								"-acltoken", "acltoken",
+								"-userpwd", "userpwd",
+								"-jwt_issuer", "jwt_issuer",
+								"-jwt_shared_secret", "shared_secret",
+								"-jwt_rsa_pubkey_file", "rsa_file",
+								"-jwt_ecds_pubkey_file", "ecds_file",
+								"-username_claim", "username_claim",
+								"-auth_system_key", "system_key",
+							},
+							Env: []v1.EnvVar{
+								{
+									Name:  "PX_TEMPLATE_VERSION",
+									Value: "v3",
+								},
+								{
+									Name:  "TEST_ENV_1",
+									Value: "value1",
+								},
+							},
+						},
+					},
+				},
+			},
+			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.OnDeleteDaemonSetStrategyType,
+			},
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(ds)
+	ctrl := &storagecluster.Controller{}
+	ctrl.SetKubernetesClient(k8sClient)
+	migrator := New(ctrl)
+
+	go migrator.Start()
+	time.Sleep(2 * time.Second)
+
+	expectedCluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: ds.Namespace,
+			Annotations: map[string]string{
+				constants.AnnotationMigrationApproved: "false",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image:           "portworx/test:version",
+			ImagePullPolicy: v1.PullNever,
+			Kvdb: &corev1.KvdbSpec{
+				Endpoints: []string{
+					"etcd:http://etcd-1.com:1111",
+					"etcd:http://etcd-2.com:1111",
+				},
+			},
+			CloudStorage: &corev1.CloudStorageSpec{
+				Provider: stringPtr("aws"),
+				CloudStorageCommon: corev1.CloudStorageCommon{
+					DeviceSpecs:                        stringSlicePtr([]string{"type=disk", "type=disk"}),
+					JournalDeviceSpec:                  stringPtr("type=journal"),
+					SystemMdDeviceSpec:                 stringPtr("type=md"),
+					KvdbDeviceSpec:                     stringPtr("type=kvdb"),
+					MaxStorageNodesPerZonePerNodeGroup: uint32Ptr("1"),
+				},
+				MaxStorageNodes:        uint32Ptr("10"),
+				MaxStorageNodesPerZone: uint32Ptr("5"),
+				NodePoolLabel:          "px/storage",
+			},
+			CommonConfig: corev1.CommonConfig{
+				Env: []v1.EnvVar{
+					{
+						Name:  "PORTWORX_AUTH_JWT_ISSUER",
+						Value: "jwt_issuer",
+					},
+					{
+						Name:  "PORTWORX_AUTH_JWT_SHAREDSECRET",
+						Value: "shared_secret",
+					},
+					{
+						Name:  "PORTWORX_AUTH_JWT_RSA_PUBKEY",
+						Value: "rsa_file",
+					},
+					{
+						Name:  "PORTWORX_AUTH_JWT_ECDS_PUBKEY",
+						Value: "ecds_file",
+					},
+					{
+						Name:  "PORTWORX_AUTH_USERNAME_CLAIM",
+						Value: "username_claim",
+					},
+					{
+						Name:  "PORTWORX_AUTH_SYSTEM_KEY",
+						Value: "system_key",
+					},
+					{
+						Name:  "TEST_ENV_1",
+						Value: "value1",
+					},
+				},
+			},
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					GuestAccess: guestAccessTypePtr(corev1.GuestRoleManaged),
+				},
+			},
+			UpdateStrategy: corev1.StorageClusterUpdateStrategy{
+				Type: corev1.OnDeleteStorageClusterStrategyType,
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			Phase: phaseAwaitingApproval,
+		},
+	}
+	cluster := &corev1.StorageCluster{}
+	err := testutil.Get(k8sClient, cluster, clusterName, ds.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedCluster.Annotations, cluster.Annotations)
+	require.ElementsMatch(t, expectedCluster.Spec.Env, cluster.Spec.Env)
+	expectedCluster.Spec.Env = nil
+	cluster.Spec.Env = nil
+	require.Equal(t, expectedCluster.Spec, cluster.Spec)
+	require.Equal(t, expectedCluster.Status, cluster.Status)
+
+	// Stop the migration process by removing the daemonset
+	err = testutil.Delete(k8sClient, ds)
+	require.NoError(t, err)
+}
+
+func TestWhenStorageClusterIsAlreadyPresent(t *testing.T) {
+	clusterName := "px-cluster"
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx",
+			Namespace: "portworx",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "portworx",
+							Args: []string{"-c", clusterName, "-a"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Cluster with some missing params from the daemonset
+	existingCluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: ds.Namespace,
+			Annotations: map[string]string{
+				constants.AnnotationMigrationApproved: "false",
+			},
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(ds, existingCluster)
+	ctrl := &storagecluster.Controller{}
+	ctrl.SetKubernetesClient(k8sClient)
+	migrator := New(ctrl)
+
+	go migrator.Start()
+	time.Sleep(2 * time.Second)
+
+	stc := &corev1.StorageCluster{}
+	err := testutil.Get(k8sClient, stc, clusterName, ds.Namespace)
+	require.NoError(t, err)
+	// The storage cluster object did not change even when the daemonset
+	// is different now
+	require.Nil(t, stc.Spec.Storage)
+
+	// Stop the migration process by removing the daemonset
+	err = testutil.Delete(k8sClient, ds)
+	require.NoError(t, err)
+}
+
+func TestWhenPortworxDaemonsetIsNotPresent(t *testing.T) {
+	k8sClient := testutil.FakeK8sClient()
+	ctrl := &storagecluster.Controller{}
+	ctrl.SetKubernetesClient(k8sClient)
+	migrator := New(ctrl)
+
+	go migrator.Start()
+	time.Sleep(2 * time.Second)
+
+	clusterList := &corev1.StorageClusterList{}
+	err := testutil.List(k8sClient, clusterList)
+	require.NoError(t, err)
+	require.Empty(t, clusterList.Items)
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -28,6 +28,8 @@ const (
 	UpdatePausedReason = "UpdatePaused"
 	// ClusterOnlineReason is added to an event when a cluster comes online
 	ClusterOnlineReason = "ClusterOnline"
+	// MigrationPendingReason is added to an event when the migration is in pending state.
+	MigrationPendingReason = "MigrationPending"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Adds a basic migration workflow. When the operator starts, it starts a goroutine for migration. The migration routine, will first create an equivalent StorageCluster object and wait for the user to approve the migration. 
- The actual migration code is not in the scope of this PR or ticket.
- This covers the migration of just the portworx daemonset. The components are not yet reflected in the StorageCluster object.
- Unit tests and functional tests will be added to this PR soon. 

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-457

**Special notes for your reviewer**:

