### PR TITLE
OPERATOR-459 Migrate portworx daemonset pods

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -17,7 +17,6 @@ import (
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,8 +37,6 @@ const (
 	storageClusterUninstallMsg        = "Portworx service removed. Portworx drives and data NOT wiped."
 	storageClusterUninstallAndWipeMsg = "Portworx service removed. Portworx drives and data wiped."
 	labelPortworxVersion              = "PX Version"
-	// portworxDaemonSetName is the name of DaemonSet when portworx is installed by DaemonSet.
-	portworxDaemonSetName = "portworx"
 )
 
 type portworx struct {
@@ -85,18 +82,6 @@ func (p *portworx) Init(
 }
 
 func (p *portworx) Validate() error {
-	daemonSetList := &apps.DaemonSetList{}
-	if err := p.k8sClient.List(context.TODO(), daemonSetList, &client.ListOptions{}); err != nil {
-		logrus.Errorf("Failed to list DaemonSet: %v", err)
-		return err
-	}
-
-	for _, daemonSet := range daemonSetList.Items {
-		if daemonSet.Name == portworxDaemonSetName {
-			return fmt.Errorf("daemonset %s is present, installation with daemonset and operator cannot coexist", portworxDaemonSetName)
-		}
-	}
-
 	return nil
 }
 

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -81,25 +81,9 @@ func TestInit(t *testing.T) {
 
 func TestValidate(t *testing.T) {
 	driver := portworx{}
-	k8sClient := testutil.FakeK8sClient()
-	scheme := runtime.NewScheme()
-	recorder := record.NewFakeRecorder(0)
 
-	err := driver.Init(k8sClient, scheme, recorder)
+	err := driver.Validate()
 	require.NoError(t, err)
-
-	err = driver.Validate()
-	require.NoError(t, err)
-
-	// Create portworx daemonset
-	daemonSet := appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "portworx",
-		},
-	}
-	k8sClient.Create(context.TODO(), &daemonSet)
-	err = driver.Validate()
-	require.NotNil(t, err)
 }
 
 func TestGetSelectorLabels(t *testing.T) {

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -35,10 +35,6 @@ const (
 	// the custom registry, there is a list of hardcoded common registries, however the list
 	// may not be complete, users can use this annotation to add more.
 	AnnotationCommonImageRegistries = OperatorPrefix + "/common-image-registries"
-
-	// AnnotationMigrationApproved is used to take user's approval for portworx migration from
-	// old installation method to the operator managed method.
-	AnnotationMigrationApproved = "portworx.io/migration-approved"
 )
 
 const (

--- a/pkg/constants/migration.go
+++ b/pkg/constants/migration.go
@@ -1,0 +1,29 @@
+package constants
+
+const (
+	// AnnotationMigrationApproved is used to take user's approval for portworx migration from
+	// old installation method to the operator managed method.
+	AnnotationMigrationApproved = "portworx.io/migration-approved"
+
+	// LabelPortworxDaemonsetMigration is used as Kubernetes node label to mark the state
+	// of the node wrt portworx daemonSet migration
+	LabelPortworxDaemonsetMigration = "portworx.io/daemonset-migration"
+	// LabelValueMigrationPending state in which migration is pending and daemonset pod still runs
+	LabelValueMigrationPending = "Pending"
+	// LabelValueMigrationStarting state in which migration is about to start but waiting for
+	// daemonset pod to be removed
+	LabelValueMigrationStarting = "Starting"
+	// LabelValueMigrationInProgress state in which migration is about to start the operator
+	// managed portworx pod
+	LabelValueMigrationInProgress = "InProgress"
+	// LabelValueMigrationDone state in which migration of portworx pod has finished on that node
+	LabelValueMigrationDone = "Done"
+	// LabelValueMigrationSkip state telling the operator to skip and not wait for portworx
+	// to be ready on that node
+	LabelValueMigrationSkip = "Skip"
+
+	// PhaseAwaitingApproval status when operator is waiting for user approval for migration
+	PhaseAwaitingApproval = "AwaitingMigrationApproval"
+	// PhaseMigrationInProgress status when migration is in progress
+	PhaseMigrationInProgress = "MigrationInProgress"
+)

--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -226,7 +226,7 @@ func (c *Controller) controlledHistories(
 		return fresh, nil
 	})
 
-	selector := c.storageClusterSelectorLabels(cluster)
+	selector := c.StorageClusterSelectorLabels(cluster)
 	// Use ControllerRefManager to adopt/orphan as needed. Histories that don't match the
 	// labels but are owned by this storage cluster are released (disowned). Histories that
 	// match the labels and do not have ref to this storage cluster are owned by it.
@@ -251,7 +251,7 @@ func (c *Controller) snapshot(
 
 	hash := computeHash(&cluster.Spec, cluster.Status.CollisionCount)
 	name := historyName(cluster.Name, hash)
-	historyLabels := c.storageClusterSelectorLabels(cluster)
+	historyLabels := c.StorageClusterSelectorLabels(cluster)
 	historyLabels[defaultStorageClusterUniqueLabelKey] = hash
 
 	history := &apps.ControllerRevision{

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -12,27 +13,36 @@ import (
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	pluginhelper "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	portworxDaemonSetName  = "portworx"
-	portworxContainerName  = "portworx"
-	migrationRetryInterval = 30 * time.Second
-	phaseAwaitingApproval  = "AwaitingMigrationApproval"
+	portworxDaemonSetName          = "portworx"
+	portworxContainerName          = "portworx"
+	migrationRetryInterval         = 30 * time.Second
+	podWaitInterval                = 10 * time.Second
+	daemonSetPodTerminationTimeout = 5 * time.Minute
+	operatorPodReadyTimeout        = 10 * time.Minute
 )
 
 // Handler object that carries out migration of Portworx Daemonset
 // and it's components to operator managed StorageCluster object
 type Handler struct {
+	ctrl   *storagecluster.Controller
 	client client.Client
 	driver storage.Driver
 }
@@ -40,6 +50,7 @@ type Handler struct {
 // New creates a new instance of migration handler
 func New(ctrl *storagecluster.Controller) *Handler {
 	return &Handler{
+		ctrl:   ctrl,
 		client: ctrl.GetKubernetesClient(),
 		driver: ctrl.Driver,
 	}
@@ -70,7 +81,8 @@ func (h *Handler) Start() {
 			return false, nil
 		}
 
-		if err := h.processMigration(cluster); err != nil {
+		if err := h.processMigration(cluster, pxDaemonSet); err != nil {
+			logrus.Errorf("Migration failed, will retry in %v. %v", migrationRetryInterval, err)
 			return false, nil
 		}
 
@@ -101,13 +113,188 @@ func (h *Handler) createStorageClusterIfAbsent(ds *appsv1.DaemonSet) (*corev1.St
 	return stc, err
 }
 
-func (h *Handler) processMigration(cluster *corev1.StorageCluster) error {
+func (h *Handler) processMigration(
+	cluster *corev1.StorageCluster,
+	ds *appsv1.DaemonSet,
+) error {
 	// TODO: Implement this
 	// 1. Backup existing specs
-	// 2. Migrate daemonset pods
-	// 3. Migrate components
-	// 4. Delete daemonset and components
+	// 2. Migrate components
+
+	nodeList := &v1.NodeList{}
+	if err := h.client.List(context.TODO(), nodeList, &client.ListOptions{}); err != nil {
+		return err
+	}
+	nodes, err := h.markAllNodesAsPending(nodeList)
+	if err != nil {
+		return err
+	}
+
+	// Unblock operator reconcile loop to start managing the storagecluster
+	cluster.Status.Phase = constants.PhaseMigrationInProgress
+	if err := h.client.Status().Update(context.TODO(), cluster, &client.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	if err := h.updateDaemonsetToRunOnPendingNodes(ds); err != nil {
+		return err
+	}
+
+	portworxNodes := sortedPortworxNodes(cluster, nodes)
+	for _, node := range portworxNodes {
+		nodeLog := logrus.WithField("node", node.Name)
+		nodeLog.Infof("Starting migration of portworx pod")
+
+		value := node.Labels[constants.LabelPortworxDaemonsetMigration]
+		if value == constants.LabelValueMigrationDone {
+			nodeLog.Infof("Portworx pod already migrated")
+			continue
+		} else if value == constants.LabelValueMigrationSkip {
+			nodeLog.Infof("Portworx pod migration skipped")
+			continue
+		}
+
+		if err := h.markMigrationAsStarting(node); err != nil {
+			return err
+		}
+
+		// Wait for daemonset pod to terminate, else it causes conflicts with
+		// the operator managed portworx pod
+		if err := h.waitForDaemonSetPodTermination(ds, node.Name, nodeLog); err != nil {
+			return err
+		}
+
+		if err := h.markMigrationAsInProgress(node); err != nil {
+			return err
+		}
+
+		// Wait until operator managed portworx pod is ready
+		if err := h.waitForPortworxPod(cluster, node.Name, nodeLog); err != nil {
+			return err
+		}
+
+		if err := h.markMigrationAsDone(node); err != nil {
+			return err
+		}
+
+		nodeLog.Infof("Portworx pod migration status: %s", node.Labels[constants.LabelPortworxDaemonsetMigration])
+	}
+
+	logrus.Infof("Deleting portworx DaemonSet")
+	if err := h.deletePortworxDaemonSet(ds); err != nil {
+		return err
+	}
+
+	logrus.Infof("Removing migration label from all nodes")
+	if err := h.unmarkAllDoneNodes(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (h *Handler) waitForDaemonSetPodTermination(
+	ds *appsv1.DaemonSet,
+	nodeName string,
+	nodeLog *logrus.Entry,
+) error {
+	return wait.PollImmediate(podWaitInterval, daemonSetPodTerminationTimeout, func() (bool, error) {
+		node := &v1.Node{}
+		if err := h.client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, node); err != nil {
+			nodeLog.Errorf("Failed to get node. %v", err)
+			return false, nil
+		}
+		value := node.Labels[constants.LabelPortworxDaemonsetMigration]
+		if value == constants.LabelValueMigrationSkip {
+			return true, nil
+		}
+
+		podList := &v1.PodList{}
+		fieldSelector := fields.SelectorFromSet(map[string]string{"nodeName": nodeName})
+		err := h.client.List(
+			context.TODO(),
+			podList,
+			&client.ListOptions{
+				Namespace:     ds.Namespace,
+				FieldSelector: fieldSelector,
+				LabelSelector: labels.SelectorFromSet(map[string]string{"name": "portworx"}),
+			},
+		)
+		if err != nil {
+			nodeLog.Errorf("Failed to list daemonset portworx pods. %v", err)
+			return false, nil
+		}
+
+		podPresent := false
+		for _, pod := range podList.Items {
+			owner := metav1.GetControllerOf(&pod)
+			if owner != nil && owner.UID == ds.UID {
+				podPresent = true
+				break
+			}
+		}
+		if podPresent {
+			nodeLog.Debugf("DaemonSet portworx pod is still present")
+			return false, nil
+		}
+
+		nodeLog.Debugf("DaemonSet portworx pod is no longer present")
+		return true, nil
+	})
+}
+
+func (h *Handler) waitForPortworxPod(
+	cluster *corev1.StorageCluster,
+	nodeName string,
+	nodeLog *logrus.Entry,
+) error {
+	return wait.PollImmediate(podWaitInterval, operatorPodReadyTimeout, func() (bool, error) {
+		node := &v1.Node{}
+		if err := h.client.Get(context.TODO(), types.NamespacedName{Name: nodeName}, node); err != nil {
+			nodeLog.Errorf("Failed to get node. %v", err)
+			return false, nil
+		}
+		value := node.Labels[constants.LabelPortworxDaemonsetMigration]
+		if value == constants.LabelValueMigrationSkip {
+			return true, nil
+		}
+
+		podList := &v1.PodList{}
+		fieldSelector := fields.SelectorFromSet(map[string]string{"nodeName": nodeName})
+		err := h.client.List(
+			context.TODO(),
+			podList,
+			&client.ListOptions{
+				Namespace:     cluster.Namespace,
+				FieldSelector: fieldSelector,
+				LabelSelector: labels.SelectorFromSet(h.ctrl.StorageClusterSelectorLabels(cluster)),
+			},
+		)
+		if err != nil {
+			nodeLog.Errorf("Failed to list operator managed portworx pods. %v", err)
+			return false, nil
+		}
+
+		var portworxPod *v1.Pod
+		for _, pod := range podList.Items {
+			owner := metav1.GetControllerOf(&pod)
+			if owner != nil && owner.UID == cluster.UID {
+				portworxPod = pod.DeepCopy()
+				break
+			}
+		}
+		if portworxPod == nil {
+			nodeLog.Debugf("Operator managed portworx pod not found")
+			return false, nil
+		}
+		if portworxPod.DeletionTimestamp != nil || !podutil.IsPodReady(portworxPod) {
+			nodeLog.Debugf("Operator managed portworx pod is not ready")
+			return false, nil
+		}
+
+		nodeLog.Debugf("Operator managed portworx pod is ready")
+		return true, nil
+	})
 }
 
 func (h *Handler) createStorageCluster(
@@ -119,9 +306,10 @@ func (h *Handler) createStorageCluster(
 	// TODO: Handle enable autopilot
 	// TODO: Handle enable monitoring
 
+	logrus.Infof("Creating StorageCluster %v/%v for migration", stc.Namespace, stc.Name)
 	err := h.client.Create(context.TODO(), stc)
 	if err == nil {
-		stc.Status.Phase = phaseAwaitingApproval
+		stc.Status.Phase = constants.PhaseAwaitingApproval
 		err = h.client.Status().Update(context.TODO(), stc)
 	}
 	return stc, err
@@ -454,6 +642,84 @@ func (h *Handler) isMigrationApproved(cluster *corev1.StorageCluster) bool {
 	return err == nil && approved
 }
 
+func (h *Handler) markMigrationAsStarting(n *v1.Node) error {
+	node := &v1.Node{}
+	if err := h.client.Get(context.TODO(), types.NamespacedName{Name: n.Name}, node); err != nil {
+		return err
+	}
+	n.Labels = node.Labels
+	value := node.Labels[constants.LabelPortworxDaemonsetMigration]
+	if value == constants.LabelValueMigrationPending {
+		node.Labels[constants.LabelPortworxDaemonsetMigration] = constants.LabelValueMigrationStarting
+		return h.client.Update(context.TODO(), node, &client.UpdateOptions{})
+	}
+	return nil
+}
+
+func (h *Handler) markMigrationAsInProgress(n *v1.Node) error {
+	node := &v1.Node{}
+	if err := h.client.Get(context.TODO(), types.NamespacedName{Name: n.Name}, node); err != nil {
+		return err
+	}
+	n.Labels = node.Labels
+	value := node.Labels[constants.LabelPortworxDaemonsetMigration]
+	if value == constants.LabelValueMigrationStarting {
+		node.Labels[constants.LabelPortworxDaemonsetMigration] = constants.LabelValueMigrationInProgress
+		return h.client.Update(context.TODO(), node, &client.UpdateOptions{})
+	}
+	return nil
+}
+
+func (h *Handler) markMigrationAsDone(n *v1.Node) error {
+	node := &v1.Node{}
+	if err := h.client.Get(context.TODO(), types.NamespacedName{Name: n.Name}, node); err != nil {
+		return err
+	}
+	n.Labels = node.Labels
+	value := node.Labels[constants.LabelPortworxDaemonsetMigration]
+	if value == constants.LabelValueMigrationInProgress {
+		node.Labels[constants.LabelPortworxDaemonsetMigration] = constants.LabelValueMigrationDone
+		return h.client.Update(context.TODO(), node, &client.UpdateOptions{})
+	}
+	return nil
+}
+
+func (h *Handler) markAllNodesAsPending(nodeList *v1.NodeList) ([]*v1.Node, error) {
+	nodes := []*v1.Node{}
+	for _, n := range nodeList.Items {
+		node := n.DeepCopy()
+		if node.Labels == nil {
+			node.Labels = make(map[string]string)
+		}
+		if v := node.Labels[constants.LabelPortworxDaemonsetMigration]; strings.TrimSpace(v) == "" {
+			node.Labels[constants.LabelPortworxDaemonsetMigration] = constants.LabelValueMigrationPending
+			if err := h.client.Update(context.TODO(), node, &client.UpdateOptions{}); err != nil {
+				return nil, err
+			}
+		}
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}
+
+func (h *Handler) unmarkAllDoneNodes() error {
+	nodeList := &v1.NodeList{}
+	if err := h.client.List(context.TODO(), nodeList, &client.ListOptions{}); err != nil {
+		return err
+	}
+
+	for _, node := range nodeList.Items {
+		value := node.Labels[constants.LabelPortworxDaemonsetMigration]
+		if value == constants.LabelValueMigrationPending || value == constants.LabelValueMigrationDone {
+			delete(node.Labels, constants.LabelPortworxDaemonsetMigration)
+			if err := h.client.Update(context.TODO(), &node, &client.UpdateOptions{}); err != nil {
+				logrus.Errorf("Failed to remove migration label from node: %v. %v", node.Name, err)
+			}
+		}
+	}
+	return nil
+}
+
 func (h *Handler) getPortworxDaemonSet(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 	if ds == nil {
 		return h.findPortworxDaemonSet()
@@ -484,6 +750,106 @@ func (h *Handler) findPortworxDaemonSet() (*appsv1.DaemonSet, error) {
 	}
 
 	return nil, errors.NewNotFound(appsv1.Resource("DaemonSet"), portworxDaemonSetName)
+}
+
+func (h *Handler) deletePortworxDaemonSet(ds *appsv1.DaemonSet) error {
+	pxDaemonSet := &appsv1.DaemonSet{}
+	err := h.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      ds.Name,
+			Namespace: ds.Namespace,
+		},
+		pxDaemonSet,
+	)
+	if errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	return h.client.Delete(context.TODO(), pxDaemonSet)
+}
+
+func (h *Handler) updateDaemonsetToRunOnPendingNodes(ds *appsv1.DaemonSet) error {
+	// Change node affinity rules to enable rolling migration of pods from daemonset
+	// to operator managed pods
+	addMigrationConstraints(&ds.Spec.Template.Spec)
+	// Set the update strategy to OnDelete to avoid restart of the daemonset
+	// pods due to the node affinity changes
+	ds.Spec.UpdateStrategy.Type = appsv1.OnDeleteDaemonSetStrategyType
+	return h.client.Update(context.TODO(), ds, &client.UpdateOptions{})
+}
+
+func addMigrationConstraints(podSpec *v1.PodSpec) {
+	if podSpec.Affinity == nil {
+		podSpec.Affinity = &v1.Affinity{}
+	}
+	if podSpec.Affinity.NodeAffinity == nil {
+		podSpec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	}
+	if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
+	}
+	if len(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0 {
+		podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []v1.NodeSelectorTerm{{}}
+	}
+	selectorTerms := podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	for i, term := range selectorTerms {
+		if term.MatchExpressions == nil {
+			term.MatchExpressions = make([]v1.NodeSelectorRequirement, 0)
+		}
+		selectorTerms[i].MatchExpressions = append(term.MatchExpressions, v1.NodeSelectorRequirement{
+			Key:      constants.LabelPortworxDaemonsetMigration,
+			Operator: v1.NodeSelectorOpIn,
+			Values:   []string{constants.LabelValueMigrationPending},
+		})
+	}
+	podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = selectorTerms
+}
+
+func sortedPortworxNodes(cluster *corev1.StorageCluster, nodes []*v1.Node) []*v1.Node {
+	selectedNodes := []*v1.Node{}
+	for _, node := range nodes {
+		simulationPod := newSimulationPod(cluster)
+		if fitsNode(simulationPod, node) {
+			selectedNodes = append(selectedNodes, node.DeepCopy())
+		} else {
+			logrus.Infof("Node %v deemed to be unfit for portworx pod", node.Name)
+		}
+	}
+
+	sort.Slice(selectedNodes, func(i, j int) bool {
+		return selectedNodes[i].Name < selectedNodes[j].Name
+	})
+
+	return selectedNodes
+}
+
+func fitsNode(pod *v1.Pod, node *v1.Node) bool {
+	fitsNodeAffinity := pluginhelper.PodMatchesNodeSelectorAndAffinityTerms(pod, node)
+	fitsTaints := v1helper.TolerationsTolerateTaintsWithFilter(pod.Spec.Tolerations, node.Spec.Taints, func(t *v1.Taint) bool {
+		return t.Effect == v1.TaintEffectNoExecute || t.Effect == v1.TaintEffectNoSchedule
+	})
+	return fitsNodeAffinity && fitsTaints
+}
+
+func newSimulationPod(cluster *corev1.StorageCluster) *v1.Pod {
+	simulationPod := &v1.Pod{}
+	if cluster.Spec.Placement != nil {
+		if cluster.Spec.Placement.NodeAffinity != nil {
+			simulationPod.Spec.Affinity = &v1.Affinity{
+				NodeAffinity: cluster.Spec.Placement.NodeAffinity.DeepCopy(),
+			}
+		}
+		if len(cluster.Spec.Placement.Tolerations) > 0 {
+			simulationPod.Spec.Tolerations = make([]v1.Toleration, 0)
+			for _, t := range cluster.Spec.Placement.Tolerations {
+				simulationPod.Spec.Tolerations = append(simulationPod.Spec.Tolerations, *(t.DeepCopy()))
+			}
+		}
+	}
+	k8sutil.AddOrUpdateStoragePodTolerations(&simulationPod.Spec)
+	return simulationPod
 }
 
 func getPortworxClusterName(ds *appsv1.DaemonSet) string {

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -219,7 +219,7 @@ func TestStorageClusterIsCreatedFromOnPremDaemonset(t *testing.T) {
 			},
 		},
 		Status: corev1.StorageClusterStatus{
-			Phase: phaseAwaitingApproval,
+			Phase: constants.PhaseAwaitingApproval,
 		},
 	}
 	cluster := &corev1.StorageCluster{}
@@ -377,7 +377,7 @@ func TestStorageClusterIsCreatedFromCloudDaemonset(t *testing.T) {
 			},
 		},
 		Status: corev1.StorageClusterStatus{
-			Phase: phaseAwaitingApproval,
+			Phase: constants.PhaseAwaitingApproval,
 		},
 	}
 	cluster := &corev1.StorageCluster{}

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -1,0 +1,157 @@
+// +build integrationtest
+
+package integrationtest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	appops "github.com/portworx/sched-ops/k8s/apps"
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	operatorops "github.com/portworx/sched-ops/k8s/operator"
+	"github.com/portworx/sched-ops/task"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiscore "k8s.io/kubernetes/pkg/apis/core"
+
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
+	"github.com/libopenstorage/operator/test/integration_test/types"
+	ci_utils "github.com/libopenstorage/operator/test/integration_test/utils"
+)
+
+const (
+	operatorRestartTimeout       = 5 * time.Minute
+	operatorRestartRetryInterval = 10 * time.Second
+	clusterCreationTimeout       = 2 * time.Minute
+	clusterCreationRetryInterval = 5 * time.Second
+)
+
+var migrationTestCases = []types.TestCase{
+	{
+		TestName:   "SimpleDaemonSetMigration",
+		ShouldSkip: func() bool { return false },
+		TestFunc:   BasicMigration,
+	},
+}
+
+func TestMigrationBasic(t *testing.T) {
+	for _, tc := range migrationTestCases {
+		tc.RunTest(t)
+	}
+}
+
+func BasicMigration(tc *types.TestCase) func(*testing.T) {
+	return func(t *testing.T) {
+		if tc.ShouldSkip() {
+			t.Skip()
+		}
+
+		logrus.Infof("Creating portworx daemonset spec")
+		ds := testutil.GetExpectedDaemonSet(t, "migration/simple-daemonset.yaml")
+		require.NotNil(t, ds)
+
+		_, err := appops.Instance().CreateDaemonSet(ds, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		err = appops.Instance().ValidateDaemonSet(ds.Name, ds.Namespace, ci_utils.DefaultValidateDeployTimeout)
+		require.NoError(t, err)
+
+		logrus.Infof("Restarting portworx operator to trigger migration")
+		restartPortworxOperator(t)
+
+		pxImageMap, err := getPortworxImagesFromDaemonSet(t, ds)
+		require.NoError(t, err)
+
+		logrus.Infof("Validate equivalient StorageCluster has been created")
+		cluster, err := validateStorageClusterIsCreatedForDaemonSet(ds)
+		require.NoError(t, err)
+
+		logrus.Infof("Approving migration for StorageCluster %s", cluster.Name)
+		cluster, err = approveMigration(cluster)
+		require.NoError(t, err)
+
+		logrus.Infof("Validate StorageCluster %s", cluster.Name)
+		err = testutil.ValidateStorageCluster(pxImageMap, cluster, ci_utils.DefaultValidateDeployTimeout, ci_utils.DefaultValidateDeployRetryInterval, true)
+		require.NoError(t, err)
+
+		logrus.Infof("Delete StorageCluster %s", cluster.Name)
+		err = testutil.UninstallStorageCluster(cluster)
+		require.NoError(t, err)
+
+		logrus.Infof("Validate StorageCluster %s deletion", cluster.Name)
+		err = testutil.ValidateUninstallStorageCluster(cluster, ci_utils.DefaultValidateUninstallTimeout, ci_utils.DefaultValidateUninstallRetryInterval)
+		require.NoError(t, err)
+	}
+}
+
+func approveMigration(cluster *corev1.StorageCluster) (*corev1.StorageCluster, error) {
+	cluster.Annotations[constants.AnnotationMigrationApproved] = "true"
+	return operatorops.Instance().UpdateStorageCluster(cluster)
+}
+
+func validateStorageClusterIsCreatedForDaemonSet(ds *appsv1.DaemonSet) (*corev1.StorageCluster, error) {
+	clusterName := getClusterNameFromDaemonSet(ds)
+	t := func() (interface{}, bool, error) {
+		cluster, err := operatorops.Instance().GetStorageCluster(clusterName, ds.Namespace)
+		if err != nil {
+			return nil, true, err
+		}
+		return cluster, false, nil
+	}
+	cluster, err := task.DoRetryWithTimeout(t, clusterCreationTimeout, clusterCreationRetryInterval)
+	if err != nil {
+		return nil, err
+	}
+	return cluster.(*corev1.StorageCluster), nil
+}
+
+func getClusterNameFromDaemonSet(ds *appsv1.DaemonSet) string {
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name == "portworx" {
+			for i, arg := range c.Args {
+				if arg == "-c" {
+					return c.Args[i+1]
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func getPortworxImagesFromDaemonSet(t *testing.T, ds *appsv1.DaemonSet) (map[string]string, error) {
+	var pxImage string
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name == "portworx" {
+			pxImage = c.Image
+			break
+		}
+	}
+	require.NotEmpty(t, pxImage)
+
+	parts := strings.Split(pxImage, ":")
+	version := parts[len(parts)-1]
+	require.NotEmpty(t, version)
+
+	versionURL := fmt.Sprintf("https://install.portworx.com/%s", version)
+	return testutil.GetImagesFromVersionURL(versionURL)
+}
+
+func restartPortworxOperator(t *testing.T) {
+	dep, err := appops.Instance().GetDeployment(ci_utils.PortworxOperatorDeploymentName, apiscore.NamespaceSystem)
+	require.NoError(t, err)
+
+	pods, err := appops.Instance().GetDeploymentPods(dep)
+	require.NoError(t, err)
+
+	err = coreops.Instance().DeletePods(pods, false)
+	require.NoError(t, err)
+
+	err = appops.Instance().ValidateDeployment(dep, operatorRestartTimeout, operatorRestartRetryInterval)
+	require.NoError(t, err)
+}

--- a/test/integration_test/testspec/migration/simple-daemonset.yaml
+++ b/test/integration_test/testspec/migration/simple-daemonset.yaml
@@ -1,0 +1,131 @@
+# SOURCE: https://install.portworx.com/?c=px-cluster&aut=false&stork=false
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: portworx
+  namespace: kube-system
+  labels:
+    name: portworx
+  annotations:
+    portworx.com/install-source: "https://install.portworx.com/?c=px-cluster&aut=false&stork=false"
+spec:
+  selector:
+    matchLabels:
+      name: portworx
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: portworx
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+      hostNetwork: true
+      hostPID: false
+      containers:
+        - name: portworx
+          image: portworx/oci-monitor:2.7.4
+          imagePullPolicy: Always
+          args:
+            ["-c", "px-cluster", "-a", "-b",
+             "-x", "kubernetes"]
+          env:
+            - name: "PX_TEMPLATE_VERSION"
+              value: "v4"
+
+          livenessProbe:
+            periodSeconds: 30
+            initialDelaySeconds: 840 # allow image pull in slow networks
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 9001
+          readinessProbe:
+            periodSeconds: 10
+            httpGet:
+              host: 127.0.0.1
+              path: /health
+              port: 9015
+          terminationMessagePath: "/tmp/px-termination-log"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: diagsdump
+              mountPath: /var/cores
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+            - name: containerdsock
+              mountPath: /run/containerd
+            - name: criosock
+              mountPath: /var/run/crio
+            - name: etcpwx
+              mountPath: /etc/pwx
+            - name: dev
+              mountPath: /dev
+            - name: optpwx
+              mountPath: /opt/pwx
+            - name: procmount
+              mountPath: /host_proc
+            - name: sysdmount
+              mountPath: /etc/systemd/system
+            - name: journalmount1
+              mountPath: /var/run/log
+              readOnly: true
+            - name: journalmount2
+              mountPath: /var/log
+              readOnly: true
+            - name: dbusmount
+              mountPath: /var/run/dbus
+      restartPolicy: Always
+      serviceAccountName: px-account
+      volumes:
+        - name: diagsdump
+          hostPath:
+            path: /var/cores
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: containerdsock
+          hostPath:
+            path: /run/containerd
+        - name: criosock
+          hostPath:
+            path: /var/run/crio
+        - name: etcpwx
+          hostPath:
+            path: /etc/pwx
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: optpwx
+          hostPath:
+            path: /opt/pwx
+        - name: procmount
+          hostPath:
+            path: /proc
+        - name: sysdmount
+          hostPath:
+            path: /etc/systemd/system
+        - name: journalmount1
+          hostPath:
+            path: /var/run/log
+        - name: journalmount2
+          hostPath:
+            path: /var/log
+        - name: dbusmount
+          hostPath:
+            path: /var/run/dbus

--- a/test/integration_test/utils/constants.go
+++ b/test/integration_test/utils/constants.go
@@ -22,15 +22,15 @@ var (
 
 const (
 	// DefaultValidateDeployTimeout is a default timeout for deployment validation
-	DefaultValidateDeployTimeout = 900 * time.Second
+	DefaultValidateDeployTimeout = 15 * time.Minute
 	// DefaultValidateDeployRetryInterval is a default retry interval for deployment validation
 	DefaultValidateDeployRetryInterval = 10 * time.Second
 	// DefaultValidateUpgradeTimeout is a default timeout for upgrade validation
-	DefaultValidateUpgradeTimeout = 1400 * time.Second
+	DefaultValidateUpgradeTimeout = 25 * time.Minute
 	// DefaultValidateUpgradeRetryInterval is a default retry interval for upgrade validation
 	DefaultValidateUpgradeRetryInterval = 10 * time.Second
 	// DefaultValidateUninstallTimeout is a default timeout for uninstall validation
-	DefaultValidateUninstallTimeout = 900 * time.Second
+	DefaultValidateUninstallTimeout = 15 * time.Minute
 	// DefaultValidateUninstallRetryInterval is a default retry interval for uninstall validation
 	DefaultValidateUninstallRetryInterval = 10 * time.Second
 
@@ -42,4 +42,7 @@ const (
 
 	// NodeReplacePrefix is used for replacing node name during the test
 	NodeReplacePrefix = "replaceWithNodeNumber"
+
+	// PortworxOperatorDeploymentName name of portworx operator deployment
+	PortworxOperatorDeploymentName = "portworx-operator"
 )


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

*Does handle:*
- Migration of portworx daemonset pods, assuming daemonset pods were in healthy state already
- Allows skipping nodes if user knows the issue and is okay with it 
- Handles restarts of operator during migration
- Handles daemonset placement constraints
- Logs states and errors

*Does not:*
- Does not raise events on failures
- Does not update status of the StorageCluster
- Does not migrate components
- No provision for rollback

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-459

**Special notes for your reviewer**:

