### PR TITLE
[OPERATOR-495] Add test report after run

### DIFF
--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -36,7 +36,7 @@ var (
 var testStorageClusterBasicCases = []types.TestCase{
 	{
 		TestName:        "InstallWithAllDefaults",
-		TestrailCaseIDs: []string{},
+		TestrailCaseIDs: []string{"C51022", "C50236"},
 		TestSpec: ci_utils.CreateStorageClusterTestSpecFunc(&corev1.StorageCluster{
 			ObjectMeta: meta.ObjectMeta{Name: "simple-install"},
 		}),
@@ -44,7 +44,7 @@ var testStorageClusterBasicCases = []types.TestCase{
 	},
 	{
 		TestName:        "NodeAffinityLabels",
-		TestrailCaseIDs: []string{},
+		TestrailCaseIDs: []string{"C50962"},
 		TestSpec: ci_utils.CreateStorageClusterTestSpecFunc(&corev1.StorageCluster{
 			ObjectMeta: meta.ObjectMeta{Name: "node-affinity-labels"},
 			Spec: corev1.StorageClusterSpec{
@@ -71,13 +71,13 @@ var testStorageClusterBasicCases = []types.TestCase{
 	},
 	{
 		TestName:        "Upgrade",
-		TestrailCaseIDs: []string{},
+		TestrailCaseIDs: []string{"C50241"},
 		TestSpec: func(t *testing.T) interface{} {
 			return &corev1.StorageCluster{
 				ObjectMeta: meta.ObjectMeta{Name: "upgrade-test"},
 			}
 		},
-		ShouldSkip: func() bool {
+		ShouldSkip: func(tc *types.TestCase) bool {
 			k8sVersion, _ := k8sutil.GetVersion()
 			pxVersion := ci_utils.GetPxVersionFromSpecGenURL(ci_utils.PxUpgradeHopsURLList[0])
 			return k8sVersion.GreaterThanOrEqual(k8sutil.K8sVer1_22) && pxVersion.LessThan(pxVer2_9)
@@ -86,7 +86,7 @@ var testStorageClusterBasicCases = []types.TestCase{
 	},
 	{
 		TestName:        "InstallWithTelemetry",
-		TestrailCaseIDs: []string{},
+		TestrailCaseIDs: []string{"C55909"},
 		TestSpec: func(t *testing.T) interface{} {
 			cluster := &corev1.StorageCluster{}
 			cluster.Name = "telemetry-test"
@@ -99,20 +99,18 @@ var testStorageClusterBasicCases = []types.TestCase{
 			}
 			return cluster
 		},
-		ShouldSkip: func() bool { return false },
-		TestFunc:   InstallWithTelemetry,
+		TestFunc: InstallWithTelemetry,
 	},
 	{
 		TestName:        "InstallWithCSI",
-		TestrailCaseIDs: []string{},
+		TestrailCaseIDs: []string{"C51020"},
 		TestSpec: ci_utils.CreateStorageClusterTestSpecFunc(&corev1.StorageCluster{
 			ObjectMeta: meta.ObjectMeta{Name: "csi-test"},
 			Spec: corev1.StorageClusterSpec{
 				FeatureGates: map[string]string{"CSI": "true"},
 			},
 		}),
-		ShouldSkip: func() bool { return false },
-		TestFunc:   BasicCsiRegression,
+		TestFunc: BasicCsiRegression,
 	},
 }
 
@@ -124,10 +122,6 @@ func TestStorageClusterBasic(t *testing.T) {
 
 func BasicInstall(tc *types.TestCase) func(*testing.T) {
 	return func(t *testing.T) {
-		if tc.ShouldSkip() {
-			t.Skip()
-		}
-
 		testSpec := tc.TestSpec(t)
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
@@ -140,10 +134,6 @@ func BasicInstall(tc *types.TestCase) func(*testing.T) {
 
 func BasicInstallWithNodeAffinity(tc *types.TestCase) func(*testing.T) {
 	return func(t *testing.T) {
-		if tc.ShouldSkip() {
-			t.Skip()
-		}
-
 		// Set Node Affinity label one of the K8S nodes
 		nodeNameWithLabel := ci_utils.AddLabelToRandomNode(t, labelKeySkipPX, ci_utils.LabelValueTrue)
 
@@ -157,10 +147,6 @@ func BasicInstallWithNodeAffinity(tc *types.TestCase) func(*testing.T) {
 
 func BasicUpgrade(tc *types.TestCase) func(*testing.T) {
 	return func(t *testing.T) {
-		if tc.ShouldSkip() {
-			t.Skip()
-		}
-
 		// Get the storage cluster to start with
 		testSpec := tc.TestSpec(t)
 		cluster, ok := testSpec.(*corev1.StorageCluster)
@@ -207,10 +193,6 @@ func BasicUpgrade(tc *types.TestCase) func(*testing.T) {
 
 func InstallWithTelemetry(tc *types.TestCase) func(*testing.T) {
 	return func(t *testing.T) {
-		if tc.ShouldSkip() {
-			t.Skip()
-		}
-
 		testSpec := tc.TestSpec(t)
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
@@ -261,10 +243,6 @@ func testInstallWithTelemetry(t *testing.T, cluster *corev1.StorageCluster) {
 // 6. Delete StorageCluster and validate it got successfully removed
 func BasicCsiRegression(tc *types.TestCase) func(*testing.T) {
 	return func(t *testing.T) {
-		if tc.ShouldSkip() {
-			t.Skip()
-		}
-
 		var err error
 		testSpec := tc.TestSpec(t)
 		cluster, ok := testSpec.(*corev1.StorageCluster)

--- a/test/integration_test/main_test.go
+++ b/test/integration_test/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	test_util "github.com/libopenstorage/operator/pkg/util/test"
+	"github.com/libopenstorage/operator/test/integration_test/types"
 	ci_utils "github.com/libopenstorage/operator/test/integration_test/utils"
 )
 
@@ -19,7 +20,9 @@ func TestMain(m *testing.M) {
 		logrus.Errorf("Setup failed with error: %v", err)
 		os.Exit(1)
 	}
-	os.Exit(m.Run())
+	exitCode := m.Run()
+	types.TestReporterInstance().PrintTestResult()
+	os.Exit(exitCode)
 }
 
 func setup() error {

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -63,10 +63,6 @@ func TestDaemonSetMigration(t *testing.T) {
 
 func BasicMigration(tc *types.TestCase) func(*testing.T) {
 	return func(t *testing.T) {
-		if tc.ShouldSkip() {
-			t.Skip()
-		}
-
 		testSpec := tc.TestSpec(t)
 		objects, ok := testSpec.([]runtime.Object)
 		require.True(t, ok)
@@ -84,10 +80,6 @@ func BasicMigration(tc *types.TestCase) func(*testing.T) {
 
 func MigrationWithoutNodeAffinity(tc *types.TestCase) func(*testing.T) {
 	return func(t *testing.T) {
-		if tc.ShouldSkip() {
-			t.Skip()
-		}
-
 		testSpec := tc.TestSpec(t)
 		objects, ok := testSpec.([]runtime.Object)
 		require.True(t, ok)

--- a/test/integration_test/types/testcase.go
+++ b/test/integration_test/types/testcase.go
@@ -1,8 +1,12 @@
 package types
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 )
+
+var testReporter *TestReporter
 
 // TestCase represent one or more testrail cases
 type TestCase struct {
@@ -18,17 +22,84 @@ type TestCase struct {
 	// started/failed to start correctly, and then remove it.
 	ShouldStartSuccessfully bool
 	// ShouldSkip check env requirements for the test case
-	ShouldSkip func() bool
+	ShouldSkip func(tc *TestCase) bool
 	// PureBackendRequirements contains additional information to construct a px-pure-secret.
 	PureBackendRequirements *PureBackendRequirements
 
 	// TODO: Add TestSetup and TestTearDown phase func when we have more cases
 }
 
+// TestReporter prints test results at the end of test runs
+// TODO: integration with Testrail in the future
+type TestReporter struct {
+	PassCases []TestCase
+	SkipCases []TestCase
+	FailCases []TestCase
+}
+
 // RunTest executes the actual test function
 func (tc *TestCase) RunTest(t *testing.T) {
 	if tc.ShouldSkip == nil {
-		tc.ShouldSkip = func() bool { return false }
+		tc.ShouldSkip = func(tc *TestCase) bool { return false }
 	}
-	t.Run(tc.TestName, tc.TestFunc(tc))
+	if tc.ShouldSkip(tc) {
+		TestReporterInstance().AddSkipCase(*tc)
+		fmt.Printf("--- SKIP: %s %s\n", tc.TestName, tc.TestrailCaseIDs)
+		return
+	}
+
+	// NOTE: Tests filtered out by name regex will be marked as passed as well
+	passed := t.Run(tc.TestName, tc.TestFunc(tc))
+	if passed {
+		TestReporterInstance().AddPassCase(*tc)
+	} else {
+		TestReporterInstance().AddFailCase(*tc)
+	}
+}
+
+// TestReporterInstance returns the test reporter instance
+func TestReporterInstance() *TestReporter {
+	if testReporter == nil {
+		testReporter = &TestReporter{}
+	}
+	return testReporter
+}
+
+// AddPassCase adds passed test case to test reporter
+func (tp *TestReporter) AddPassCase(tc TestCase) {
+	tp.PassCases = append(tp.PassCases, tc)
+}
+
+// AddSkipCase adds skipped test case to test reporter
+func (tp *TestReporter) AddSkipCase(tc TestCase) {
+	tp.SkipCases = append(tp.SkipCases, tc)
+}
+
+// AddFailCase adds failed test case to test reporter
+func (tp *TestReporter) AddFailCase(tc TestCase) {
+	tp.FailCases = append(tp.FailCases, tc)
+}
+
+// PrintTestResult prints the test result at the end of test
+func (tp *TestReporter) PrintTestResult() {
+	fmt.Println(strings.Repeat("=", 50))
+	defer fmt.Println(strings.Repeat("=", 50))
+
+	// Print Passed cases
+	fmt.Println("--- PASS:")
+	for _, tc := range TestReporterInstance().PassCases {
+		fmt.Printf("    %s %s\n", tc.TestName, tc.TestrailCaseIDs)
+	}
+
+	// Print Skipped cases
+	fmt.Println("--- SKIP:")
+	for _, tc := range TestReporterInstance().SkipCases {
+		fmt.Printf("    %s %s\n", tc.TestName, tc.TestrailCaseIDs)
+	}
+
+	// Print Failed cases
+	fmt.Println("--- FAIL:")
+	for _, tc := range TestReporterInstance().FailCases {
+		fmt.Printf("    %s %s\n", tc.TestName, tc.TestrailCaseIDs)
+	}
 }

--- a/test/integration_test/utils/constants.go
+++ b/test/integration_test/utils/constants.go
@@ -1,6 +1,8 @@
 package utils
 
-import "time"
+import (
+	"time"
+)
 
 // Global test parameters that are set at the beginning of the run
 var (


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: print a test report block after run
```
--- PASS:
--- SKIP:
--- FAIL:
```

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**: sample output
```
--- PASS: TestStorageClusterBasic (170.98s)
    --- PASS: TestStorageClusterBasic/NodeAffinityLabels (170.98s)
=== RUN   TestFAFBPositiveInstallation
Source config not present, skipping
--- SKIP: C55130 [C55130]
Source config not present, skipping
--- SKIP: C55129-C56414-C56411-C55003 [C55129 C56414 C56411 C55003]
Source config not present, skipping
--- SKIP: C55133 [C55133]
Source config not present, skipping
--- SKIP: C56412 [C56412]
Source config not present, skipping
--- SKIP: C56413 [C56413]
--- PASS: TestFAFBPositiveInstallation (0.00s)
=== RUN   TestMigrationBasic
--- PASS: TestMigrationBasic (0.00s)
PASS
--- PASS:
    InstallWithAllDefaults [C51022 C50236]
    NodeAffinityLabels [C50962]
    Upgrade [C50241]
    InstallWithTelemetry [C55909]
    InstallWithCSI [C51020]
    SimpleDaemonSetMigration []
--- SKIP:
    C55130 [C55130]
    C55129-C56414-C56411-C55003 [C55129 C56414 C56411 C55003]
    C55133 [C55133]
    C56412 [C56412]
    C56413 [C56413]
--- FAIL:
=== Skipped
=== SKIP: . C55130 [C55130] (0.00s)
--- SKIP: C55130 [C55130]
Source config not present, skipping
=== SKIP: . C55129-C56414-C56411-C55003 [C55129 C56414 C56411 C55003] (0.00s)
--- SKIP: C55129-C56414-C56411-C55003 [C55129 C56414 C56411 C55003]
Source config not present, skipping
=== SKIP: . C55133 [C55133] (0.00s)
--- SKIP: C55133 [C55133]
Source config not present, skipping
=== SKIP: . C56412 [C56412] (0.00s)
--- SKIP: C56412 [C56412]
Source config not present, skipping
=== SKIP: . C56413 [C56413] (0.00s)
--- SKIP: C56413 [C56413]
DONE 9 tests, 5 skipped in 171.271s
Tests passed
```
last a few lines were printed automatically by go test.