### PR TITLE
[OPERATOR-502] Add support to check portworx-operator version

### DIFF
--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -100,6 +100,9 @@ var testStorageClusterBasicCases = []types.TestCase{
 			return cluster
 		},
 		TestFunc: InstallWithTelemetry,
+		ShouldSkip: func(tc *types.TestCase) bool {
+			return ci_utils.PxOperatorVersion.LessThan(ci_utils.PxOperatorVer1_7)
+		},
 	},
 	{
 		TestName:        "InstallWithCSI",

--- a/test/integration_test/main_test.go
+++ b/test/integration_test/main_test.go
@@ -4,6 +4,7 @@ package integrationtest
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -62,6 +63,11 @@ func setup() error {
 	}
 
 	ci_utils.PxUpgradeHopsURLList = strings.Split(pxUpgradeHopsURLs, ",")
+
+	ci_utils.PxOperatorVersion, err = ci_utils.GetPXOperatorVersion()
+	if err != nil {
+		return fmt.Errorf("failed to discover installed portworx operator version: %v", err)
+	}
 
 	// Set log level
 	logrusLevel, err := logrus.ParseLevel(logLevel)

--- a/test/integration_test/types/testcase.go
+++ b/test/integration_test/types/testcase.go
@@ -87,19 +87,19 @@ func (tp *TestReporter) PrintTestResult() {
 
 	// Print Passed cases
 	fmt.Println("--- PASS:")
-	for _, tc := range TestReporterInstance().PassCases {
+	for _, tc := range tp.PassCases {
 		fmt.Printf("    %s %s\n", tc.TestName, tc.TestrailCaseIDs)
 	}
 
 	// Print Skipped cases
 	fmt.Println("--- SKIP:")
-	for _, tc := range TestReporterInstance().SkipCases {
+	for _, tc := range tp.SkipCases {
 		fmt.Printf("    %s %s\n", tc.TestName, tc.TestrailCaseIDs)
 	}
 
 	// Print Failed cases
 	fmt.Println("--- FAIL:")
-	for _, tc := range TestReporterInstance().FailCases {
+	for _, tc := range tp.FailCases {
 		fmt.Printf("    %s %s\n", tc.TestName, tc.TestrailCaseIDs)
 	}
 }

--- a/test/integration_test/utils/constants.go
+++ b/test/integration_test/utils/constants.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"time"
+
+	"github.com/hashicorp/go-version"
 )
 
 // Global test parameters that are set at the beginning of the run
@@ -20,6 +22,9 @@ var (
 
 	// PxUpgradeHopsURLList urls for upgrade test
 	PxUpgradeHopsURLList []string
+
+	// PxOperatorVersion is the version of installed px operator found
+	PxOperatorVersion *version.Version
 )
 
 const (
@@ -54,6 +59,10 @@ const (
 	// NodeReplacePrefix is used for replacing node name during the test
 	NodeReplacePrefix = "replaceWithNodeNumber"
 
+	// PxNamespace is a default namespace for StorageCluster
+	PxNamespace = "kube-system"
 	// PortworxOperatorDeploymentName name of portworx operator deployment
 	PortworxOperatorDeploymentName = "portworx-operator"
+	// PortworxOperatorContainerName name of portworx operator container
+	PortworxOperatorContainerName = "portworx-operator"
 )

--- a/test/integration_test/utils/px_operator.go
+++ b/test/integration_test/utils/px_operator.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	"github.com/sirupsen/logrus"
+
+	appops "github.com/portworx/sched-ops/k8s/apps"
+)
+
+const (
+	nextReleaseTag = "1.7.0-dev"
+)
+
+var (
+	// PxOperatorVer1_7 portworx-operator 1.7 minimum version
+	PxOperatorVer1_7, _ = version.NewVersion("1.7-")
+)
+
+// TODO: Install portworx-operator in test automation
+
+// GetPXOperatorVersion returns the portworx operator version found
+func GetPXOperatorVersion() (*version.Version, error) {
+	pxImageTag, err := getPXOperatorImageTag()
+	if err != nil {
+		return nil, err
+	}
+
+	// We may run the automation on operator installed using private images,
+	// so assume we are testing the latest operator version if failed to parse the tag
+	opVersion, err := version.NewVersion(pxImageTag)
+	if err != nil {
+		logrus.WithError(err).Warnf("Failed to parse portworx-operator tag to version, assuming next release tag")
+		opVersion, _ = version.NewVersion(nextReleaseTag)
+	}
+
+	logrus.Infof("Testing portworx-operator version: %s", opVersion.String())
+	return opVersion, nil
+}
+
+func getPXOperatorImageTag() (string, error) {
+	deployment, err := appops.Instance().GetDeployment(PortworxOperatorDeploymentName, PxNamespace)
+	if err != nil {
+		return "", err
+	}
+
+	var image string
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == PortworxOperatorContainerName {
+			image = container.Image
+			logrus.Infof("Get portworx-operator image installed: %s", image)
+			break
+		}
+	}
+
+	return strings.Split(image, ":")[1], nil
+}

--- a/test/integration_test/utils/storagecluster.go
+++ b/test/integration_test/utils/storagecluster.go
@@ -18,8 +18,6 @@ import (
 const (
 	// specDir is a directory with all the specs
 	specDir = "./operator-test"
-	// PxNamespace is a default namespace for StorageCluster
-	PxNamespace = "kube-system"
 )
 
 // CreateStorageClusterTestSpecFunc creates a function that returns test specs for a test case


### PR DESCRIPTION

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Check the px-operator version and skip tests

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

