### PR TITLE
OPERATOR-505 Add spec fields for components during migration

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -597,7 +597,7 @@ func (t *template) csiRegistrarContainer() *v1.Container {
 	}
 
 	if t.cluster.Status.DesiredImages.CSINodeDriverRegistrar != "" {
-		container.Name = "csi-node-driver-registrar"
+		container.Name = pxutil.CSIRegistrarContainerName
 		container.Image = util.GetImageURN(
 			t.cluster,
 			t.cluster.Status.DesiredImages.CSINodeDriverRegistrar,
@@ -629,7 +629,7 @@ func (t *template) csiRegistrarContainer() *v1.Container {
 
 func (t *template) telemetryContainer() *v1.Container {
 	container := v1.Container{
-		Name: "telemetry",
+		Name: pxutil.TelemetryContainerName,
 		Image: util.GetImageURN(
 			t.cluster,
 			t.getDesiredTelemetryImage(t.cluster),

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -48,6 +48,10 @@ const (
 	PortworxServiceName = "portworx-service"
 	// PortworxKVDBServiceName name of the Portworx KVDB Kubernetes service
 	PortworxKVDBServiceName = "portworx-kvdb-service"
+	// CSIRegistrarContainerName name of the Portworx CSI node driver registrar container
+	CSIRegistrarContainerName = "csi-node-driver-registrar"
+	// TelemetryContainerName name of the Portworx telemetry container
+	TelemetryContainerName = "telemetry"
 	// PortworxRESTPortName name of the Portworx API port
 	PortworxRESTPortName = "px-api"
 	// PortworxSDKPortName name of the Portworx SDK port

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -1,0 +1,138 @@
+package migration
+
+import (
+	"context"
+
+	"github.com/libopenstorage/operator/drivers/storage/portworx/component"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	storkDeploymentName              = "stork"
+	prometheusOperatorDeploymentName = "prometheus-operator"
+	serviceMonitorName               = "portworx-prometheus-sm"
+)
+
+func (h *Handler) addStorkSpec(cluster *corev1.StorageCluster) error {
+	dep, err := h.getDeployment(storkDeploymentName, cluster.Namespace)
+	if err != nil {
+		return err
+	}
+	cluster.Spec.Stork = &corev1.StorkSpec{
+		Enabled: dep != nil,
+	}
+	return nil
+}
+
+func (h *Handler) addAutopilotSpec(cluster *corev1.StorageCluster) error {
+	dep, err := h.getDeployment(component.AutopilotDeploymentName, cluster.Namespace)
+	if err != nil {
+		return err
+	}
+	cluster.Spec.Autopilot = &corev1.AutopilotSpec{
+		Enabled: dep != nil,
+	}
+	return nil
+}
+
+func (h *Handler) addPVCControllerSpec(cluster *corev1.StorageCluster) error {
+	dep, err := h.getDeployment(component.PVCDeploymentName, cluster.Namespace)
+	if err != nil {
+		return err
+	} else if dep == nil {
+		return nil
+	}
+	// Explicitly enable pvc controller in kube system namespace as operator won't
+	// enable it by default if running in kube-system namespace
+	if cluster.Namespace == "kube-system" {
+		cluster.Annotations[pxutil.AnnotationPVCController] = "true"
+	}
+	return nil
+}
+
+func (h *Handler) addMonitoringSpec(cluster *corev1.StorageCluster) error {
+	// Check if metrics need to be exported
+	svcMonitorFound := true
+	svcMonitor := &monitoringv1.ServiceMonitor{}
+	err := h.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      serviceMonitorName,
+			Namespace: cluster.Namespace,
+		},
+		svcMonitor,
+	)
+	if errors.IsNotFound(err) {
+		svcMonitorFound = false
+	} else if err != nil {
+		return err
+	}
+	if cluster.Spec.Monitoring == nil {
+		cluster.Spec.Monitoring = &corev1.MonitoringSpec{}
+	}
+	cluster.Spec.Monitoring.Prometheus = &corev1.PrometheusSpec{
+		ExportMetrics: svcMonitorFound,
+	}
+
+	// Check for alert manager
+	alertManagerFound := true
+	alertManager := &monitoringv1.Alertmanager{}
+	err = h.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      component.AlertManagerInstanceName,
+			Namespace: cluster.Namespace,
+		},
+		alertManager,
+	)
+	if errors.IsNotFound(err) {
+		alertManagerFound = false
+	} else if err != nil {
+		return err
+	}
+	cluster.Spec.Monitoring.Prometheus.AlertManager = &corev1.AlertManagerSpec{
+		Enabled: alertManagerFound,
+	}
+
+	if !cluster.Spec.Monitoring.Prometheus.ExportMetrics &&
+		!cluster.Spec.Monitoring.Prometheus.AlertManager.Enabled {
+		return nil
+	}
+
+	// Check for prometheus operator
+	dep, err := h.getDeployment(prometheusOperatorDeploymentName, cluster.Namespace)
+	if err != nil {
+		return err
+	}
+	if dep != nil {
+		if dep.Labels["k8s-app"] != prometheusOperatorDeploymentName {
+			return nil
+		}
+		cluster.Spec.Monitoring.Prometheus.Enabled = true
+	}
+
+	return nil
+}
+
+func (h *Handler) getDeployment(name, namespace string) (*appsv1.Deployment, error) {
+	dep := &appsv1.Deployment{}
+	err := h.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+		dep,
+	)
+	if errors.IsNotFound(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	return dep, nil
+}


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Created a separate file for StorageCluster spec generation code as the file was getting big. Have added only the new code to it to make it easier for review. Will move the rest of the StorageCluster creation code in a separate PR later.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-505

**Special notes for your reviewer**:

