### PR TITLE
PTX-2758 Autopilot validation and basic regression test

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -966,6 +966,12 @@ func ValidateAutopilot(pxImageList map[string]string, cluster *corev1.StorageClu
 		if errors.IsNotFound(err) {
 			return fmt.Errorf("failed to validate ConfigMap %s, Err: %v", autopilotConfigMapName, err)
 		}
+
+		// Validate Autopilot ServiceAccount
+		_, err = coreops.Instance().GetServiceAccount(autopilotDp.Name, autopilotDp.Namespace)
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("failed to validate ServiceAccount %s, Err: %v", autopilotDp.Name, err)
+		}
 	} else {
 		logrus.Debug("Autopilot is Disabled in StorageCluster")
 		// Validate autopilot deployment is terminated or doesn't exist
@@ -989,6 +995,12 @@ func ValidateAutopilot(pxImageList map[string]string, cluster *corev1.StorageClu
 		_, err = coreops.Instance().GetConfigMap(autopilotConfigMapName, autopilotDp.Namespace)
 		if !errors.IsNotFound(err) {
 			return fmt.Errorf("failed to validate ConfigMap %s, is found when shouldn't be", autopilotConfigMapName)
+		}
+
+		// Validate Autopilot ServiceAccount doesn't exist
+		_, err = coreops.Instance().GetServiceAccount(autopilotDp.Name, autopilotDp.Namespace)
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to validate ServiceAccount %s, is found when shouldn't be", autopilotDp.Name)
 		}
 	}
 

--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -420,9 +420,9 @@ func BasicStorkRegression(tc *types.TestCase) func(*testing.T) {
 }
 
 // BasicAutopilotRegression test includes the following steps:
-// 1. Deploy PX and validate Stork components and images
+// 1. Deploy PX and validate Autopilot components and images
 // 2. Validate Autopilot is disabled by default
-// 3. Enabled Autopilot and validate Autopilot components and images
+// 3. Enable Autopilot and validate Autopilot components and images
 // 4. Delete "autopilot" pod and validate it gets re-deployed
 // 5. Disable Autopilot and validate Autopilot components got successfully removed
 // 6. Delete StorageCluster and validate it got successfully removed
@@ -442,10 +442,9 @@ func BasicAutopilotRegression(tc *types.TestCase) func(*testing.T) {
 		logrus.Info("Enable Autopilot and validate StorageCluster")
 		updateParamFunc := func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
 			// At this point this object should be <nil>
-			if cluster.Spec.Autopilot == nil {
-				cluster.Spec.Autopilot = &corev1.AutopilotSpec{}
+			cluster.Spec.Autopilot = &corev1.AutopilotSpec{
+				Enabled: true,
 			}
-			cluster.Spec.Autopilot.Enabled = true
 			return cluster
 		}
 		cluster = ci_utils.UpdateAndValidateAutopilot(cluster, updateParamFunc, ci_utils.PxSpecImages, t)

--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -123,6 +123,14 @@ var testStorageClusterBasicCases = []types.TestCase{
 		}),
 		TestFunc: BasicStorkRegression,
 	},
+	{
+		TestName: "BasicAutopilotRegression",
+		TestrailCaseIDs: []string{"C57036", "C51237", "C58434", "	C58435", "C58433", "C51238", "C58432", "C51245"},
+		TestSpec: ci_utils.CreateStorageClusterTestSpecFunc(&corev1.StorageCluster{
+			ObjectMeta: meta.ObjectMeta{Name: "autopilot-regression-test"},
+		}),
+		TestFunc: BasicAutopilotRegression,
+	},
 }
 
 func TestStorageClusterBasic(t *testing.T) {
@@ -405,6 +413,67 @@ func BasicStorkRegression(tc *types.TestCase) func(*testing.T) {
 		}
 		cluster = ci_utils.UpdateAndValidateStork(cluster, updateParamFunc, ci_utils.PxSpecImages, ci_utils.K8sVersion, t)
 		require.True(t, cluster.Spec.Stork.Enabled, "failed to validate Stork is enabled: expected: true, actual: %v", cluster.Spec.Stork.Enabled)
+
+		// Delete and validate StorageCluster deletion
+		ci_utils.UninstallAndValidateStorageCluster(cluster, t)
+	}
+}
+
+// BasicAutopilotRegression test includes the following steps:
+// 1. Deploy PX and validate Stork components and images
+// 2. Validate Autopilot is disabled by default
+// 3. Enabled Autopilot and validate Autopilot components and images
+// 4. Delete "autopilot" pod and validate it gets re-deployed
+// 5. Disable Autopilot and validate Autopilot components got successfully removed
+// 6. Delete StorageCluster and validate it got successfully removed
+func BasicAutopilotRegression(tc *types.TestCase) func(*testing.T) {
+	return func(t *testing.T) {
+		var err error
+		testSpec := tc.TestSpec(t)
+		cluster, ok := testSpec.(*corev1.StorageCluster)
+		require.True(t, ok)
+
+		// Create and validate StorageCluster
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
+
+		// Validate Autopilot block is nil
+		require.Nil(t, cluster.Spec.Autopilot, "failed to validate Autopilot block, it should be nil by default, but it seems there is something set in there %+v", cluster.Spec.Autopilot)
+
+		logrus.Info("Enable Autopilot and validate StorageCluster")
+		updateParamFunc := func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
+			// At this point this object should be <nil>
+			if cluster.Spec.Autopilot == nil {
+				cluster.Spec.Autopilot = &corev1.AutopilotSpec{}
+			}
+			cluster.Spec.Autopilot.Enabled = true
+			return cluster
+		}
+		cluster = ci_utils.UpdateAndValidateAutopilot(cluster, updateParamFunc, ci_utils.PxSpecImages, t)
+		require.NotNil(t, cluster.Spec.Autopilot, "failed to validate Autopilot block, it should not be nil here, but it is: %+v", cluster.Spec.Autopilot)
+		require.True(t, cluster.Spec.Autopilot.Enabled, "failed to validate Autopilot is enabled: expected: true, actual: %v", cluster.Spec.Autopilot.Enabled)
+
+		logrus.Info("Delete autopilot pod and validate it gets re-deployed")
+		err = appsops.Instance().DeleteDeploymentPods("autopilot", cluster.Namespace, 60*time.Second)
+		require.NoError(t, err)
+		err = testutil.ValidateAutopilot(ci_utils.PxSpecImages, cluster, ci_utils.DefaultValidateAutopilotTimeout, ci_utils.DefaultValidateAutopilotRetryInterval)
+		require.NoError(t, err)
+
+		logrus.Info("Disable Autopilot and validate StorageCluster")
+		updateParamFunc = func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
+			cluster.Spec.Autopilot.Enabled = false
+			return cluster
+		}
+		cluster = ci_utils.UpdateAndValidateAutopilot(cluster, updateParamFunc, ci_utils.PxSpecImages, t)
+		require.NotNil(t, cluster.Spec.Autopilot, "failed to validate Autopilot block, it should not be nil here, but it is: %+v", cluster.Spec.Autopilot)
+		require.False(t, cluster.Spec.Autopilot.Enabled, "failed to validate Autopilot is enabled: expected: false, actual: %v", cluster.Spec.Autopilot.Enabled)
+
+		logrus.Info("Remove Autopilot block (set it to nil) and validate StorageCluster")
+		updateParamFunc = func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
+			cluster.Spec.Autopilot = nil
+			return cluster
+		}
+		cluster = ci_utils.UpdateAndValidateAutopilot(cluster, updateParamFunc, ci_utils.PxSpecImages, t)
+		require.Nil(t, cluster.Spec.Autopilot, "failed to validate Autopilot block, it should be nil here, but it is not: %+v", cluster.Spec.Autopilot)
 
 		// Delete and validate StorageCluster deletion
 		ci_utils.UninstallAndValidateStorageCluster(cluster, t)

--- a/test/integration_test/utils/constants.go
+++ b/test/integration_test/utils/constants.go
@@ -51,6 +51,10 @@ const (
 	DefaultValidateStorkTimeout = 10 * time.Minute
 	// DefaultValidateStorkRetryInterval is a default retry interval for stork validation
 	DefaultValidateStorkRetryInterval = 5 * time.Second
+	// DefaultValidateAutopilotTimeout is a default timeout for autopilot validation
+	DefaultValidateAutopilotTimeout = 3 * time.Minute
+	// DefaultValidateAutopilotRetryInterval is a default retry interval for autopilot validation
+	DefaultValidateAutopilotRetryInterval = 2 * time.Second
 
 	// LabelValueTrue value "true" for a label
 	LabelValueTrue = "true"

--- a/test/integration_test/utils/storagecluster.go
+++ b/test/integration_test/utils/storagecluster.go
@@ -122,6 +122,22 @@ func UpdateAndValidateStork(cluster *corev1.StorageCluster, f func(*corev1.Stora
 	return latestLiveCluster
 }
 
+// UpdateAndValidateAutopilot update StorageCluster, validates Autopilot components only and return latest version of live StorageCluster
+func UpdateAndValidateAutopilot(cluster *corev1.StorageCluster, f func(*corev1.StorageCluster) *corev1.StorageCluster, pxSpecImages map[string]string, t *testing.T) *corev1.StorageCluster {
+	liveCluster, err := operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
+	require.NoError(t, err)
+
+	newCluster := f(liveCluster)
+
+	latestLiveCluster, err := UpdateStorageCluster(newCluster)
+	require.NoError(t, err)
+
+	err = testutil.ValidateAutopilot(pxSpecImages, latestLiveCluster, DefaultValidateAutopilotTimeout, DefaultValidateAutopilotRetryInterval)
+	require.NoError(t, err)
+
+	return latestLiveCluster
+}
+
 // UninstallAndValidateStorageCluster uninstall and validate the cluster deletion
 func UninstallAndValidateStorageCluster(cluster *corev1.StorageCluster, t *testing.T) {
 	// Delete cluster


### PR DESCRIPTION
Stork basic regression test and various improvements for validation of Stork components and images

* Added Autopilot basic regression test that covers multiple Autopilot test cases
             Autopilot - Validate Autopilot is not enabled by default
             Autopilot - Deploy Autopilot with enabled set to true
             Autopilot - Validate Autopilot serviceaccount, clusterrole, clusterrolebindings and configmap when Autopilot is Enabled 
             Autopilot - Validate Autopilot serviceaccount, clusterrole, clusterrolebindings and configmap are deleted when Autopilot is Disabled or is nil
             Autopilot - Delete Autopilot pod and validate it get re-deployed 
             Autopilot - Disable Autopilot by setting enabled to false 
             Autopilot - Delete Autopilot all together by removing autopilot block/object or setting it to nil 
             Autopilot - Autopilot should not be deployed if enabled set to false 
* Added more in-depth validation for Autopilot components and images

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>

