### PR TITLE
OPERATOR-527 Check if the monitoring APIs are registered

### DIFF
--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -9,6 +9,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -67,7 +68,9 @@ func (h *Handler) addMonitoringSpec(cluster *corev1.StorageCluster) error {
 		},
 		svcMonitor,
 	)
-	if errors.IsNotFound(err) {
+	if meta.IsNoMatchError(err) {
+		return nil
+	} else if errors.IsNotFound(err) {
 		svcMonitorFound = false
 	} else if err != nil {
 		return err


### PR DESCRIPTION
- Do not assume that monitoring APIs are registered. If they are
  not then it means the monitoring components are not present
  at all. So no need to add anything to the StorageCluster spec.

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-527

**Special notes for your reviewer**:

