### PR TITLE
[OPERATOR-438] Add portworx proxy support for telemetry ccm container

### DIFF
--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2289,6 +2289,31 @@ func TestPodWithTelemetry(t *testing.T) {
 
 	assertPodSpecEqual(t, expected, &actual)
 
+	// Add a proxy for CCM service
+	expected = getExpectedPodSpecFromDaemonset(t, "testspec/px_telemetry_with_proxy.yaml")
+	cluster.Spec.Env = []v1.EnvVar{
+		{
+			Name:  pxutil.EnvKeyPortworxHTTPProxy,
+			Value: "https://username:password@hotstname:port",
+		},
+	}
+	driver = portworx{}
+	driver.SetDefaultsOnStorageCluster(cluster)
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+
+	assertPodSpecEqual(t, expected, &actual)
+
+	// Remove the proxy for CCM service
+	expected = getExpectedPodSpecFromDaemonset(t, "testspec/px_telemetry.yaml")
+	cluster.Spec.Env = nil
+	driver = portworx{}
+	driver.SetDefaultsOnStorageCluster(cluster)
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+
+	assertPodSpecEqual(t, expected, &actual)
+
 	// Now disable telemetry
 	expected = getExpectedPodSpecFromDaemonset(t, "testspec/px_disable_telemetry.yaml")
 	cluster.Spec.Monitoring.Telemetry.Enabled = false

--- a/drivers/storage/portworx/testspec/ccmconfig.yaml
+++ b/drivers/storage/portworx/testspec/ccmconfig.yaml
@@ -68,7 +68,7 @@ data:
             "use_appliance_id": "true"
           },
           "proxy": {
-            "path": "/dev/null"
+            "path": "/cache/network/http_proxy"
           }
         }
   location: internal

--- a/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
@@ -1,0 +1,235 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: portworx
+  namespace: kube-system
+  labels:
+    name: portworx
+  annotations:
+    portworx.io/arcus-location: "internal"
+spec:
+  selector:
+    matchLabels:
+      name: portworx
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: portworx
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                  - "false"
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+      hostNetwork: true
+      hostPID: false
+      containers:
+        - name: portworx
+          image: portworx/oci-monitor:2.8.0
+          imagePullPolicy: Always
+          args:
+            ["-c", "px-cluster", "-a", "-b",
+             "-secret_type", "k8s",
+             "-x", "kubernetes"]
+          env:
+            - name: "PX_TEMPLATE_VERSION"
+              value: "v4"
+            - name: "PX_HTTP_PROXY"
+              value: "https://username:password@hotstname:port"
+            - name: "PX_NAMESPACE"
+              value: "kube-system"
+            - name: "PX_SECRETS_NAMESPACE"
+              value: "kube-system"
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+          livenessProbe:
+            periodSeconds: 30
+            initialDelaySeconds: 840 # allow image pull in slow networks
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 9001
+          readinessProbe:
+            periodSeconds: 10
+            httpGet:
+              host: 127.0.0.1
+              path: /health
+              port: 9015
+          terminationMessagePath: "/tmp/px-termination-log"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: diagsdump
+              mountPath: /var/cores
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+            - name: containerddir
+              mountPath: /run/containerd
+            - name: criosock
+              mountPath: /var/run/crio
+            - name: crioconf
+              mountPath: /etc/crictl.yaml
+            - name: etcpwx
+              mountPath: /etc/pwx
+            - name: optpwx
+              mountPath: /opt/pwx
+            - name: varlibosd
+              mountPath: /var/lib/osd
+              mountPropagation: Bidirectional
+            - name: procmount
+              mountPath: /host_proc
+            - name: sysdmount
+              mountPath: /etc/systemd/system
+            - name: journalmount1
+              mountPath: /var/run/log
+              readOnly: true
+            - name: journalmount2
+              mountPath: /var/log
+              readOnly: true
+            - name: dbusmount
+              mountPath: /var/run/dbus
+        - env:
+            - name: configFile
+              value: /etc/ccm/ccm.properties
+            - name: PX_NAMESPACE
+              value: kube-system
+          image: portworx/px-telemetry:2.1.2
+          imagePullPolicy: Always
+          args:
+            - "-Dserver.rest_server.core_pool_size=2"
+            - "-Dstandalone.controller_sn=testNode"
+          livenessProbe:
+            periodSeconds: 30
+            httpGet:
+              host: 127.0.0.1
+              path: /1.0/status
+              port: 1970
+          name: telemetry
+          resources:
+            requests:
+              memory: "256Mi"
+            limits:
+              memory: "512Mi"
+          readinessProbe:
+            periodSeconds: 30
+            httpGet:
+              host: 127.0.0.1
+              path: /1.0/status
+              port: 1970
+          securityContext:
+            privileged: true
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/cache
+              name: varcache
+            - mountPath: /etc/timezone
+              name: timezone
+            - mountPath: /etc/localtime
+              name: localtime
+            - mountPath: /etc/ccm
+              name: ccm-config
+            - mountPath: /cache/network/http_proxy
+              name: ccm-proxy-config
+              subPath: http_proxy
+            - mountPath: /var/cores
+              name: diagsdump
+            - mountPath: /etc/pwx
+              name: etcpwx
+            - name: varlibosd
+              mountPath: /var/lib/osd
+              mountPropagation: Bidirectional
+            - mountPath: /var/run/log
+              name: journalmount1
+              readOnly: true
+            - mountPath: /var/log
+              name: journalmount2
+              readOnly: true
+      restartPolicy: Always
+      serviceAccountName: portworx
+      volumes:
+        - name: diagsdump
+          hostPath:
+            path: /var/cores
+        - name: dockersock
+          hostPath:
+            path: /var/run/docker.sock
+        - name: containerddir
+          hostPath:
+            path: /run/containerd
+        - name: criosock
+          hostPath:
+            path: /var/run/crio
+        - name: crioconf
+          hostPath:
+            path: /etc/crictl.yaml
+            type: FileOrCreate
+        - name: etcpwx
+          hostPath:
+            path: /etc/pwx
+        - name: optpwx
+          hostPath:
+            path: /opt/pwx
+        - name: varlibosd
+          hostPath:
+            path: /var/lib/osd
+        - name: procmount
+          hostPath:
+            path: /proc
+        - name: sysdmount
+          hostPath:
+            path: /etc/systemd/system
+        - name: journalmount1
+          hostPath:
+            path: /var/run/log
+        - name: journalmount2
+          hostPath:
+            path: /var/log
+        - name: dbusmount
+          hostPath:
+            path: /var/run/dbus
+        - hostPath:
+            path: /var/cache
+          name: varcache
+        - hostPath:
+            path: /etc/timezone
+          name: timezone
+        - hostPath:
+            path: /etc/localtime
+          name: localtime
+        - configMap:
+            items:
+              - key: ccm.properties
+                path: ccm.properties
+              - key: location
+                path: location
+            name: px-telemetry-config
+          name: ccm-config
+        - configMap:
+            items:
+              - key: http_proxy
+                path: http_proxy
+            name: px-ccm-service-proxy-config
+          name: ccm-proxy-config

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -159,6 +159,10 @@ const (
 	EnvKeyPortworxEssentials = "PORTWORX_ESSENTIALS"
 	// EnvKeyMarketplaceName env var for the name of the source marketplace
 	EnvKeyMarketplaceName = "MARKETPLACE_NAME"
+	// EnvKeyPortworxHTTPProxy env var to use http proxy
+	EnvKeyPortworxHTTPProxy = "PX_HTTP_PROXY"
+	// EnvKeyPortworxHTTPSProxy env var to use https proxy
+	EnvKeyPortworxHTTPSProxy = "PX_HTTPS_PROXY"
 
 	// SecurityPXSystemSecretsSecretName is the secret name for PX security system secrets
 	SecurityPXSystemSecretsSecretName = "px-system-secrets"
@@ -494,6 +498,20 @@ func GetClusterEnvVarValue(ctx context.Context, cluster *corev1.StorageCluster, 
 	}
 
 	return ""
+}
+
+// GetPxProxyEnvVarValue returns the PX_HTTP(S)_PROXY environment variable value for a cluster.
+// Note: we only expect one proxy for the telemetry CCM container but we prefer https over http if both are specified
+func GetPxProxyEnvVarValue(cluster *corev1.StorageCluster) string {
+	httpProxy := ""
+	for _, env := range cluster.Spec.Env {
+		if env.Name == EnvKeyPortworxHTTPSProxy {
+			return env.Value
+		} else if env.Name == EnvKeyPortworxHTTPProxy {
+			httpProxy = env.Value
+		}
+	}
+	return httpProxy
 }
 
 // GetValueFromEnvVar returns the value of v1.EnvVar Value or ValueFrom


### PR DESCRIPTION
Signed-off-by: Jiafeng Liao <jliao@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: mount PX_HTTP(S)_PROXY as a configmap to ccm container

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-438](https://portworx.atlassian.net/browse/OPERATOR-438)

**Special notes for your reviewer**: will add unit tests once verified the functionality manually.

