### PR TITLE
PTX-4514 PVC Controller validation and basic regression test

### DIFF
--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -131,6 +131,14 @@ var testStorageClusterBasicCases = []types.TestCase{
 		}),
 		TestFunc: BasicAutopilotRegression,
 	},
+	{
+		TestName:        "BasicPvcControllerRegression",
+		TestrailCaseIDs: []string{"C58438", "C54697", "C54698", "C54707", "C58437", "C54476", "C54477"},
+		TestSpec: ci_utils.CreateStorageClusterTestSpecFunc(&corev1.StorageCluster{
+			ObjectMeta: meta.ObjectMeta{Name: "pvccontroller-regression-test"},
+		}),
+		TestFunc: BasicPvcControllerRegression,
+	},
 }
 
 func TestStorageClusterBasic(t *testing.T) {
@@ -473,6 +481,87 @@ func BasicAutopilotRegression(tc *types.TestCase) func(*testing.T) {
 		}
 		cluster = ci_utils.UpdateAndValidateAutopilot(cluster, updateParamFunc, ci_utils.PxSpecImages, t)
 		require.Nil(t, cluster.Spec.Autopilot, "failed to validate Autopilot block, it should be nil here, but it is not: %+v", cluster.Spec.Autopilot)
+
+		// Delete and validate StorageCluster deletion
+		ci_utils.UninstallAndValidateStorageCluster(cluster, t)
+	}
+}
+
+// BasicPvcControllerRegression test includes the following steps:
+// 1. Deploy PX and validate PVC Controller components and images
+// 2. Validate PVC Controller is not present in StorageCluster annotations by default
+// 3. Enable PVC Controller in StorageCluster annotations and validate components
+// 4. Delete PVC Controller pods and validate they get re-deployed
+// 5. Set custom PVC Controller port and secure-port in StorageCluster annotations and validate components
+// 6. Delete custom PVC Controller ports from StorageCluster annotations and validate components
+// 7. Disable PVC Controller in StorageCluster annotations and validate components
+// 8. Delete PVC Controller from StorageCluster annotations and validate components
+// 9. Delete StorageCluster and validate it got successfully removed
+func BasicPvcControllerRegression(tc *types.TestCase) func(*testing.T) {
+	return func(t *testing.T) {
+		var err error
+		testSpec := tc.TestSpec(t)
+		cluster, ok := testSpec.(*corev1.StorageCluster)
+		require.True(t, ok)
+
+		// Create and validate StorageCluster
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
+
+		require.Empty(t, cluster.Annotations["portworx.io/pvc-controller"], "failed to validate portworx.io/pvc-controller annotation, it shouldn't exist by default, but it is and has value of %s", cluster.Annotations["portworx.io/pvc-controller"])
+
+		logrus.Info("Enable PVC Controller annotation and validate StorageCluster")
+		updateParamFunc := func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
+			// If annotations are nil, make it first
+			if cluster.Annotations == nil {
+				cluster.Annotations = make(map[string]string)
+			}
+			cluster.Annotations["portworx.io/pvc-controller"] = "true"
+			return cluster
+		}
+		cluster = ci_utils.UpdateAndValidatePvcController(cluster, updateParamFunc, ci_utils.PxSpecImages, ci_utils.K8sVersion, t)
+		require.Equal(t, cluster.Annotations["portworx.io/pvc-controller"], "true")
+
+		logrus.Info("Delete portworx-pvc-controller pods and validate it gets re-deployed")
+		err = appsops.Instance().DeleteDeploymentPods("portworx-pvc-controller", cluster.Namespace, 60*time.Second)
+		require.NoError(t, err)
+		err = testutil.ValidatePvcController(ci_utils.PxSpecImages, cluster, ci_utils.K8sVersion, ci_utils.DefaultValidateAutopilotTimeout, ci_utils.DefaultValidateAutopilotRetryInterval)
+		require.NoError(t, err)
+
+		logrus.Info("Set PVC Controller custom port and secure-port in the annotations and validate StorageCluster")
+		updateParamFunc = func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
+			cluster.Annotations["portworx.io/pvc-controller-port"] = "1111"
+			cluster.Annotations["portworx.io/pvc-controller-secure-port"] = "2222"
+			return cluster
+		}
+		cluster = ci_utils.UpdateAndValidatePvcController(cluster, updateParamFunc, ci_utils.PxSpecImages, ci_utils.K8sVersion, t)
+		require.Equal(t, cluster.Annotations["portworx.io/pvc-controller-port"], "1111")
+		require.Equal(t, cluster.Annotations["portworx.io/pvc-controller-secure-port"], "2222")
+
+		logrus.Info("Delete PVC Controller custom port and secure-port from the annotations and validate StorageCluster")
+		updateParamFunc = func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
+			delete(cluster.Annotations, "portworx.io/pvc-controller-port")
+			delete(cluster.Annotations, "portworx.io/pvc-controller-secure-port")
+			return cluster
+		}
+		cluster = ci_utils.UpdateAndValidatePvcController(cluster, updateParamFunc, ci_utils.PxSpecImages, ci_utils.K8sVersion, t)
+		require.Empty(t, cluster.Annotations["portworx.io/pvc-controller-port"], "failed to validate portworx.io/pvc-controller annotation, it shouldn't be here, because it was deleted")
+		require.Empty(t, cluster.Annotations["portworx.io/pvc-controller-secure-port"], "failed to validate portworx.io/pvc-controller-secure-port annotation, it shouldn't be here, because it was deleted")
+
+		logrus.Info("Disable PVC Controller annotation and validate StorageCluster")
+		updateParamFunc = func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
+			cluster.Annotations["portworx.io/pvc-controller"] = "false"
+			return cluster
+		}
+		cluster = ci_utils.UpdateAndValidatePvcController(cluster, updateParamFunc, ci_utils.PxSpecImages, ci_utils.K8sVersion, t)
+		require.Equal(t, cluster.Annotations["portworx.io/pvc-controller"], "false")
+
+		logrus.Info("Delete PVC Controller annotation and validate StorageCluster")
+		updateParamFunc = func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
+			delete(cluster.Annotations, "portworx.io/pvc-controller")
+			return cluster
+		}
+		cluster = ci_utils.UpdateAndValidatePvcController(cluster, updateParamFunc, ci_utils.PxSpecImages, ci_utils.K8sVersion, t)
+		require.Empty(t, cluster.Annotations["portworx.io/pvc-controller"], "failed to validate portworx.io/pvc-controller annotation, it shouldn't be here, because it was deleted")
 
 		// Delete and validate StorageCluster deletion
 		ci_utils.UninstallAndValidateStorageCluster(cluster, t)

--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -492,7 +492,7 @@ func BasicAutopilotRegression(tc *types.TestCase) func(*testing.T) {
 // 2. Validate PVC Controller is not present in StorageCluster annotations by default
 // 3. Enable PVC Controller in StorageCluster annotations and validate components
 // 4. Delete PVC Controller pods and validate they get re-deployed
-// 5. Set custom PVC Controller port and secure-port in StorageCluster annotations and validate components
+// 5. Set custom PVC Controller secure-port in StorageCluster annotations and validate components
 // 6. Delete custom PVC Controller ports from StorageCluster annotations and validate components
 // 7. Disable PVC Controller in StorageCluster annotations and validate components
 // 8. Delete PVC Controller from StorageCluster annotations and validate components
@@ -527,24 +527,20 @@ func BasicPvcControllerRegression(tc *types.TestCase) func(*testing.T) {
 		err = testutil.ValidatePvcController(ci_utils.PxSpecImages, cluster, ci_utils.K8sVersion, ci_utils.DefaultValidateAutopilotTimeout, ci_utils.DefaultValidateAutopilotRetryInterval)
 		require.NoError(t, err)
 
-		logrus.Info("Set PVC Controller custom port and secure-port in the annotations and validate StorageCluster")
+		logrus.Info("Set PVC Controller custom secure-port in the annotations and validate StorageCluster")
 		updateParamFunc = func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
-			cluster.Annotations["portworx.io/pvc-controller-port"] = "1111"
-			cluster.Annotations["portworx.io/pvc-controller-secure-port"] = "2222"
+			cluster.Annotations["portworx.io/pvc-controller-secure-port"] = "1111"
 			return cluster
 		}
 		cluster = ci_utils.UpdateAndValidatePvcController(cluster, updateParamFunc, ci_utils.PxSpecImages, ci_utils.K8sVersion, t)
-		require.Equal(t, cluster.Annotations["portworx.io/pvc-controller-port"], "1111")
-		require.Equal(t, cluster.Annotations["portworx.io/pvc-controller-secure-port"], "2222")
+		require.Equal(t, cluster.Annotations["portworx.io/pvc-controller-secure-port"], "1111")
 
-		logrus.Info("Delete PVC Controller custom port and secure-port from the annotations and validate StorageCluster")
+		logrus.Info("Delete PVC Controller custom secure-port from the annotations and validate StorageCluster")
 		updateParamFunc = func(cluster *corev1.StorageCluster) *corev1.StorageCluster {
-			delete(cluster.Annotations, "portworx.io/pvc-controller-port")
 			delete(cluster.Annotations, "portworx.io/pvc-controller-secure-port")
 			return cluster
 		}
 		cluster = ci_utils.UpdateAndValidatePvcController(cluster, updateParamFunc, ci_utils.PxSpecImages, ci_utils.K8sVersion, t)
-		require.Empty(t, cluster.Annotations["portworx.io/pvc-controller-port"], "failed to validate portworx.io/pvc-controller annotation, it shouldn't be here, because it was deleted")
 		require.Empty(t, cluster.Annotations["portworx.io/pvc-controller-secure-port"], "failed to validate portworx.io/pvc-controller-secure-port annotation, it shouldn't be here, because it was deleted")
 
 		logrus.Info("Disable PVC Controller annotation and validate StorageCluster")

--- a/test/integration_test/utils/storagecluster.go
+++ b/test/integration_test/utils/storagecluster.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"path"
 	"testing"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -116,9 +115,6 @@ func UpdateAndValidatePvcController(cluster *corev1.StorageCluster, f func(*core
 
 	latestLiveCluster, err := UpdateStorageCluster(newCluster)
 	require.NoError(t, err)
-
-	// TODO: Remove this when we figure out how to avoid this hardcoded timeout
-	time.Sleep(5 * time.Second)
 
 	err = testutil.ValidatePvcController(pxSpecImages, latestLiveCluster, k8sVersion, DefaultValidateAutopilotTimeout, DefaultValidateAutopilotRetryInterval)
 	require.NoError(t, err)


### PR DESCRIPTION
PVC Controller basic regression test and various improvements for validation of PVC Controller components and images

* Added PVC Controller basic regression test that covers multiple PVC Controller test cases
             Validate PVC Controller annotations are missing by default
             Enable portworx-pvc-controller in StorageCluster annotations and validate PVC Controller pods are created
             Disable portworx-pvc-controller in StorageCluster annotations and validate PVC Controller pods are deleted 
             Validate portworx-pvc-controller deployment and pods 
             Delete PVC Controller pods and validate pods get re-deployed 
             Set custom PVC Controller secure-port in StorageCluster annotations and validate
             Delete custom PVC Controller secure-port in StorageCluster annotations and validate ports are changed to default
* Added more in-depth validation for PVC Controller components and images

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>
