### PR TITLE
OPERATOR-529: Bump ccm service image

### DIFF
--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -29,7 +29,7 @@ const (
 	defaultAutopilotImage  = "portworx/autopilot:1.3.1"
 	defaultLighthouseImage = "portworx/px-lighthouse:2.0.7"
 	defaultNodeWiperImage  = "portworx/px-node-wiper:2.5.0"
-	defaultTelemetryImage  = "purestorage/ccm-service:3.0.3"
+	defaultTelemetryImage  = "purestorage/ccm-service:3.0.6"
 
 	defaultCollectorProxyImage = "envoyproxy/envoy:v1.19.1"
 	defaultCollectorImage      = "purestorage/realtime-metrics:latest"

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -36,7 +36,7 @@ func TestManifestWithNewerPortworxVersion(t *testing.T) {
 			PrometheusConfigMapReload: "image/configmap-reload:2.6.0",
 			PrometheusConfigReloader:  "image/prometheus-config-reloader:2.6.0",
 			AlertManager:              "image/alertmanager:2.6.0",
-			Telemetry:                 "image/ccm-service:2.6.0",
+			Telemetry:                 "image/ccm-service:3.0.6",
 			MetricsCollector:          "purestorage/realtime-metrics:latest",
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.19.1",
 		},

--- a/test/integration_test/testspec/migration/daemonset-with-all-components.yaml
+++ b/test/integration_test/testspec/migration/daemonset-with-all-components.yaml
@@ -153,7 +153,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: telemetry
-          image: purestorage/ccm-service:3.0.3
+          image: purestorage/ccm-service:3.0.6
           imagePullPolicy: Always
           args:
             ["-Dserver.rest_server.core_pool_size=2"]


### PR DESCRIPTION
Signed-off-by: pault84 <paul@portworx.com>

**What this PR does / why we need it**:
OPERATOR-529: CCM 3.0.3 has a big security hole regarding certificates.
3.0.4 fixed this but pushing image to latest for other addressed fixes.

Goes together with a daemon set fix in px-installer.

**Special notes for your reviewer**:
