### PR TITLE
[OPERATOR-535] fix kubectl logs permission issue of metrics collector container

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -381,6 +381,9 @@ func (t *telemetry) getCollectorDeployment(
 						{
 							Name:  "collector",
 							Image: collectorImage,
+							SecurityContext: &v1.SecurityContext{
+								RunAsUser: &runAsUser,
+							},
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									v1.ResourceMemory: resource.MustParse(defaultCollectorMemoryRequest),

--- a/drivers/storage/portworx/testspec/metricsCollectorDeployment.yaml
+++ b/drivers/storage/portworx/testspec/metricsCollectorDeployment.yaml
@@ -46,6 +46,8 @@ spec:
           image: purestorage/realtime-metrics:latest
           imagePullPolicy: Always
           name: collector
+          securityContext:
+            runAsUser: 1111
           resources:
             requests:
               cpu: 200m

--- a/test/integration_test/testspec/metricsCollectorDeployment.yaml
+++ b/test/integration_test/testspec/metricsCollectorDeployment.yaml
@@ -3,6 +3,12 @@ kind: Deployment
 metadata:
   name: px-metrics-collector
   namespace: kube-test
+  ownerReferences:
+    - apiVersion: core.libopenstorage.org/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: StorageCluster
+      name: px-cluster
 spec:
   replicas: 1
   selector:
@@ -40,6 +46,8 @@ spec:
           image: purestorage/realtime-metrics:latest
           imagePullPolicy: Always
           name: collector
+          securityContext:
+            runAsUser: 1111
           resources:
             requests:
               cpu: 200m


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: https://portworx.atlassian.net/browse/OPERATOR-535

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

