### PR TITLE
OPERATOR-519 Using /var/lib/osd mount even for PKS

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1635,7 +1635,18 @@ func getDefaultVolumeInfoList(pxVersion *version.Version) []volumeInfo {
 
 // getCommonVolumeList returns a common list of volumes across all containers
 func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
-	list := []volumeInfo{
+	list := make([]volumeInfo, 0)
+	pxVer2_9_1, _ := version.NewVersion("2.9.1")
+	if pxVersion.GreaterThanOrEqual(pxVer2_9_1) {
+		list = append(list, volumeInfo{
+			name:             "varlibosd",
+			hostPath:         "/var/lib/osd",
+			mountPath:        "/var/lib/osd",
+			mountPropagation: mountPropagationModePtr(v1.MountPropagationBidirectional),
+		})
+	}
+
+	list = append(list, []volumeInfo{
 		{
 			name:      "diagsdump",
 			hostPath:  "/var/cores",
@@ -1653,6 +1664,13 @@ func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 			},
 		},
 		{
+			name: "pxlogs",
+			pks: &pksVolumeInfo{
+				mountPath: "/var/lib/osd/log",
+				hostPath:  "/var/vcap/store/lib/osd/log",
+			},
+		},
+		{
 			name:      "journalmount1",
 			hostPath:  "/var/run/log",
 			mountPath: "/var/run/log",
@@ -1664,31 +1682,8 @@ func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 			mountPath: "/var/log",
 			readOnly:  true,
 		},
-	}
+	}...)
 
-	pxVer2_9_1, _ := version.NewVersion("2.9.1")
-	var osdVolume volumeInfo
-	if pxVersion.LessThan(pxVer2_9_1) {
-		osdVolume = volumeInfo{
-			name: "pxlogs",
-			pks: &pksVolumeInfo{
-				mountPath: "/var/lib/osd/log",
-				hostPath:  "/var/vcap/store/lib/osd/log",
-			},
-		}
-	} else {
-		osdVolume = volumeInfo{
-			name:             "varlibosd",
-			hostPath:         "/var/lib/osd",
-			mountPath:        "/var/lib/osd",
-			mountPropagation: mountPropagationModePtr(v1.MountPropagationBidirectional),
-			pks: &pksVolumeInfo{
-				hostPath: "/var/vcap/store/lib/osd",
-			},
-		}
-	}
-
-	list = append(list, osdVolume)
 	return list
 }
 

--- a/drivers/storage/portworx/testspec/pks_2.9.1.yaml
+++ b/drivers/storage/portworx/testspec/pks_2.9.1.yaml
@@ -73,6 +73,8 @@ spec:
             - name: varlibosd
               mountPath: /var/lib/osd
               mountPropagation: Bidirectional
+            - name: pxlogs
+              mountPath: /var/lib/osd/log
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -114,7 +116,10 @@ spec:
             path: /var/vcap/store/opt/pwx
         - name: varlibosd
           hostPath:
-            path: /var/vcap/store/lib/osd
+            path: /var/lib/osd
+        - name: pxlogs
+          hostPath:
+            path: /var/vcap/store/lib/osd/log
         - name: procmount
           hostPath:
             path: /proc


### PR DESCRIPTION
- For backward compatibility using the `/var/lib/osd` host path even for PKS.
- Continuing to mount `/var/lib/osd/log` from the `/var/vcap/store/lib/osd/log` directory like before.
- As Zoran suggested, mounting `/var/lib/osd` before `/var/lib/osd/log` to keep the old behavior.

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-519

**Special notes for your reviewer**:

