### PR TITLE
OPERATOR-301 Do not remove portworx-service

### DIFF
--- a/drivers/storage/portworx/component/portworx_proxy.go
+++ b/drivers/storage/portworx/component/portworx_proxy.go
@@ -101,8 +101,13 @@ func (c *portworxProxy) Delete(cluster *corev1.StorageCluster) error {
 	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, PxProxyClusterRoleBindingName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteService(c.k8sClient, pxutil.PortworxServiceName, api.NamespaceSystem); err != nil {
-		return err
+	if pxutil.IsPortworxEnabled(cluster) {
+		// Do not delete the portworx-service when portworx is explicitly disabled. This is only
+		// used by px-central to enable monitoring stack when portworx is deployed with daemonset.
+		// This avoids the daemonset's portworx-service from getting deleted.
+		if err := k8sutil.DeleteService(c.k8sClient, pxutil.PortworxServiceName, api.NamespaceSystem); err != nil {
+			return err
+		}
 	}
 	if err := k8sutil.DeleteDaemonSet(c.k8sClient, PxProxyDaemonSetName, api.NamespaceSystem); err != nil {
 		return err

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -950,7 +950,7 @@ func TestDisablePortworx(t *testing.T) {
 
 	pxProxySvc = &v1.Service{}
 	err = testutil.Get(k8sClient, pxProxySvc, pxutil.PortworxServiceName, api.NamespaceSystem)
-	require.True(t, errors.IsNotFound(err))
+	require.False(t, errors.IsNotFound(err))
 
 	pxProxyDS = &appsv1.DaemonSet{}
 	err = testutil.Get(k8sClient, pxProxyDS, component.PxProxyDaemonSetName, api.NamespaceSystem)

--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -408,18 +408,21 @@ func (c *Controller) getUnavailableNumbers(
 			"update of storage cluster %s/%s: %v", cluster.Namespace, cluster.Name, err)
 	}
 
-	storageNodeList, err := c.Driver.GetStorageNodes(cluster)
-	if err != nil {
-		return -1, -1, fmt.Errorf("couldn't get list of storage nodes during rolling "+
-			"update of storage cluster %s/%s: %v", cluster.Namespace, cluster.Name, err)
-	}
 	storageNodeMap := make(map[string]*storageapi.StorageNode)
 	var nonK8sStorageNodes []*storageapi.StorageNode
-	for _, storageNode := range storageNodeList {
-		if len(storageNode.SchedulerNodeName) == 0 {
-			nonK8sStorageNodes = append(nonK8sStorageNodes, storageNode)
-		} else {
-			storageNodeMap[storageNode.SchedulerNodeName] = storageNode
+
+	if storagePodsEnabled(cluster) {
+		storageNodeList, err := c.Driver.GetStorageNodes(cluster)
+		if err != nil {
+			return -1, -1, fmt.Errorf("couldn't get list of storage nodes during rolling "+
+				"update of storage cluster %s/%s: %v", cluster.Namespace, cluster.Name, err)
+		}
+		for _, storageNode := range storageNodeList {
+			if len(storageNode.SchedulerNodeName) == 0 {
+				nonK8sStorageNodes = append(nonK8sStorageNodes, storageNode)
+			} else {
+				storageNodeMap[storageNode.SchedulerNodeName] = storageNode
+			}
 		}
 	}
 


### PR DESCRIPTION
- When running in storage disabled mode, which is mostly used by
PX Central, the operator used to delete the portworx-service
created by the daemonset spec. We specially handle this by ignoring
the deletion of the service when storage is disabled.
- Ignore the GetStorageNodes call when storage is disabled.

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-301

**Special notes for your reviewer**:

