### PR TITLE
[OPERATOR-549] do not remove pure-telemetry-certs when telemetry is disabled

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -159,10 +159,6 @@ func (t *telemetry) Delete(cluster *corev1.StorageCluster) error {
 		return err
 	}
 
-	if err := k8sutil.DeleteSecret(t.k8sClient, TelemetryCertName, cluster.Namespace, *ownerRef); err != nil {
-		return nil
-	}
-
 	if err := t.deleteMetricsCollector(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -11742,6 +11742,7 @@ func TestTelemetryEnableAndDisable(t *testing.T) {
 	secret := v1.Secret{}
 	err = testutil.Get(k8sClient, &secret, component.TelemetryCertName, cluster.Namespace)
 	require.NoError(t, err)
+	require.Equal(t, secret.OwnerReferences[0].Name, cluster.Name)
 
 	// Now disable telemetry
 	cluster.Spec.Monitoring.Telemetry.Enabled = false
@@ -11773,8 +11774,9 @@ func TestTelemetryEnableAndDisable(t *testing.T) {
 	err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
 
+	// Cert is not deleted after telemetry is disabled. it would be reused when it's re-enabled.
 	err = testutil.Get(k8sClient, &secret, component.TelemetryCertName, cluster.Namespace)
-	require.True(t, errors.IsNotFound(err))
+	require.NoError(t, err)
 }
 
 func TestMetricsCollectorIsDisabledForOldPxVersions(t *testing.T) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

