### PR TITLE
OPERATOR-554: change portworx pod dns policy to DNSClusterFirstWithHostNet bcz host…

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -261,6 +261,8 @@ func (p *portworx) GetStoragePodSpec(
 
 	containers := t.portworxContainer(cluster)
 	podSpec := v1.PodSpec{
+		// For Pods running with hostNetwork, you should explicitly set its DNS policy to DNSClusterFirstWithHostNet
+		DNSPolicy:          v1.DNSClusterFirstWithHostNet,
 		HostNetwork:        true,
 		RestartPolicy:      v1.RestartPolicyAlways,
 		ServiceAccountName: pxutil.PortworxServiceAccountName(cluster),

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -1628,7 +1628,6 @@ func TestPodSpecWithCustomStartPort(t *testing.T) {
 
 	actual, err := driver.GetStoragePodSpec(cluster, nodeName)
 	require.NoError(t, err, "Unexpected error on GetStoragePodSpec")
-
 	assertPodSpecEqual(t, expected, &actual)
 
 	// Don't set the start port if same as default start port
@@ -3630,6 +3629,7 @@ func getExpectedPodSpec(t *testing.T, podSpecFileName string) *v1.PodSpec {
 func assertPodSpecEqual(t *testing.T, expected, actual *v1.PodSpec) {
 	assert.Equal(t, expected.Affinity, actual.Affinity)
 	assert.Equal(t, expected.HostNetwork, actual.HostNetwork)
+	assert.Equal(t, expected.DNSPolicy, actual.DNSPolicy)
 	assert.Equal(t, expected.RestartPolicy, actual.RestartPolicy)
 	assert.Equal(t, expected.ServiceAccountName, actual.ServiceAccountName)
 	assert.Equal(t, expected.ImagePullSecrets, actual.ImagePullSecrets)

--- a/drivers/storage/portworx/testspec/openshift_runc.yaml
+++ b/drivers/storage/portworx/testspec/openshift_runc.yaml
@@ -30,6 +30,7 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/pks.yaml
+++ b/drivers/storage/portworx/testspec/pks.yaml
@@ -28,6 +28,7 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/pks_2.9.1.yaml
+++ b/drivers/storage/portworx/testspec/pks_2.9.1.yaml
@@ -17,6 +17,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
@@ -17,6 +17,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
@@ -15,6 +15,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_csi_0.3.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_0.3.yaml
@@ -17,6 +17,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_csi_1.0.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_1.0.yaml
@@ -17,6 +17,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_disable_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_disable_telemetry.yaml
@@ -42,6 +42,7 @@ spec:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -30,6 +30,7 @@ spec:
                 values:
                 - "false"
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
@@ -15,6 +15,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
@@ -15,6 +15,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_cert.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_cert.yaml
@@ -15,6 +15,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
@@ -15,6 +15,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
@@ -15,6 +15,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_master.yaml
+++ b/drivers/storage/portworx/testspec/px_master.yaml
@@ -30,6 +30,7 @@ spec:
                 values:
                 - "false"
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
+++ b/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
@@ -15,6 +15,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
@@ -42,6 +42,7 @@ spec:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -42,6 +42,7 @@ spec:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
@@ -42,6 +42,7 @@ spec:
               - key: node-role.kubernetes.io/worker
                 operator: Exists
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/runc.yaml
+++ b/drivers/storage/portworx/testspec/runc.yaml
@@ -28,6 +28,7 @@ spec:
               - key: node-role.kubernetes.io/master
                 operator: DoesNotExist
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx

--- a/drivers/storage/portworx/testspec/runc_2.9.1.yaml
+++ b/drivers/storage/portworx/testspec/runc_2.9.1.yaml
@@ -17,6 +17,7 @@ spec:
         name: portworx
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       hostPID: false
       containers:
         - name: portworx


### PR DESCRIPTION
…network is true

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

