### PR TITLE
Add PrependRegistryToImages to cluster spec

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -82,6 +82,10 @@ spec:
                 type: string
                 description: Image pull secret is a reference to secret in the same namespace as the
                   StorageCluster. It is used for pulling all images used by the StorageCluster.
+              prependRegistryToImages:
+                type: boolean
+                description: Set this to true to prepend `docker.io/` to images without a registry in their
+                  path. This mitigates an issue where GetImageURN swallows part of the image tag.
               customImageRegistry:
                 type: string
                 description: >-

--- a/go.mod
+++ b/go.mod
@@ -36,13 +36,13 @@ require (
 )
 
 replace (
+	github.com/coreos/prometheus-operator => github.com/prometheus-operator/prometheus-operator v0.46.0
 	github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v5.1.1-0.20190919185747-9394ee8dd536+incompatible
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20211117020105-370e0c26d39f
 
 	google.golang.org/grpc => google.golang.org/grpc v1.29.1
 	google.golang.org/grpc/examples/helloworld/helloworld => google.golang.org/grpc/examples/helloworld/helloworld v1.29.1
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
-	github.com/coreos/prometheus-operator => github.com/prometheus-operator/prometheus-operator v0.46.0
 
 	// Replacing k8s.io dependencies is required if a dependency or any dependency of a dependency
 	// depends on k8s.io/kubernetes. See https://github.com/kubernetes/kubernetes/issues/79384#issuecomment-505725449

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -72,6 +72,9 @@ type StorageClusterSpec struct {
 	// repository) that will be used instead of index.docker.io to download Docker
 	// images. (Example: myregistry.net:5443 or myregistry.com/myrepository)
 	CustomImageRegistry string `json:"customImageRegistry,omitempty"`
+	// This hack is to fix an issue where images without a registry get part of the
+	// image tag removed when using a customImageRegistry
+	PrependRegistryToImages bool `json:"prependRegistryToImages,omitempty"`
 	// Kvdb is the information of kvdb that storage driver uses
 	Kvdb *KvdbSpec `json:"kvdb,omitempty"`
 	// CloudStorage details of storage in cloud environment.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -47,6 +47,17 @@ var (
 		"registry-1.docker.io":        true,
 		"registry.connect.redhat.com": true,
 	}
+	imagesWithoutRegistry = [...]string{
+		"portworx/oci-monitor",
+		"openstorage/stork",
+		"portworx/autopilot",
+		"portworx/px-lighthouse",
+		"portworx/px-node-wiper",
+		"purestorage/ccm-service",
+		"envoyproxy/envoy",
+		"purestorage/realtime-metrics",
+		"portworx/px-repo",
+	}
 )
 
 func getMergedCommonRegistries(cluster *corev1.StorageCluster) map[string]bool {
@@ -77,6 +88,15 @@ func GetImageURN(cluster *corev1.StorageCluster, image string) string {
 
 	registryAndRepo := cluster.Spec.CustomImageRegistry
 	mergedCommonRegistries := getMergedCommonRegistries(cluster)
+	prependRegistryToImages := cluster.Spec.PrependRegistryToImages
+
+	if prependRegistryToImages {
+		for i := 0; i < len(imagesWithoutRegistry); i++ {
+			if strings.HasPrefix(image, imagesWithoutRegistry[i]) {
+				image = "docker.io/" + image
+			}
+		}
+	}
 
 	omitRepo := false
 	if strings.HasSuffix(registryAndRepo, "//") {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -102,11 +102,36 @@ func TestImageURN(t *testing.T) {
 	require.Equal(t, "registry.io/testrepo/pause:3.1", out)
 }
 
-func getImageURN(commonRegistries string, customImageRegistry string, image string) string {
+func TestImageURNPrepended(t *testing.T) {
+	// TestCase: Empty repo and registry
+	out := getImageURNPrepended("", "", "portworx/oci-monitor")
+	require.Equal(t, "docker.io/portworx/oci-monitor", out)
+
+	// TestCase: Registry without repo but image with repo
+	out = getImageURNPrepended("", "registry.io", "portworx/oci-monitor")
+	require.Equal(t, "registry.io/portworx/oci-monitor", out)
+
+	// TestCase: Common registry, custom registry, image
+	out = getImageURNPrepended("docker.io", "registry.io/", "portworx/oci-monitor")
+	require.Equal(t, "registry.io/portworx/oci-monitor", out)
+}
+
+func setUpCluster(commonRegistries string, customImageRegistry string, image string) corev1.StorageCluster {
 	cluster := corev1.StorageCluster{}
 	cluster.Annotations = make(map[string]string)
 	cluster.Annotations[constants.AnnotationCommonImageRegistries] = commonRegistries
 	cluster.Spec.CustomImageRegistry = customImageRegistry
+	return cluster
+}
+
+func getImageURN(commonRegistries string, customImageRegistry string, image string) string {
+	cluster := setUpCluster(commonRegistries, customImageRegistry, image)
+	return GetImageURN(&cluster, image)
+}
+
+func getImageURNPrepended(commonRegistries string, customImageRegistry string, image string) string {
+	cluster := setUpCluster(commonRegistries, customImageRegistry, image)
+	cluster.Spec.PrependRegistryToImages = true
 	return GetImageURN(&cluster, image)
 }
 


### PR DESCRIPTION
This is to fix the issue where images without a registry have part of
their image tag removed when specifying a custom image registry. This
preserves the original behaviour if prependRegistryToImages is unset but
will add `docker.io` (the default registry) when set to true.

Remediates Pure portal ticket #01194532

