### PR TITLE
Add preserveFullCustomRegistry to not swallow part of image

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -88,6 +88,14 @@ spec:
                   Custom container image registry server that will be used instead of
                   index.docker.io to download Docker images. This may include the repository as well.
                   (Example: myregistry.net:5443 or myregistry.com/myrepository)
+              preserveFullCustomImageRegistry:
+                type: boolean
+                description: >-
+                  Setting this to true this stops part of the image tag being swallowed when setting a
+                  customImageRegistry with a / in it. When set to false using a customImageRegistry of
+                  `example.io/public` and an image of `portworx/oci-monitor` the full image path is is
+                  `example.io/public/oci-monitor`, setting to true gives you
+                  `example.io/public/portworx/oci-monitor`. Defaults to false
               secretsProvider:
                 type: string
                 description: Secrets provider is the name of secret provider that driver will connect to.

--- a/go.mod
+++ b/go.mod
@@ -36,13 +36,13 @@ require (
 )
 
 replace (
+	github.com/coreos/prometheus-operator => github.com/prometheus-operator/prometheus-operator v0.46.0
 	github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v5.1.1-0.20190919185747-9394ee8dd536+incompatible
 	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20211117020105-370e0c26d39f
 
 	google.golang.org/grpc => google.golang.org/grpc v1.29.1
 	google.golang.org/grpc/examples/helloworld/helloworld => google.golang.org/grpc/examples/helloworld/helloworld v1.29.1
 	gopkg.in/fsnotify.v1 v1.4.7 => github.com/fsnotify/fsnotify v1.4.7
-	github.com/coreos/prometheus-operator => github.com/prometheus-operator/prometheus-operator v0.46.0
 
 	// Replacing k8s.io dependencies is required if a dependency or any dependency of a dependency
 	// depends on k8s.io/kubernetes. See https://github.com/kubernetes/kubernetes/issues/79384#issuecomment-505725449

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -72,6 +72,10 @@ type StorageClusterSpec struct {
 	// repository) that will be used instead of index.docker.io to download Docker
 	// images. (Example: myregistry.net:5443 or myregistry.com/myrepository)
 	CustomImageRegistry string `json:"customImageRegistry,omitempty"`
+	// This is a hack to stop GetImageURN from swallowing part of the image tag.
+	// Without it having a customImageRegistry with a / in it means that an image
+	// `portworx/oci-monitor` becomes just `oci-monitor`
+	PreserveFullCustomRegistryPath bool `json:"preserveFullCustomRegistryPath"`
 	// Kvdb is the information of kvdb that storage driver uses
 	Kvdb *KvdbSpec `json:"kvdb,omitempty"`
 	// CloudStorage details of storage in cloud environment.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -77,6 +77,7 @@ func GetImageURN(cluster *corev1.StorageCluster, image string) string {
 
 	registryAndRepo := cluster.Spec.CustomImageRegistry
 	mergedCommonRegistries := getMergedCommonRegistries(cluster)
+	preserveFullCustomImageRegistry := cluster.Spec.PreserveFullCustomRegistryPath
 
 	omitRepo := false
 	if strings.HasSuffix(registryAndRepo, "//") {
@@ -97,11 +98,13 @@ func GetImageURN(cluster *corev1.StorageCluster, image string) string {
 		}
 	}
 
-	// if we have '/' in the registryAndRepo, return <registry/repository/><only-image>
-	// else (registry only) -- return <registry/><image-with-repository>
-	if strings.Contains(registryAndRepo, "/") || omitRepo {
-		// advance to the last element, skipping image's repository
-		imgParts = imgParts[len(imgParts)-1:]
+	if !preserveFullCustomImageRegistry {
+		// if we have '/' in the registryAndRepo, return <registry/repository/><only-image>
+		// else (registry only) -- return <registry/><image-with-repository>
+		if strings.Contains(registryAndRepo, "/") || omitRepo {
+			// advance to the last element, skipping image's repository
+			imgParts = imgParts[len(imgParts)-1:]
+		}
 	}
 	return registryAndRepo + "/" + path.Join(imgParts...)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -102,11 +102,48 @@ func TestImageURN(t *testing.T) {
 	require.Equal(t, "registry.io/testrepo/pause:3.1", out)
 }
 
-func getImageURN(commonRegistries string, customImageRegistry string, image string) string {
+func TestImageURNPreserved(t *testing.T) {
+	// Ensure original behaviour remains
+	out := getImageURNPreserved("", "registry.io", "")
+	require.Equal(t, "", out)
+
+	// Ensure original behaviour remains
+	out = getImageURNPreserved("", "", "test/image")
+	require.Equal(t, "test/image", out)
+
+	// Ensure original behaviour remains
+	out = getImageURNPreserved("", "registry.io", "test/image")
+	require.Equal(t, "registry.io/test/image", out)
+
+	// Ensure original behaviour remains
+	out = getImageURNPreserved("", "registry.io/", "test/image")
+	require.Equal(t, "registry.io/test/image", out)
+
+	// TestCase: Image without registry, registry with / in it
+	out = getImageURNPreserved("", "registry.io/public", "test/image")
+	require.Equal(t, "registry.io/public/test/image", out)
+
+	// TestCase: Image with registry, registry with / in it
+	out = getImageURNPreserved("", "registry.io/public", "docker.io/test/image")
+	require.Equal(t, "registry.io/public/test/image", out)
+}
+
+func setUpCluster(commonRegistries string, customImageRegistry string, image string) corev1.StorageCluster {
 	cluster := corev1.StorageCluster{}
 	cluster.Annotations = make(map[string]string)
 	cluster.Annotations[constants.AnnotationCommonImageRegistries] = commonRegistries
 	cluster.Spec.CustomImageRegistry = customImageRegistry
+	return cluster
+}
+
+func getImageURN(commonRegistries string, customImageRegistry string, image string) string {
+	cluster := setUpCluster(commonRegistries, customImageRegistry, image)
+	return GetImageURN(&cluster, image)
+}
+
+func getImageURNPreserved(commonRegistries string, customImageRegistry string, image string) string {
+	cluster := setUpCluster(commonRegistries, customImageRegistry, image)
+	cluster.Spec.PreserveFullCustomRegistryPath = true
 	return GetImageURN(&cluster, image)
 }
 


### PR DESCRIPTION
This is to stop GetImageURN from swallowing part of the image tag when
setting a customImageRegistry with a / in it. Original behaviour is,
when a registry of `example.io/public` is used with an image of
`portworx/oci-monitor`, for the image to become
`emaple.io/public/oci-monitor`. Setting this to true will preserve the
full path and the image will be `example.io/public/portworx/oci-monitor`

Remediates Pure portal ticket #01194532