### PR TITLE
[OPERATOR-543] Allow adding custom labels to portworx-api service

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -55,6 +55,14 @@ spec:
                       storage cluster components. The key specifies component in format of "kind/component",
                       e.g. "deployment/stork" to pass custom annotations to stork deployment. The value is a map of
                       string that contains custom annotation key and value pairs.
+                  labels:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                    description: >-
+                      The labels section of spec is a map of map to pass custom labels to different storage cluster
+                      components. The key specifies component in format of "kind/component", e.g. "service/portworx-api"
+                      to pass custom labels to portworx-api service. The value is a map of string that contains custom
+                      label key and value pairs.
               resources:
                 type: object
                 description: Specifies the compute resource requirements for the storage pod.

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -90,6 +90,14 @@ func (c *portworxAPI) createService(
 	ownerRef *metav1.OwnerReference,
 ) error {
 	labels := getPortworxAPIServiceLabels()
+	if customLabels := util.GetCustomLabels(cluster, k8sutil.Service, PxAPIServiceName); customLabels != nil {
+		for k, v := range customLabels {
+			// Custom labels should not overwrite builtin portworx labels
+			if _, ok := labels[k]; !ok {
+				labels[k] = v
+			}
+		}
+	}
 
 	startPort := pxutil.StartPort(cluster)
 	sdkTargetPort := 9020
@@ -107,7 +115,7 @@ func (c *portworxAPI) createService(
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 		},
 		Spec: v1.ServiceSpec{
-			Selector: labels,
+			Selector: getPortworxAPIServiceLabels(),
 			Type:     v1.ServiceTypeClusterIP,
 			Ports: []v1.ServicePort{
 				{

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -39,6 +39,8 @@ type StorageClusterList struct {
 type Metadata struct {
 	// Annotations that will be passed to different StorageCluster components
 	Annotations map[string]map[string]string `json:"annotations,omitempty"`
+	// Labels that will be passed to different StorageCluster components
+	Labels map[string]map[string]string `json:"labels,omitempty"`
 }
 
 // StorageClusterSpec is the spec used to define a storage cluster

--- a/pkg/apis/core/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1/zz_generated.deepcopy.go
@@ -441,6 +441,23 @@ func (in *Metadata) DeepCopyInto(out *Metadata) {
 			(*out)[key] = outVal
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]map[string]string, len(*in))
+		for key, val := range *in {
+			var outVal map[string]string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make(map[string]string, len(*in))
+				for key, val := range *in {
+					(*out)[key] = val
+				}
+			}
+			(*out)[key] = outVal
+		}
+	}
 	return
 }
 

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -37,7 +37,8 @@ import (
 
 // Constants for k8s object kinds
 const (
-	Pod = "pod"
+	Pod     = "pod"
+	Service = "service"
 )
 
 var (

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -420,6 +420,11 @@ func ValidateStorageCluster(
 		return err
 	}
 
+	// Validate Portworx API Service
+	if err = validatePortworxAPIService(liveCluster, timeout, interval); err != nil {
+		return err
+	}
+
 	if err = validateComponents(pxImageList, liveCluster, timeout, interval); err != nil {
 		return err
 	}
@@ -781,6 +786,42 @@ func validatePortworxService(namespace string) error {
 	if err != nil {
 		return fmt.Errorf("failed to validate Service %s/%s, Err: %v", namespace, pxServiceName, err)
 	}
+	return nil
+}
+
+func validatePortworxAPIService(cluster *corev1.StorageCluster, timeout, interval time.Duration) error {
+	t := func() (interface{}, bool, error) {
+		pxAPIServiceName := "portworx-api"
+		service, err := coreops.Instance().GetService(pxAPIServiceName, cluster.Namespace)
+		if err != nil {
+			return nil, true, fmt.Errorf("failed to validate Service %s/%s, Err: %v", cluster.Namespace, pxAPIServiceName, err)
+		}
+		if cluster.Spec.Metadata != nil && cluster.Spec.Metadata.Labels != nil {
+			for k, expectedVal := range cluster.Spec.Metadata.Labels["service/portworx-api"] {
+				if actualVal, ok := service.Labels[k]; !ok || actualVal != expectedVal {
+					return nil, true, fmt.Errorf("failed to validate Service %s/%s custom labels, label %s doesn't exist or value doesn't match", cluster.Namespace, pxAPIServiceName, k)
+				}
+			}
+			for k := range service.Labels {
+				if k == "name" {
+					continue
+				}
+				if labels, ok := cluster.Spec.Metadata.Labels["service/portworx-api"]; ok {
+					if _, ok := labels[k]; !ok {
+						return nil, true, fmt.Errorf("failed to validate Service %s/%s custom labels, found unexpected label %s", cluster.Namespace, pxAPIServiceName, k)
+					}
+				} else {
+					return nil, true, fmt.Errorf("failed to validate Service %s/%s custom labels, found unexpected label %s", cluster.Namespace, pxAPIServiceName, k)
+				}
+			}
+		}
+		return nil, false, nil
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, timeout, interval); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -274,6 +274,23 @@ func GetCustomAnnotations(
 	return nil
 }
 
+// GetCustomLabels returns custom labels for different StorageCluster components from spec
+func GetCustomLabels(
+	cluster *corev1.StorageCluster,
+	k8sObjKind string,
+	componentName string,
+) map[string]string {
+	if cluster.Spec.Metadata == nil || cluster.Spec.Metadata.Labels == nil {
+		return nil
+	}
+	// Use kind/component to locate the custom labels, e.g. service/portworx-api
+	key := fmt.Sprintf("%s/%s", k8sObjKind, componentName)
+	if labels, ok := cluster.Spec.Metadata.Labels[key]; ok && len(labels) != 0 {
+		return labels
+	}
+	return nil
+}
+
 // ComponentsPausedForMigration returns true if the daemonset migration is going on and
 // the components are waiting for storage pods to migrate first
 func ComponentsPausedForMigration(cluster *corev1.StorageCluster) bool {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -238,6 +238,31 @@ func TestGetCustomAnnotations(t *testing.T) {
 	require.Equal(t, podPortworxAnnotations, GetCustomAnnotations(cluster, k8s.Pod, componentName))
 }
 
+func TestGetCustomLabels(t *testing.T) {
+	// To avoid loop import, define the component name directly
+	componentName := "portworx-api"
+	cluster := &corev1.StorageCluster{
+		Spec: corev1.StorageClusterSpec{},
+	}
+	require.Nil(t, GetCustomLabels(cluster, k8s.Service, componentName))
+
+	cluster.Spec.Metadata = &corev1.Metadata{}
+	require.Nil(t, GetCustomLabels(cluster, k8s.Service, componentName))
+
+	cluster.Spec.Metadata.Labels = make(map[string]map[string]string)
+	require.Nil(t, GetCustomLabels(cluster, k8s.Pod, componentName))
+
+	portworxAPIServiceLabels := map[string]string{
+		"portworx-api-service-key": "portworx-api-service-val",
+	}
+	cluster.Spec.Metadata.Labels = map[string]map[string]string{
+		"service/portworx-api": portworxAPIServiceLabels,
+	}
+	require.Nil(t, GetCustomLabels(cluster, k8s.Service, "invalid-component"))
+	require.Nil(t, GetCustomLabels(cluster, "invalid-kind", componentName))
+	require.Equal(t, portworxAPIServiceLabels, GetCustomLabels(cluster, k8s.Service, componentName))
+}
+
 func TestComponentsPausedForMigration(t *testing.T) {
 	cluster := &corev1.StorageCluster{}
 	require.False(t, ComponentsPausedForMigration(cluster))

--- a/test/integration_test/utils/px_operator.go
+++ b/test/integration_test/utils/px_operator.go
@@ -16,6 +16,8 @@ const (
 var (
 	// PxOperatorVer1_7 portworx-operator 1.7 minimum version
 	PxOperatorVer1_7, _ = version.NewVersion("1.7-")
+	// PxOperatorVer1_8 portworx-operator 1.8 minimum version
+	PxOperatorVer1_8, _ = version.NewVersion("1.8-")
 )
 
 // TODO: Install portworx-operator in test automation


### PR DESCRIPTION
Signed-off-by: Jiafeng Liao <jliao@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: To pass custom labels to portworx-api service

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-543](https://portworx.atlassian.net/browse/OPERATOR-543)

**Special notes for your reviewer**:

