### PR TITLE
[OPERATOR-560] Add pod topology spread constraints to stork, pvc and csi pods

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12123,6 +12123,123 @@ func TestPortworxAPIServiceCustomLabels(t *testing.T) {
 	require.Equal(t, expectedPxAPIService.Spec, pxAPIService.Spec)
 }
 
+func TestCSIAndPVCControllerDeploymentWithPodTopologySpreadConstraints(t *testing.T) {
+	fakeNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node0",
+			Labels: map[string]string{
+				"topology.kubernetes.io/region": "region0",
+			},
+		},
+	}
+	versionClient := fakek8sclient.NewSimpleClientset(fakeNode)
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.17.0",
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient(fakeNode)
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "true",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			CSI: &corev1.CSISpec{
+				Enabled: true,
+			},
+		},
+	}
+
+	err := driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// CSI deployment topology constraints
+	deployment := &appsv1.Deployment{}
+	err = testutil.Get(driver.k8sClient, deployment, component.CSIApplicationName, cluster.Namespace)
+	require.NoError(t, err)
+	expectedConstraints := []v1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "topology.kubernetes.io/region",
+			WhenUnsatisfiable: v1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "px-csi-driver",
+				},
+			},
+		},
+	}
+	require.Equal(t, expectedConstraints, deployment.Spec.Template.Spec.TopologySpreadConstraints)
+
+	// PVC controller deployment topology constraints
+	deployment = &appsv1.Deployment{}
+	err = testutil.Get(driver.k8sClient, deployment, component.PVCDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	expectedConstraints = []v1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "topology.kubernetes.io/region",
+			WhenUnsatisfiable: v1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"name": component.PVCDeploymentName,
+					"tier": "control-plane",
+				},
+			},
+		},
+	}
+	require.Equal(t, expectedConstraints, deployment.Spec.Template.Spec.TopologySpreadConstraints)
+}
+
+func TestCSIAndPVCControllerDeploymentWithoutPodTopologySpreadConstraints(t *testing.T) {
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.17.0",
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "true",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			CSI: &corev1.CSISpec{
+				Enabled: true,
+			},
+		},
+	}
+
+	err := driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// CSI deployment topology constraints
+	deployment := &appsv1.Deployment{}
+	err = testutil.Get(driver.k8sClient, deployment, component.CSIApplicationName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Empty(t, deployment.Spec.Template.Spec.TopologySpreadConstraints)
+
+	// PVC controller deployment topology constraints
+	deployment = &appsv1.Deployment{}
+	err = testutil.Get(driver.k8sClient, deployment, component.PVCDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Empty(t, deployment.Spec.Template.Spec.TopologySpreadConstraints)
+}
+
 func contains(slice []string, val string) bool {
 	for _, v := range slice {
 		if v == val {

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -60,6 +60,24 @@ const (
 	userVolumeNamePrefix    = "user-"
 )
 
+var (
+	storkServiceLabels = map[string]string{
+		"name": "stork",
+	}
+	storkDeploymentLabels = map[string]string{
+		"tier": "control-plane",
+	}
+	storkTemplateLabels = map[string]string{
+		"name": "stork",
+		"tier": "control-plane",
+	}
+	storkSchedulerDeploymentLabels = map[string]string{
+		"tier":      "control-plane",
+		"component": "scheduler",
+		"name":      storkSchedDeploymentName,
+	}
+)
+
 func (c *Controller) syncStork(
 	cluster *corev1.StorageCluster,
 ) error {
@@ -477,7 +495,7 @@ func (c *Controller) createStorkService(
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Spec: v1.ServiceSpec{
-				Selector: getStorkServiceLabels(),
+				Selector: storkServiceLabels,
 				Ports: []v1.ServicePort{
 					{
 						Name:       "extender",
@@ -597,6 +615,11 @@ func (c *Controller) createStorkDeployment(
 	existingVolumes := append([]v1.Volume{}, existingDeployment.Spec.Template.Spec.Volumes...)
 	sort.Sort(k8sutil.VolumeByName(existingVolumes))
 
+	updatedTopologySpreadConstraints, err := util.GetTopologySpreadConstraints(c.client, storkTemplateLabels)
+	if err != nil {
+		return err
+	}
+
 	// Check if image, envs, cpu or args are modified
 	modified := existingImage != imageName ||
 		!reflect.DeepEqual(existingCommand, command) ||
@@ -607,11 +630,13 @@ func (c *Controller) createStorkDeployment(
 		existingDeployment.Spec.Template.Spec.HostNetwork != hostNetwork ||
 		util.HasPullSecretChanged(cluster, existingDeployment.Spec.Template.Spec.ImagePullSecrets) ||
 		util.HasNodeAffinityChanged(cluster, existingDeployment.Spec.Template.Spec.Affinity) ||
-		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations)
+		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations) ||
+		util.HaveTopologySpreadConstraintsChanged(updatedTopologySpreadConstraints,
+			existingDeployment.Spec.Template.Spec.TopologySpreadConstraints)
 
 	if !c.isStorkDeploymentCreated || modified {
 		deployment := c.getStorkDeploymentSpec(cluster, ownerRef, imageName,
-			command, envVars, volumes, volumeMounts, targetCPUQuantity)
+			command, envVars, volumes, volumeMounts, targetCPUQuantity, updatedTopologySpreadConstraints)
 		if err = k8sutil.CreateOrUpdateDeployment(c.client, deployment, ownerRef); err != nil {
 			return err
 		}
@@ -629,16 +654,9 @@ func (c *Controller) getStorkDeploymentSpec(
 	volumes []v1.Volume,
 	volumeMounts []v1.VolumeMount,
 	cpuQuantity resource.Quantity,
+	topologySpreadConstraints []v1.TopologySpreadConstraint,
 ) *apps.Deployment {
 	pullPolicy := imagePullPolicy(cluster)
-	deploymentLabels := map[string]string{
-		"tier": "control-plane",
-	}
-	templateLabels := getStorkServiceLabels()
-	for k, v := range deploymentLabels {
-		templateLabels[k] = v
-	}
-
 	replicas := int32(3)
 	maxUnavailable := intstr.FromInt(1)
 	maxSurge := intstr.FromInt(1)
@@ -650,7 +668,7 @@ func (c *Controller) getStorkDeploymentSpec(
 			Annotations: map[string]string{
 				"scheduler.alpha.kubernetes.io/critical-pod": "",
 			},
-			Labels:          deploymentLabels,
+			Labels:          storkDeploymentLabels,
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 		},
 		Spec: apps.DeploymentSpec{
@@ -662,7 +680,7 @@ func (c *Controller) getStorkDeploymentSpec(
 				},
 			},
 			Selector: &metav1.LabelSelector{
-				MatchLabels: templateLabels,
+				MatchLabels: storkTemplateLabels,
 			},
 			Replicas: &replicas,
 			Template: v1.PodTemplateSpec{
@@ -670,7 +688,7 @@ func (c *Controller) getStorkDeploymentSpec(
 					Annotations: map[string]string{
 						"scheduler.alpha.kubernetes.io/critical-pod": "",
 					},
-					Labels: templateLabels,
+					Labels: storkTemplateLabels,
 				},
 				Spec: v1.PodSpec{
 					ServiceAccountName: storkServiceAccountName,
@@ -750,6 +768,10 @@ func (c *Controller) getStorkDeploymentSpec(
 		deployment.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
 	}
 
+	if len(topologySpreadConstraints) != 0 {
+		deployment.Spec.Template.Spec.TopologySpreadConstraints = topologySpreadConstraints
+	}
+
 	return deployment
 }
 
@@ -821,15 +843,22 @@ func (c *Controller) createStorkSchedDeployment(
 		}
 	}
 
+	updatedTopologySpreadConstraints, err := util.GetTopologySpreadConstraints(c.client, storkSchedulerDeploymentLabels)
+	if err != nil {
+		return err
+	}
+
 	modified := existingImage != imageName ||
 		!reflect.DeepEqual(existingCommand, command) ||
 		existingCPUQuantity.Cmp(targetCPUQuantity) != 0 ||
 		util.HasPullSecretChanged(cluster, existingDeployment.Spec.Template.Spec.ImagePullSecrets) ||
 		util.HasNodeAffinityChanged(cluster, existingDeployment.Spec.Template.Spec.Affinity) ||
-		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations)
+		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations) ||
+		util.HaveTopologySpreadConstraintsChanged(updatedTopologySpreadConstraints,
+			existingDeployment.Spec.Template.Spec.TopologySpreadConstraints)
 
 	if !c.isStorkSchedDeploymentCreated || modified {
-		deployment := getStorkSchedDeploymentSpec(cluster, ownerRef, imageName, command, targetCPUQuantity)
+		deployment := getStorkSchedDeploymentSpec(cluster, ownerRef, imageName, command, targetCPUQuantity, updatedTopologySpreadConstraints)
 		if err = k8sutil.CreateOrUpdateDeployment(c.client, deployment, ownerRef); err != nil {
 			return err
 		}
@@ -844,32 +873,27 @@ func getStorkSchedDeploymentSpec(
 	imageName string,
 	command []string,
 	cpuQuantity resource.Quantity,
+	topologySpreadConstraints []v1.TopologySpreadConstraint,
 ) *apps.Deployment {
 	pullPolicy := imagePullPolicy(cluster)
-	labels := map[string]string{
-		"tier":      "control-plane",
-		"component": "scheduler",
-		"name":      storkSchedDeploymentName,
-	}
-
 	replicas := int32(3)
 
 	deployment := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            storkSchedDeploymentName,
 			Namespace:       cluster.Namespace,
-			Labels:          labels,
+			Labels:          storkSchedulerDeploymentLabels,
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 		},
 		Spec: apps.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: storkSchedulerDeploymentLabels,
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   storkSchedDeploymentName,
-					Labels: labels,
+					Labels: storkSchedulerDeploymentLabels,
 				},
 				Spec: v1.PodSpec{
 					ServiceAccountName: storkSchedServiceAccountName,
@@ -954,6 +978,10 @@ func getStorkSchedDeploymentSpec(
 		}
 	}
 
+	if len(topologySpreadConstraints) != 0 {
+		deployment.Spec.Template.Spec.TopologySpreadConstraints = topologySpreadConstraints
+	}
+
 	return deployment
 }
 
@@ -980,12 +1008,6 @@ func getDesiredStorkVolumesAndMounts(
 	sort.Sort(k8sutil.VolumeByName(volumes))
 	sort.Sort(k8sutil.VolumeMountByName(volumeMounts))
 	return volumes, volumeMounts
-}
-
-func getStorkServiceLabels() map[string]string {
-	return map[string]string{
-		"name": "stork",
-	}
 }
 
 func imagePullPolicy(cluster *corev1.StorageCluster) v1.PullPolicy {

--- a/pkg/util/k8s/node.go
+++ b/pkg/util/k8s/node.go
@@ -6,12 +6,13 @@ import (
 	"strconv"
 	"time"
 
-	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	cluster_v1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/deprecated/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
 )
 
 /*

--- a/pkg/util/k8s/node_test.go
+++ b/pkg/util/k8s/node_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 	"time"
 
-	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/constants"
-	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cluster_v1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/deprecated/v1alpha1"
+
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
 )
 
 func TestIsNodeBeingDeleted(t *testing.T) {

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -1379,7 +1379,7 @@ func validateStorkNamespaceEnvVar(namespace string, storkDeployment *appsv1.Depl
 }
 
 func validateCSI(pxImageList map[string]string, cluster *corev1.StorageCluster, timeout, interval time.Duration) error {
-	csi, _ := strconv.ParseBool(cluster.Spec.FeatureGates["CSI"])
+	csi := cluster.Spec.CSI.Enabled
 	pxCsiDp := &appsv1.Deployment{}
 	pxCsiDp.Name = "px-csi-ext"
 	pxCsiDp.Namespace = cluster.Namespace

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -3,7 +3,15 @@ package util
 import (
 	"testing"
 
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	cluster_v1alpha1 "sigs.k8s.io/cluster-api/pkg/apis/deprecated/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
@@ -280,4 +288,95 @@ func TestComponentsPausedForMigration(t *testing.T) {
 
 	cluster.Annotations[constants.AnnotationPauseComponentMigration] = "true"
 	require.True(t, ComponentsPausedForMigration(cluster))
+}
+
+func TestHaveTopologySpreadConstraintsChanged(t *testing.T) {
+	regionConstraint := v1.TopologySpreadConstraint{
+		MaxSkew:           1,
+		TopologyKey:       "topology.kubernetes.io/region",
+		WhenUnsatisfiable: v1.ScheduleAnyway,
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"key": "value",
+			},
+		},
+	}
+	zoneConstraint := v1.TopologySpreadConstraint{
+		MaxSkew:           1,
+		TopologyKey:       "topology.kubernetes.io/zone",
+		WhenUnsatisfiable: v1.ScheduleAnyway,
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"key": "value",
+			},
+		},
+	}
+	var updatedConstraints, existingConstraints []v1.TopologySpreadConstraint
+	require.False(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
+	// Add region constraint
+	updatedConstraints = append(updatedConstraints, *regionConstraint.DeepCopy())
+	require.True(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
+	existingConstraints = append(existingConstraints, *regionConstraint.DeepCopy())
+	require.False(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
+	// Change labels
+	updatedConstraints[0].LabelSelector.MatchLabels["key"] = "new-val"
+	require.True(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
+	existingConstraints[0].LabelSelector.MatchLabels["key"] = "new-val"
+	require.False(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
+	// Add zone constraint
+	updatedConstraints = append(updatedConstraints, *zoneConstraint.DeepCopy())
+	require.True(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
+	existingConstraints = append(existingConstraints, *zoneConstraint.DeepCopy())
+	require.False(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
+	// Remove constraints
+	updatedConstraints = nil
+	require.True(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
+	existingConstraints = nil
+	require.False(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
+}
+
+func TestGetTopologySpreadConstraints(t *testing.T) {
+	fakeNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node0",
+			Labels: map[string]string{
+				"topology.kubernetes.io/region": "region0",
+				"topology.kubernetes.io/zone":   "zone0",
+				"other.label.key":               "value",
+			},
+		},
+	}
+	k8sClient := fakeK8sClient(fakeNode)
+	templateLabels := map[string]string{
+		"key": "value",
+	}
+	expectedConstraints := []v1.TopologySpreadConstraint{
+		{
+			MaxSkew:           1,
+			TopologyKey:       "topology.kubernetes.io/region",
+			WhenUnsatisfiable: v1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: templateLabels,
+			},
+		},
+		{
+			MaxSkew:           1,
+			TopologyKey:       "topology.kubernetes.io/zone",
+			WhenUnsatisfiable: v1.ScheduleAnyway,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: templateLabels,
+			},
+		},
+	}
+	constraints, err := GetTopologySpreadConstraints(k8sClient, templateLabels)
+	require.NoError(t, err)
+	require.Equal(t, expectedConstraints, constraints)
+}
+
+func fakeK8sClient(initObjects ...runtime.Object) client.Client {
+	s := scheme.Scheme
+	corev1.AddToScheme(s)
+	monitoringv1.AddToScheme(s)
+	cluster_v1alpha1.AddToScheme(s)
+	return fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(initObjects...).Build()
 }

--- a/test/integration_test/utils/node.go
+++ b/test/integration_test/utils/node.go
@@ -3,9 +3,10 @@ package utils
 import (
 	"testing"
 
-	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
+	coreops "github.com/portworx/sched-ops/k8s/core"
 )
 
 // AddLabelToRandomNode adds the given label to a random worker node


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Add pod topology spread constraints to csi, pvc controller, stork and stork scheduler pods.

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-560](https://portworx.atlassian.net/browse/OPERATOR-560)

**Special notes for your reviewer**:

