### PR TITLE
OPERATOR-482, OPERATOR-596 Skip security secrets from PX backup

### DIFF
--- a/drivers/storage/portworx/component/auth.go
+++ b/drivers/storage/portworx/component/auth.go
@@ -32,6 +32,8 @@ const (
 	AuthTokenBufferLength = time.Minute * 1
 	// AuthSystemGuestRoleName is the role name to maintain for the guest role
 	AuthSystemGuestRoleName = "system.guest"
+	// AnnotationSkipResource stork annotation to skip a resource from a backup
+	AnnotationSkipResource = "stork.libopenstorage.org/skip-resource"
 )
 
 // GuestRoleEnabled is the default configuration for the guest role
@@ -250,6 +252,9 @@ func (a *auth) createPrivateKeysSecret(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      *cluster.Spec.Security.Auth.SelfSigned.SharedSecret,
 			Namespace: cluster.Namespace,
+			Annotations: map[string]string{
+				AnnotationSkipResource: "true",
+			},
 		}, Data: map[string][]byte{
 			pxutil.SecuritySharedSecretKey: []byte(sharedSecretKey),
 		},
@@ -258,6 +263,9 @@ func (a *auth) createPrivateKeysSecret(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pxutil.SecurityPXSystemSecretsSecretName,
 			Namespace: cluster.Namespace,
+			Annotations: map[string]string{
+				AnnotationSkipResource: "true",
+			},
 		}, Data: map[string][]byte{
 			pxutil.SecuritySystemSecretKey: []byte(internalSystemSecretKey),
 			pxutil.SecurityAppsSecretKey:   []byte(appsSecretKey),
@@ -361,8 +369,11 @@ func (a *auth) maintainAuthTokenSecret(
 		// Store new token
 		secret := &v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            authTokenSecretName,
-				Namespace:       cluster.Namespace,
+				Name:      authTokenSecretName,
+				Namespace: cluster.Namespace,
+				Annotations: map[string]string{
+					AnnotationSkipResource: "true",
+				},
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Data: map[string][]byte{

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3691,7 +3691,6 @@ func TestAutopilotVolumesChange(t *testing.T) {
 
 func TestSecurityInstall(t *testing.T) {
 	// auth enabled through security.enabled
-	logrus.SetLevel(logrus.TraceLevel)
 	cluster := &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
@@ -3738,6 +3737,8 @@ func validateAuthSecurityInstall(t *testing.T, cluster *corev1.StorageCluster) {
 	err = testutil.Get(k8sClient, sharedSecret, *cluster.Spec.Security.Auth.SelfSigned.SharedSecret, cluster.Namespace)
 	require.NoError(t, err)
 	require.Empty(t, sharedSecret.OwnerReferences)
+	require.Len(t, sharedSecret.Annotations, 1)
+	require.Equal(t, "true", sharedSecret.Annotations[component.AnnotationSkipResource])
 	require.Equal(t, 64, len(sharedSecret.Data[pxutil.SecuritySharedSecretKey]))
 	oldSharedSecret := sharedSecret.Data[pxutil.SecuritySharedSecretKey]
 
@@ -3745,6 +3746,8 @@ func validateAuthSecurityInstall(t *testing.T, cluster *corev1.StorageCluster) {
 	err = testutil.Get(k8sClient, systemSecret, pxutil.SecurityPXSystemSecretsSecretName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Empty(t, systemSecret.OwnerReferences)
+	require.Len(t, systemSecret.Annotations, 1)
+	require.Equal(t, "true", systemSecret.Annotations[component.AnnotationSkipResource])
 	require.Equal(t, 64, len(systemSecret.Data[pxutil.SecuritySystemSecretKey]))
 	oldSystemSecret := systemSecret.Data[pxutil.SecuritySystemSecretKey]
 	require.Equal(t, 64, len(systemSecret.Data[pxutil.SecurityAppsSecretKey]))
@@ -3772,6 +3775,8 @@ func validateAuthSecurityInstall(t *testing.T, cluster *corev1.StorageCluster) {
 	require.NoError(t, err)
 	require.Len(t, adminSecret.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, adminSecret.OwnerReferences[0].Name)
+	require.Len(t, adminSecret.Annotations, 1)
+	require.Equal(t, "true", adminSecret.Annotations[component.AnnotationSkipResource])
 	_, _, err = new(jwt.Parser).ParseUnverified(string(adminSecret.Data[pxutil.SecurityAuthTokenKey]), &jwtClaims)
 	require.NoError(t, err)
 	groups := jwtClaims["groups"].([]interface{})
@@ -3789,6 +3794,8 @@ func validateAuthSecurityInstall(t *testing.T, cluster *corev1.StorageCluster) {
 	require.NoError(t, err)
 	require.Len(t, userSecret.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, userSecret.OwnerReferences[0].Name)
+	require.Len(t, userSecret.Annotations, 1)
+	require.Equal(t, "true", userSecret.Annotations[component.AnnotationSkipResource])
 	_, _, err = new(jwt.Parser).ParseUnverified(string(userSecret.Data[pxutil.SecurityAuthTokenKey]), &jwtClaims)
 	require.NoError(t, err)
 	groups = jwtClaims["groups"].([]interface{})
@@ -3919,7 +3926,6 @@ func validateAuthSecurityInstall(t *testing.T, cluster *corev1.StorageCluster) {
 }
 
 func TestTLSSpecValidation(t *testing.T) {
-	logrus.SetLevel(logrus.TraceLevel)
 	caCertFileName := stringPtr("/etc/pwx/testCA.crt")
 	serverCertFileName := stringPtr("/etc/pwx/testServer.crt")
 	serverKeyFileName := stringPtr("/etc/pwx/testServer.key")
@@ -4148,11 +4154,10 @@ func validateSecurityTokenRefreshOnUpdate(t *testing.T, cluster *corev1.StorageC
 	newSharedSecretName := fmt.Sprintf("newsharedsecret%d", rand.Intn(100000))
 	sharedSecret.Name = newSharedSecretName
 	sharedSecret.Namespace = cluster.Namespace
+	sharedSecret.Annotations = map[string]string{component.AnnotationSkipResource: "true"}
 	sharedSecret.Data = make(map[string][]byte)
-	sharedSecret.StringData = make(map[string]string)
 	sharedSecret.Type = v1.SecretTypeOpaque
 	sharedSecret.Data[pxutil.SecuritySharedSecretKey] = []byte(fmt.Sprintf("mynewsecret_in_different_location%d", rand.Intn(100000)))
-	sharedSecret.StringData[pxutil.SecuritySharedSecretKey] = fmt.Sprintf("mynewsecret_in_different_location%d", rand.Intn(100000))
 	err = k8sClient.Create(context.TODO(), sharedSecret)
 	require.NoError(t, err)
 	cluster.Spec.Security.Auth.SelfSigned.SharedSecret = &newSharedSecretName
@@ -4164,7 +4169,7 @@ func validateSecurityTokenRefreshOnUpdate(t *testing.T, cluster *corev1.StorageC
 	err = testutil.Get(k8sClient, userSecret, pxutil.SecurityPXUserTokenSecretName, cluster.Namespace)
 	require.NoError(t, err)
 	newUserToken = userSecret.Data[pxutil.SecurityAuthTokenKey]
-	require.NotEqual(t, oldUserToken, newUserToken)
+	require.NotEqual(t, string(oldUserToken), string(newUserToken))
 
 	// no changes, token remains the same.
 	err = testutil.Get(k8sClient, userSecret, pxutil.SecurityPXUserTokenSecretName, cluster.Namespace)
@@ -4178,6 +4183,109 @@ func validateSecurityTokenRefreshOnUpdate(t *testing.T, cluster *corev1.StorageC
 	require.NoError(t, err)
 	newUserToken = userSecret.Data[pxutil.SecurityAuthTokenKey]
 	require.Equal(t, oldUserToken, newUserToken)
+}
+
+func TestSecuritySkipAnnotationIsAdded(t *testing.T) {
+	// auth enabled through security.enabled
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					GuestAccess: guestAccessTypePtr(corev1.GuestRoleManaged),
+					SelfSigned: &corev1.SelfSignedSpec{
+						TokenLifetime: stringPtr("1h"),
+					},
+				},
+			},
+		},
+	}
+
+	sharedSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-shared-secret",
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string][]byte{
+			pxutil.SecuritySharedSecretKey: []byte("shared-secret"),
+		},
+	}
+	systemSecret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-system-secrets",
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string][]byte{
+			pxutil.SecuritySystemSecretKey: []byte("system-secret"),
+			pxutil.SecurityAppsSecretKey:   []byte("apps-secret"),
+		},
+	}
+	adminToken := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-admin-token",
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string][]byte{
+			pxutil.SecurityAuthTokenKey: []byte("admin-token"),
+		},
+	}
+	userToken := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-user-token",
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string][]byte{
+			pxutil.SecurityAuthTokenKey: []byte("user-token"),
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(sharedSecret, systemSecret, adminToken, userToken)
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
+	require.NoError(t, err)
+
+	SetPortworxDefaults(cluster)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	updatedSharedSecret := &v1.Secret{}
+	err = testutil.Get(k8sClient, updatedSharedSecret, pxutil.SecurityPXSharedSecretSecretName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t,
+		sharedSecret.Data[pxutil.SecuritySharedSecretKey],
+		updatedSharedSecret.Data[pxutil.SecuritySharedSecretKey],
+	)
+	require.Len(t, updatedSharedSecret.Annotations, 1)
+	require.Equal(t, "true", updatedSharedSecret.Annotations[component.AnnotationSkipResource])
+
+	updatedSystemSecret := &v1.Secret{}
+	err = testutil.Get(k8sClient, updatedSystemSecret, pxutil.SecurityPXSystemSecretsSecretName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t,
+		systemSecret.Data[pxutil.SecuritySystemSecretKey],
+		updatedSystemSecret.Data[pxutil.SecuritySystemSecretKey],
+	)
+	require.Len(t, updatedSystemSecret.Annotations, 1)
+	require.Equal(t, "true", updatedSystemSecret.Annotations[component.AnnotationSkipResource])
+
+	updatedAdminToken := &v1.Secret{}
+	err = testutil.Get(k8sClient, updatedAdminToken, pxutil.SecurityPXAdminTokenSecretName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Len(t, updatedAdminToken.Annotations, 1)
+	require.Equal(t, "true", updatedAdminToken.Annotations[component.AnnotationSkipResource])
+
+	updatedUserToken := &v1.Secret{}
+	err = testutil.Get(k8sClient, updatedUserToken, pxutil.SecurityPXUserTokenSecretName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Len(t, updatedUserToken.Annotations, 1)
+	require.Equal(t, "true", updatedUserToken.Annotations[component.AnnotationSkipResource])
 }
 
 func TestGuestAccessSecurity(t *testing.T) {

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -846,15 +846,10 @@ func getStorkSchedDeploymentSpec(
 	cpuQuantity resource.Quantity,
 ) *apps.Deployment {
 	pullPolicy := imagePullPolicy(cluster)
-	templateLabels := map[string]string{
+	labels := map[string]string{
 		"tier":      "control-plane",
 		"component": "scheduler",
-	}
-	deploymentLabels := map[string]string{
-		"name": storkSchedDeploymentName,
-	}
-	for k, v := range templateLabels {
-		deploymentLabels[k] = v
+		"name":      storkSchedDeploymentName,
 	}
 
 	replicas := int32(3)
@@ -863,18 +858,18 @@ func getStorkSchedDeploymentSpec(
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            storkSchedDeploymentName,
 			Namespace:       cluster.Namespace,
-			Labels:          deploymentLabels,
+			Labels:          labels,
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 		},
 		Spec: apps.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: templateLabels,
+				MatchLabels: labels,
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   storkSchedDeploymentName,
-					Labels: templateLabels,
+					Labels: labels,
 				},
 				Spec: v1.PodSpec{
 					ServiceAccountName: storkSchedServiceAccountName,

--- a/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
@@ -13,11 +13,13 @@ spec:
     matchLabels:
       component: scheduler
       tier: control-plane
+      name: stork-scheduler
   template:
     metadata:
       labels:
         component: scheduler
         tier: control-plane
+        name: stork-scheduler
       name: stork-scheduler
     spec:
       containers:

--- a/pkg/controller/storagecluster/testspec/storkSchedVersionedDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedVersionedDeployment.yaml
@@ -13,11 +13,13 @@ spec:
     matchLabels:
       component: scheduler
       tier: control-plane
+      name: stork-scheduler
   template:
     metadata:
       labels:
         component: scheduler
         tier: control-plane
+        name: stork-scheduler
       name: stork-scheduler
     spec:
       containers:

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1730,6 +1730,8 @@ func CreateOrAppendToSecret(
 		}
 	}
 
+	modified = modified || !reflect.DeepEqual(secret.Annotations, existingSecret.Annotations)
+
 	for _, o := range existingSecret.OwnerReferences {
 		if ownerRef != nil && o.UID != ownerRef.UID {
 			secret.OwnerReferences = append(secret.OwnerReferences, o)


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

For OPERATOR-596: The pod template was using 'name: stork-scheduler' labels in 
the pod antiaffinity, but we were not setting that label. Adding the label now for new
installs only. For existing installs, users will have to delete the scheduler
deployment manually.

**Which issue(s) this PR fixes** (optional)
Closes # 
https://portworx.atlassian.net/browse/OPERATOR-482
https://portworx.atlassian.net/browse/OPERATOR-596

**Special notes for your reviewer**:

