### PR TITLE
[OPERATOR-561] Don't initialize default storage spec when only node level cloud storage spec is specified.

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -595,7 +595,17 @@ func SetPortworxDefaults(toUpdate *corev1.StorageCluster) {
 
 	// If no storage spec is provided, initialize one where Portworx takes all available drives
 	if toUpdate.Spec.CloudStorage == nil && toUpdate.Spec.Storage == nil {
-		toUpdate.Spec.Storage = &corev1.StorageSpec{}
+		// Only initialize storage spec when there's no node level cloud storage spec specified
+		initializeStorageSpec := true
+		for _, nodeSpec := range toUpdate.Spec.Nodes {
+			if nodeSpec.CloudStorage != nil {
+				initializeStorageSpec = false
+				break
+			}
+		}
+		if initializeStorageSpec {
+			toUpdate.Spec.Storage = &corev1.StorageSpec{}
+		}
 	}
 	if toUpdate.Spec.Storage != nil {
 		if toUpdate.Spec.Storage.Devices == nil &&

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -1327,6 +1327,17 @@ func TestStorageClusterDefaultsForNodeSpecsWithCloudStorage(t *testing.T) {
 	require.Nil(t, cluster.Spec.Nodes[0].CloudStorage.KvdbDeviceSpec)
 	require.Nil(t, cluster.Spec.Nodes[0].CloudStorage.MaxStorageNodesPerZonePerNodeGroup)
 
+	// Do not set default storage spec if node cloud storage spec exists
+	cluster.Spec.Storage = nil
+	cluster.Spec.Nodes = []corev1.NodeSpec{
+		{
+			CloudStorage: &corev1.CloudStorageNodeSpec{},
+		},
+	}
+	driver.SetDefaultsOnStorageCluster(cluster)
+	require.Nil(t, cluster.Spec.Storage)
+	require.Nil(t, cluster.Spec.Nodes[0].Storage)
+
 	// Set node spec cloudstorage fields from cluster cloudstorage spec, if empty at node level
 	clusterDeviceSpecs := []string{"type=dev1", "type=dev2"}
 	maxStorageNodes := uint32(3)

--- a/test/integration_test/utils/px_operator.go
+++ b/test/integration_test/utils/px_operator.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	nextReleaseTag = "1.7.0-dev"
+	nextReleaseTag = "1.8.0-dev"
 )
 
 var (


### PR DESCRIPTION

Signed-off-by: Jiafeng Liao <jliao@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: When only node level cloudStorage specs are provided, operator shouldn't set default cluster level storage spec

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-561](https://portworx.atlassian.net/browse/OPERATOR-561)

**Special notes for your reviewer**:


