### PR TITLE
[OPERATOR-507] - implement daemonset backup

### DIFF
--- a/pkg/migration/backup.go
+++ b/pkg/migration/backup.go
@@ -1,0 +1,284 @@
+package migration
+
+import (
+	"context"
+	"strings"
+
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
+)
+
+const (
+	// BackupConfigMapName is the name of configmap that contains Daemonset backup.
+	BackupConfigMapName = "px-daemonset-backup"
+)
+
+func (h *Handler) backup(namespace string) error {
+	var objs []client.Object
+	if err := h.getDaemonSetComponent(namespace, &objs); err != nil {
+		return err
+	}
+
+	if err := h.getPortworxAPI(namespace, &objs); err != nil {
+		return err
+	}
+	if err := h.getPortworxRbac(namespace, &objs); err != nil {
+		return err
+	}
+
+	if err := h.getStorkComponent(namespace, &objs); err != nil {
+		return err
+	}
+
+	if err := h.getAutopilotComponent(namespace, &objs); err != nil {
+		return err
+	}
+	if err := h.getCSIComponent(namespace, &objs); err != nil {
+		return err
+	}
+	if err := h.getPVCControllerComponent(namespace, &objs); err != nil {
+		return err
+	}
+	if err := h.getMonitoringComponent(namespace, &objs); err != nil {
+		return err
+	}
+
+	var sb strings.Builder
+	for _, obj := range objs {
+		bytes, err := yaml.Marshal(obj)
+		if err != nil {
+			return err
+		}
+
+		sb.WriteString(string(bytes))
+		sb.WriteString("\n")
+	}
+
+	data := map[string]string{
+		"backup": sb.String(),
+	}
+
+	return k8sutil.CreateOrUpdateConfigMap(
+		h.client,
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      BackupConfigMapName,
+				Namespace: namespace,
+			},
+			Data: data,
+		},
+		nil,
+	)
+}
+
+func (h *Handler) addObject(
+	name, namespace string,
+	obj client.Object,
+	objs *[]client.Object,
+) error {
+	err := h.client.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+		obj,
+	)
+	if meta.IsNoMatchError(err) || errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	newObjs := append(*objs, obj)
+	*objs = newObjs
+
+	return nil
+}
+
+func (h *Handler) getDaemonSetComponent(namespace string, objs *[]client.Object) error {
+	if err := h.addObject(portworxDaemonSetName, namespace, &appsv1.DaemonSet{}, objs); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *Handler) getStorkComponent(namespace string, objs *[]client.Object) error {
+	if err := h.addObject(storkDeploymentName, namespace, &appsv1.Deployment{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(storkServiceName, namespace, &v1.Service{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(storkConfigName, namespace, &v1.ConfigMap{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(storkRoleBindingName, "", &rbacv1.ClusterRoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(storkRoleName, "", &rbacv1.ClusterRole{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(storkAccountName, namespace, &v1.ServiceAccount{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(schedDeploymentName, namespace, &appsv1.Deployment{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(schedRoleBindingName, "", &rbacv1.ClusterRoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(schedRoleName, "", &rbacv1.ClusterRole{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(schedAccountName, namespace, &v1.ServiceAccount{}, objs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) getPortworxRbac(namespace string, objs *[]client.Object) error {
+	if err := h.addObject(pxClusterRoleBindingName, "", &rbacv1.ClusterRoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pxClusterRoleName, "", &rbacv1.ClusterRole{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pxRoleBindingName, namespace, &rbacv1.RoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pxRoleName, namespace, &rbacv1.Role{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pxRoleBindingName, secretsNamespace, &rbacv1.RoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pxRoleName, secretsNamespace, &rbacv1.Role{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pxAccountName, namespace, &v1.ServiceAccount{}, objs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) getPortworxAPI(namespace string, objs *[]client.Object) error {
+	if err := h.addObject(pxAPIDaemonSetName, namespace, &appsv1.DaemonSet{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pxAPIServiceName, namespace, &v1.Service{}, objs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) getAutopilotComponent(namespace string, objs *[]client.Object) error {
+	if err := h.addObject(autopilotDeploymentName, namespace, &appsv1.Deployment{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(autopilotServiceName, namespace, &v1.Service{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(autopilotConfigName, namespace, &v1.ConfigMap{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(autopilotRoleBindingName, "", &rbacv1.ClusterRoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(autopilotRoleName, "", &rbacv1.ClusterRole{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(autopilotAccountName, namespace, &v1.ServiceAccount{}, objs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) getPVCControllerComponent(namespace string, objs *[]client.Object) error {
+	if err := h.addObject(pvcDeploymentName, namespace, &appsv1.Deployment{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pvcRoleBindingName, "", &rbacv1.ClusterRoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pvcRoleName, "", &rbacv1.ClusterRole{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(pvcAccountName, namespace, &v1.ServiceAccount{}, objs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) getCSIComponent(namespace string, objs *[]client.Object) error {
+	if err := h.addObject(csiDeploymentName, namespace, &appsv1.Deployment{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(csiServiceName, namespace, &v1.Service{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(csiRoleBindingName, "", &rbacv1.ClusterRoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(csiRoleName, "", &rbacv1.ClusterRole{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(csiAccountName, namespace, &v1.ServiceAccount{}, objs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (h *Handler) getMonitoringComponent(namespace string, objs *[]client.Object) error {
+	if err := h.addObject(serviceMonitorName, namespace, &monitoringv1.ServiceMonitor{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusRuleName, namespace, &monitoringv1.PrometheusRule{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(alertManagerName, namespace, &monitoringv1.Alertmanager{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(alertManagerServiceName, namespace, &v1.Service{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusInstanceName, namespace, &monitoringv1.Prometheus{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusServiceName, namespace, &v1.Service{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusRoleBindingName, "", &rbacv1.ClusterRoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusRoleName, "", &rbacv1.ClusterRole{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusAccountName, namespace, &v1.ServiceAccount{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusOpDeploymentName, namespace, &appsv1.Deployment{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusOpRoleBindingName, "", &rbacv1.ClusterRoleBinding{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusOpRoleName, "", &rbacv1.ClusterRole{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(prometheusOpAccountName, namespace, &v1.ServiceAccount{}, objs); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/migration/backup_test.go
+++ b/pkg/migration/backup_test.go
@@ -1,24 +1,34 @@
 package migration
 
 import (
-	"fmt"
+	"context"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/libopenstorage/operator/drivers/storage/portworx/component"
 	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestBackup(t *testing.T) {
+	testBackup(t, true)
+	testBackup(t, false)
+}
+
+func testBackup(t *testing.T, backupExits bool) {
 	clusterName := "px-cluster"
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -84,25 +94,61 @@ func TestBackup(t *testing.T) {
 		ds, storkDeployment, autopilotDeployment,
 	)
 
+	if backupExits {
+		err := k8sClient.Create(context.TODO(),
+			&v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      BackupConfigMapName,
+					Namespace: ds.Namespace,
+				},
+			})
+		require.NoError(t, err)
+	}
+
 	driver := testutil.MockDriver(gomock.NewController(t))
 	ctrl := &storagecluster.Controller{
 		Driver: driver,
 	}
 	ctrl.SetKubernetesClient(k8sClient)
 
-	migrator := New(ctrl)
-
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().String().Return("mock-driver").AnyTimes()
 
+	migrator := New(ctrl)
 	go migrator.Start()
-	time.Sleep(10 * time.Second)
 
-	// Verify the configmap is created
-	cm := v1.ConfigMap{}
-	err := testutil.Get(k8sClient, &cm, BackupConfigMapName, ds.Namespace)
+	err := wait.PollImmediate(time.Millisecond*200, time.Minute, func() (bool, error) {
+		currentCluster := &corev1.StorageCluster{}
+		err := testutil.Get(k8sClient, currentCluster, "px-cluster", ds.Namespace)
+		if errors.IsNotFound(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+
+		// Approve the migration
+		if currentCluster.Annotations[constants.AnnotationMigrationApproved] != "true" {
+			currentCluster.Annotations[constants.AnnotationMigrationApproved] = "true"
+			err = testutil.Update(k8sClient, currentCluster)
+			require.NoError(t, err)
+		}
+
+		cm := v1.ConfigMap{}
+		err = testutil.Get(k8sClient, &cm, BackupConfigMapName, ds.Namespace)
+		if err == nil {
+			// Precreated configmap is empty.
+			if backupExits {
+				require.Nil(t, cm.Data)
+			} else {
+				require.NotNil(t, cm.Data)
+			}
+			return true, nil
+		} else if errors.IsNotFound(err) {
+			return false, nil
+		} else {
+			return false, err
+		}
+	})
 	require.NoError(t, err)
-
-	fmt.Printf("%v\n", cm.Data)
 }

--- a/pkg/migration/backup_test.go
+++ b/pkg/migration/backup_test.go
@@ -1,0 +1,108 @@
+package migration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/libopenstorage/operator/drivers/storage/portworx/component"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
+)
+
+func TestBackup(t *testing.T) {
+	clusterName := "px-cluster"
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx",
+			Namespace: "portworx",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "portworx",
+							Image: "pximage",
+							Args: []string{
+								"-c", clusterName,
+							},
+						},
+						{
+							Name:  pxutil.TelemetryContainerName,
+							Image: "telemetryImage",
+						},
+					},
+				},
+			},
+		},
+	}
+	storkDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      storkDeploymentName,
+			Namespace: ds.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "storkImage",
+						},
+					},
+				},
+			},
+		},
+	}
+	autopilotDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      component.AutopilotDeploymentName,
+			Namespace: ds.Namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Image: "autopilogImage",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(
+		ds, storkDeployment, autopilotDeployment,
+	)
+
+	driver := testutil.MockDriver(gomock.NewController(t))
+	ctrl := &storagecluster.Controller{
+		Driver: driver,
+	}
+	ctrl.SetKubernetesClient(k8sClient)
+
+	migrator := New(ctrl)
+
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
+	driver.EXPECT().String().Return("mock-driver").AnyTimes()
+
+	go migrator.Start()
+	time.Sleep(10 * time.Second)
+
+	// Verify the configmap is created
+	cm := v1.ConfigMap{}
+	err := testutil.Get(k8sClient, &cm, BackupConfigMapName, ds.Namespace)
+	require.NoError(t, err)
+
+	fmt.Printf("%v\n", cm.Data)
+}

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -82,13 +82,13 @@ func (h *Handler) Start() {
 			return false, nil
 		}
 
-		err = h.backup(cluster.Namespace)
-		if err != nil {
-			logrus.Errorf("Failed to backup daemonset components. %v", err)
+		if !h.isMigrationApproved(cluster) {
 			return false, nil
 		}
 
-		if !h.isMigrationApproved(cluster) {
+		err = h.backup(cluster.Namespace)
+		if err != nil {
+			logrus.Errorf("Failed to backup daemonset components. %v", err)
 			return false, nil
 		}
 

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -82,6 +82,12 @@ func (h *Handler) Start() {
 			return false, nil
 		}
 
+		err = h.backup(cluster.Namespace)
+		if err != nil {
+			logrus.Errorf("Failed to backup daemonset components. %v", err)
+			return false, nil
+		}
+
 		if !h.isMigrationApproved(cluster) {
 			return false, nil
 		}
@@ -212,6 +218,8 @@ func (h *Handler) processMigration(
 
 	// TODO: Wait for all components to be up, before marking the migration as completed
 
+	// TODO: once daemonset is deleted, if we restart operator all code after this line
+	// will not be re-executed, so we should delete daemonset after everything is finished.
 	logrus.Infof("Deleting portworx DaemonSet")
 	if err := h.deletePortworxDaemonSet(ds); err != nil {
 		return err


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
backup portworx components that are deployed by daemonset method, if migration to operator fails we can rollback.
https://portworx.atlassian.net/browse/OPERATOR-507

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

