### PR TITLE
[OPERATOR-562] Fix pod disruption budget spec issue when using Metro DR

### DIFF
--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -24,7 +24,6 @@ import (
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: when using Metro DR, operator should exclude storage nodes from other clusters when calculating the pod disruption budget.

**Which issue(s) this PR fixes** (optional)
Closes #[OPERATOR-562]

**Special notes for your reviewer**:

