### PR TITLE
OPERATOR-538 Add default secrets namespace if not provided

### DIFF
--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -290,7 +290,11 @@ func (h *Handler) constructStorageCluster(ds *appsv1.DaemonSet) *corev1.StorageC
 	secretsNamespaceProvided := false
 	// Populate env variables from args and env vars of portworx container
 	for _, env := range c.Env {
-		if env.Name == "PX_TEMPLATE_VERSION" {
+		if env.Name == "PX_TEMPLATE_VERSION" ||
+			env.Name == "PORTWORX_CSIVERSION" ||
+			env.Name == "CSI_ENDPOINT" ||
+			env.Name == "NODE_NAME" ||
+			env.Name == pxutil.EnvKeyPortworxNamespace {
 			continue
 		}
 		if env.Name == pxutil.EnvKeyPortworxSecretsNamespace {

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -31,6 +31,7 @@ import (
 const (
 	portworxDaemonSetName          = "portworx"
 	portworxContainerName          = "portworx"
+	defaultSecretsNamespace        = "portworx"
 	migrationRetryInterval         = 30 * time.Second
 	podWaitInterval                = 10 * time.Second
 	daemonSetPodTerminationTimeout = 5 * time.Minute
@@ -128,10 +129,6 @@ func (h *Handler) processMigration(
 	cluster *corev1.StorageCluster,
 	ds *appsv1.DaemonSet,
 ) error {
-	// TODO: Implement this
-	// 1. Backup existing specs
-	// 2. Migrate components
-
 	nodeList := &v1.NodeList{}
 	if err := h.client.List(context.TODO(), nodeList, &client.ListOptions{}); err != nil {
 		return err
@@ -225,6 +222,7 @@ func (h *Handler) processMigration(
 		return err
 	}
 
+	// Unmark the nodes after the daemonset has been deleted, else it will create pods again
 	logrus.Infof("Removing migration label from all nodes")
 	if err := h.unmarkAllDoneNodes(); err != nil {
 		return err

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -316,6 +316,30 @@ func TestStorageClusterIsCreatedFromCloudDaemonset(t *testing.T) {
 									Value: "v3",
 								},
 								{
+									Name:  "PORTWORX_CSIVERSION",
+									Value: "0.3",
+								},
+								{
+									Name:  "CSI_ENDPOINT",
+									Value: "unix:///var/lib/kubelet/plugins/pxd.portworx.com/csi.sock",
+								},
+								{
+									Name: "NODE_NAME",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "spec.nodeName",
+										},
+									},
+								},
+								{
+									Name: "PX_NAMESPACE",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.namespace",
+										},
+									},
+								},
+								{
 									Name:  "TEST_ENV_1",
 									Value: "value1",
 								},


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

-  The 'portworx' secrets namesapce needs to be explicitly added to the storage
    cluster during migration. As most daemonset clusters have been using portworx
    namespace to store secrets by default. If a secrets namespace is provided
    explicitly then we honor that.
-  Some env variables are added by the operator to the portworx pod directly. We
    don't need to copy them to the storage cluster.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-538

**Special notes for your reviewer**:

