### PR TITLE
[CSI] Add desired snapshot controller image when empty

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -5018,6 +5018,7 @@ func TestCSIInstallEphemeralWithK8s1_20VersionAndPX2_5(t *testing.T) {
 	// Enable snapshot controller
 	cluster.Spec.CSI.Enabled = true
 	cluster.Spec.CSI.InstallSnapshotController = boolPtr(true)
+	driver.SetDefaultsOnStorageCluster(cluster)
 
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -234,18 +234,23 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			toUpdate.Status.DesiredImages.PxRepo = release.Components.PxRepo
 		}
 
-		if pxutil.IsCSIEnabled(toUpdate) &&
-			(toUpdate.Status.DesiredImages.CSIProvisioner == "" ||
+		if pxutil.IsCSIEnabled(toUpdate) {
+			if toUpdate.Status.DesiredImages.CSIProvisioner == "" ||
 				pxVersionChanged ||
-				autoUpdateComponents(toUpdate)) {
-			toUpdate.Status.DesiredImages.CSIProvisioner = release.Components.CSIProvisioner
-			toUpdate.Status.DesiredImages.CSINodeDriverRegistrar = release.Components.CSINodeDriverRegistrar
-			toUpdate.Status.DesiredImages.CSIDriverRegistrar = release.Components.CSIDriverRegistrar
-			toUpdate.Status.DesiredImages.CSIAttacher = release.Components.CSIAttacher
-			toUpdate.Status.DesiredImages.CSIResizer = release.Components.CSIResizer
-			toUpdate.Status.DesiredImages.CSISnapshotter = release.Components.CSISnapshotter
-			toUpdate.Status.DesiredImages.CSISnapshotController = release.Components.CSISnapshotController
-			toUpdate.Status.DesiredImages.CSIHealthMonitorController = release.Components.CSIHealthMonitorController
+				autoUpdateComponents(toUpdate) {
+				toUpdate.Status.DesiredImages.CSIProvisioner = release.Components.CSIProvisioner
+				toUpdate.Status.DesiredImages.CSINodeDriverRegistrar = release.Components.CSINodeDriverRegistrar
+				toUpdate.Status.DesiredImages.CSIDriverRegistrar = release.Components.CSIDriverRegistrar
+				toUpdate.Status.DesiredImages.CSIAttacher = release.Components.CSIAttacher
+				toUpdate.Status.DesiredImages.CSIResizer = release.Components.CSIResizer
+				toUpdate.Status.DesiredImages.CSISnapshotter = release.Components.CSISnapshotter
+				toUpdate.Status.DesiredImages.CSIHealthMonitorController = release.Components.CSIHealthMonitorController
+			}
+			if toUpdate.Status.DesiredImages.CSISnapshotController == "" ||
+				pxVersionChanged ||
+				autoUpdateComponents(toUpdate) {
+				toUpdate.Status.DesiredImages.CSISnapshotController = release.Components.CSISnapshotController
+			}
 		}
 
 		if toUpdate.Spec.Monitoring != nil && toUpdate.Spec.Monitoring.Prometheus != nil {
@@ -937,7 +942,7 @@ func hasLighthouseChanged(cluster *corev1.StorageCluster) bool {
 
 func hasCSIChanged(cluster *corev1.StorageCluster) bool {
 	return pxutil.IsCSIEnabled(cluster) &&
-		cluster.Status.DesiredImages.CSIProvisioner == ""
+		(cluster.Status.DesiredImages.CSIProvisioner == "" || cluster.Status.DesiredImages.CSISnapshotController == "")
 }
 
 func hasTelemetryChanged(cluster *corev1.StorageCluster) bool {

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -246,7 +246,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 				toUpdate.Status.DesiredImages.CSISnapshotter = release.Components.CSISnapshotter
 				toUpdate.Status.DesiredImages.CSIHealthMonitorController = release.Components.CSIHealthMonitorController
 			}
-			if toUpdate.Status.DesiredImages.CSISnapshotController == "" ||
+			if autoUpdateCSISnapshotController(toUpdate) ||
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate) {
 				toUpdate.Status.DesiredImages.CSISnapshotController = release.Components.CSISnapshotController
@@ -942,7 +942,13 @@ func hasLighthouseChanged(cluster *corev1.StorageCluster) bool {
 
 func hasCSIChanged(cluster *corev1.StorageCluster) bool {
 	return pxutil.IsCSIEnabled(cluster) &&
-		(cluster.Status.DesiredImages.CSIProvisioner == "" || cluster.Status.DesiredImages.CSISnapshotController == "")
+		(cluster.Status.DesiredImages.CSIProvisioner == "" || autoUpdateCSISnapshotController(cluster))
+}
+
+func autoUpdateCSISnapshotController(cluster *corev1.StorageCluster) bool {
+	return cluster.Spec.CSI.InstallSnapshotController != nil &&
+		*cluster.Spec.CSI.InstallSnapshotController &&
+		cluster.Status.DesiredImages.CSISnapshotController == ""
 }
 
 func hasTelemetryChanged(cluster *corev1.StorageCluster) bool {

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -984,11 +984,19 @@ func TestStorageClusterDefaultsForCSI(t *testing.T) {
 			Image: "px/image:2.9.0.1",
 		},
 	}
-	// Simulate DesiredImages.CSISnapshotController being empty for old operator version w/o this image
 	driver.SetDefaultsOnStorageCluster(cluster)
-	cluster.Status.DesiredImages.CSISnapshotController = ""
 
-	// Enable CSI by default for a new install
+	// Simulate DesiredImages.CSISnapshotController being empty for old operator version w/o this image
+	cluster.Status.DesiredImages.CSISnapshotController = ""
+	driver.SetDefaultsOnStorageCluster(cluster)
+
+	// SnapshotController image should be empty
+	require.Empty(t, cluster.Status.DesiredImages.CSISnapshotController)
+
+	// Enable CSI by default for a new install.
+	// Enable Snapshot controller, desired image should be set
+	trueBool := true
+	cluster.Spec.CSI.InstallSnapshotController = &trueBool
 	driver.SetDefaultsOnStorageCluster(cluster)
 	require.True(t, pxutil.IsCSIEnabled(cluster))
 	require.NotEmpty(t, cluster.Status.DesiredImages.CSIProvisioner)

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -984,10 +984,8 @@ func TestStorageClusterDefaultsForCSI(t *testing.T) {
 			Image: "px/image:2.9.0.1",
 		},
 	}
-	driver.SetDefaultsOnStorageCluster(cluster)
 
 	// Simulate DesiredImages.CSISnapshotController being empty for old operator version w/o this image
-	cluster.Status.DesiredImages.CSISnapshotController = ""
 	driver.SetDefaultsOnStorageCluster(cluster)
 
 	// SnapshotController image should be empty

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -981,14 +981,18 @@ func TestStorageClusterDefaultsForCSI(t *testing.T) {
 			Namespace: "kube-test",
 		},
 		Spec: corev1.StorageClusterSpec{
-			Image: "px/image:2.1.5.1",
+			Image: "px/image:2.9.0.1",
 		},
 	}
+	// Simulate DesiredImages.CSISnapshotController being empty for old operator version w/o this image
+	driver.SetDefaultsOnStorageCluster(cluster)
+	cluster.Status.DesiredImages.CSISnapshotController = ""
 
 	// Enable CSI by default for a new install
 	driver.SetDefaultsOnStorageCluster(cluster)
 	require.True(t, pxutil.IsCSIEnabled(cluster))
 	require.NotEmpty(t, cluster.Status.DesiredImages.CSIProvisioner)
+	require.NotEmpty(t, cluster.Status.DesiredImages.CSISnapshotController)
 
 	// Feature gate should not be set when CSI is enabled
 	require.NotContains(t, cluster.Spec.FeatureGates, string(pxutil.FeatureCSI))


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>
**What this PR does / why we need it**:
Add desired snapshot controller image when empty

**Which issue(s) this PR fixes** (optional)
OPERATOR-613

**Special notes for your reviewer**:

