### PR TITLE
Revert "PWX-22998 bump px-node-wiper to 2.10.0 (#542)"

### DIFF
--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -28,7 +28,7 @@ const (
 	defaultStorkImage          = "openstorage/stork:2.7.0"
 	defaultAutopilotImage      = "portworx/autopilot:1.3.1"
 	defaultLighthouseImage     = "portworx/px-lighthouse:2.0.7"
-	defaultNodeWiperImage      = "portworx/px-node-wiper:2.10.0"
+	defaultNodeWiperImage      = "portworx/px-node-wiper:2.5.0"
 	defaultTelemetryImage      = "purestorage/ccm-service:3.0.9"
 	defaultCollectorProxyImage = "envoyproxy/envoy:v1.19.1"
 	defaultCollectorImage      = "purestorage/realtime-metrics:1.0.0"


### PR DESCRIPTION
This reverts commit 8afbd3c21fb1aec50bb8490dcd9099f21cb7b129.

2.10.0 wiper is failing due to an issue still to be root caused. I've repushed 2.5.0 as the previously working image.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

