### PR TITLE
OPERATOR-629 Fix migration with auto journal device

### DIFF
--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -373,11 +373,15 @@ func validateStorageClusterFromPortworxContainer(
 		envMap[env.Name] = env.DeepCopy()
 	}
 	for _, dsEnv := range container.Env {
-		if dsEnv.Name == "PX_TEMPLATE_VERSION" {
+		if dsEnv.Name == "PX_TEMPLATE_VERSION" ||
+			dsEnv.Name == "PORTWORX_CSIVERSION" ||
+			dsEnv.Name == "CSI_ENDPOINT" ||
+			dsEnv.Name == "NODE_NAME" ||
+			dsEnv.Name == "PX_NAMESPACE" {
 			continue
 		}
 		if env, present := envMap[dsEnv.Name]; !present {
-			return fmt.Errorf("expected env: %s to be present in StorageCluster", env.Name)
+			return fmt.Errorf("expected env: %s to be present in StorageCluster", dsEnv.Name)
 		} else if !reflect.DeepEqual(dsEnv, *env) {
 			return fmt.Errorf("environment variable do not match: expected: %+v, actual: %+v", dsEnv, env)
 		}


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- 'auto' journal device is supported for both storage and cloud storage. It is a special word treated by portworx. As it does not start with a `/` like a normal device it was getting put in the cloud storage section.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-629

**Special notes for your reviewer**:

