### PR TITLE
Revert "Revert "PWX-22998 bump px-node-wiper to 2.10.0 (#542)""

### DIFF
--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -28,7 +28,7 @@ const (
 	defaultStorkImage          = "openstorage/stork:2.7.0"
 	defaultAutopilotImage      = "portworx/autopilot:1.3.1"
 	defaultLighthouseImage     = "portworx/px-lighthouse:2.0.7"
-	defaultNodeWiperImage      = "portworx/px-node-wiper:2.5.0"
+	defaultNodeWiperImage      = "portworx/px-node-wiper:2.10.0"
 	defaultTelemetryImage      = "purestorage/ccm-service:3.0.9"
 	defaultCollectorProxyImage = "envoyproxy/envoy:v1.19.1"
 	defaultCollectorImage      = "purestorage/realtime-metrics:1.0.0"


### PR DESCRIPTION
This reverts commit 93b934c16b65e0464ad16d50d3052d8096e29a03.

node wiper 2.10.0 is fixed now and re-pushed.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

