### PR TITLE
backup px-telemetry-config configmap

### DIFF
--- a/pkg/migration/backup.go
+++ b/pkg/migration/backup.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	"github.com/libopenstorage/operator/drivers/storage/portworx/component"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 )
 
@@ -305,6 +306,9 @@ func (h *Handler) getMonitoringComponent(namespace string, objs *[]client.Object
 		return err
 	}
 	if err := h.addObject(prometheusOpAccountName, namespace, &v1.ServiceAccount{}, objs); err != nil {
+		return err
+	}
+	if err := h.addObject(component.TelemetryConfigMapName, namespace, &v1.ConfigMap{}, objs); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
the configmap will be update after operator migration, and has ownerRef to storagecluster. If migration fails and user deletes storage cluster, the configmap will be deleted as well. hence we need to backup it.