### PR TITLE
[OPERATOR-616] Fix IPv6 endpoint format passed to PX gRPC server

### DIFF
--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"net"
 	"os"
 	"path"
 	"strconv"
@@ -610,7 +611,7 @@ func GetPortworxConn(sdkConn *grpc.ClientConn, k8sClient client.Client, namespac
 		}
 	}
 
-	endpoint = fmt.Sprintf("%s:%d", endpoint, sdkPort)
+	endpoint = net.JoinHostPort(endpoint, strconv.Itoa(sdkPort))
 	return GetGrpcConn(endpoint)
 }
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: pass IPv6 endpoint in format of [ip]:port instead of ip:port

**Which issue(s) this PR fixes** (optional)
Closes # [OPERATOR-616]

**Special notes for your reviewer**:

