### PR TITLE
OPERATOR-659 Remove metadata from backup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009
 	sigs.k8s.io/cluster-api v0.2.11
 	sigs.k8s.io/controller-runtime v0.8.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (

--- a/pkg/migration/backup.go
+++ b/pkg/migration/backup.go
@@ -121,6 +121,26 @@ func (h *Handler) addObject(
 		return err
 	}
 
+	obj.SetGenerateName("")
+	obj.SetUID("")
+	obj.SetResourceVersion("")
+	obj.SetGeneration(0)
+	obj.SetSelfLink("")
+	obj.SetCreationTimestamp(metav1.Time{})
+	obj.SetFinalizers(nil)
+	obj.SetOwnerReferences(nil)
+	obj.SetClusterName("")
+	obj.SetManagedFields(nil)
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Kind == "Service" && gvk.GroupVersion().String() == "v1" {
+		if svc, ok := obj.(*v1.Service); ok && svc.Spec.ClusterIP != v1.ClusterIPNone {
+			svc.Spec.ClusterIP = ""
+			svc.Spec.ClusterIPs = nil
+			obj = svc.DeepCopy()
+		}
+	}
+
 	*objs = append(*objs, obj)
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -911,6 +911,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.2
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # github.com/coreos/prometheus-operator => github.com/prometheus-operator/prometheus-operator v0.46.0
 # github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v5.1.1-0.20190919185747-9394ee8dd536+incompatible


### PR DESCRIPTION
Also, remove clusterIP from the service to avoid issues when the service is
applied during rollback.

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-659

**Special notes for your reviewer**:

