### PR TITLE
OPERATOR-666 Set maxSurge and maxUnavailable in stork scheduler

### DIFF
--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -883,6 +883,8 @@ func getStorkSchedDeploymentSpec(
 ) *apps.Deployment {
 	pullPolicy := imagePullPolicy(cluster)
 	replicas := int32(3)
+	maxUnavailable := intstr.FromInt(1)
+	maxSurge := intstr.FromInt(1)
 
 	deployment := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -893,6 +895,13 @@ func getStorkSchedDeploymentSpec(
 		},
 		Spec: apps.DeploymentSpec{
 			Replicas: &replicas,
+			Strategy: apps.DeploymentStrategy{
+				Type: apps.RollingUpdateDeploymentStrategyType,
+				RollingUpdate: &apps.RollingUpdateDeployment{
+					MaxSurge:       &maxSurge,
+					MaxUnavailable: &maxUnavailable,
+				},
+			},
 			Selector: &metav1.LabelSelector{
 				MatchLabels: storkSchedulerDeploymentLabels,
 			},

--- a/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
@@ -9,6 +9,11 @@ metadata:
   namespace: kube-test
 spec:
   replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   selector:
     matchLabels:
       component: scheduler

--- a/pkg/controller/storagecluster/testspec/storkSchedVersionedDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedVersionedDeployment.yaml
@@ -9,6 +9,11 @@ metadata:
   namespace: kube-test
 spec:
   replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
   selector:
     matchLabels:
       component: scheduler


### PR DESCRIPTION
In a 3 node cluster, the stork scheduler upgrades were getting stuck because of
the pod anti-affinity policy. The new 4th pod was going in a Pending state and
waiting for one of the existing 3 pods to go down. This was happening because
the default maxUnavailable is 25%. This was preventing the existing pod from
going down, and the pod anti-affinity stopped the new pod from coming up.

Signed-off-by: Piyush Nimbalkar <pnimbalkar@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/OPERATOR-666
 
**Special notes for your reviewer**:

