### PR TITLE
[OPERATOR-506] add migration dry-run support

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -336,7 +336,7 @@ func (t *telemetry) createCollectorDeployment(
 	}
 
 	modified := false
-	if equal, _ := util.DeploymentDeepEqual(deployment, existingDeployment); !equal {
+	if equal, _ := util.DeepEqualDeployment(deployment, existingDeployment); !equal {
 		modified = true
 	}
 

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -232,10 +232,12 @@ func (p *portworx) GetStoragePodSpec(
 		t.cluster.Status.DesiredImages = &corev1.ComponentImages{}
 	}
 
-	if node, err := p.getNodeByName(nodeName); err != nil {
-		logrus.WithError(err).Warnf("Could not get OSImage for node %s", nodeName)
-	} else {
-		t.setOSImage(node.Status.NodeInfo.OSImage)
+	if nodeName != "" {
+		if node, err := p.getNodeByName(nodeName); err != nil {
+			logrus.WithError(err).Warnf("Could not get OSImage for node %s", nodeName)
+		} else {
+			t.setOSImage(node.Status.NodeInfo.OSImage)
+		}
 	}
 
 	if cluster.Spec.CloudStorage != nil && len(cluster.Spec.CloudStorage.CapacitySpecs) > 0 {
@@ -249,7 +251,7 @@ func (p *portworx) GetStoragePodSpec(
 			return v1.PodSpec{}, err
 		}
 
-		if !storageNodeExists(nodeName, nodes) {
+		if nodeName != "" && !storageNodeExists(nodeName, nodes) {
 			err = p.createStorageNode(cluster, nodeName, cloudConfig)
 			if err != nil {
 				msg := fmt.Sprintf("Failed to create node for nodeID %v: %v", nodeName, err)

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -952,7 +952,7 @@ func (c *Controller) createPodTemplateForNodeGroup(
 	hash string,
 ) error {
 	for _, node := range nodeGroup {
-		podTemplate, err := c.createPodTemplate(cluster, node, hash)
+		podTemplate, err := c.CreatePodTemplate(cluster, node, hash)
 		if err != nil {
 			return err
 		}
@@ -1055,7 +1055,8 @@ func (c *Controller) nodeShouldRunStoragePod(
 	return k8s.CheckPredicatesForStoragePod(node, cluster, c.StorageClusterSelectorLabels(cluster))
 }
 
-func (c *Controller) createPodTemplate(
+// CreatePodTemplate creates a Portworx pod template spec.
+func (c *Controller) CreatePodTemplate(
 	cluster *corev1.StorageCluster,
 	node *v1.Node,
 	hash string,

--- a/pkg/migration/dryrun.go
+++ b/pkg/migration/dryrun.go
@@ -207,25 +207,19 @@ func (h *Handler) deepEqualEnvVars(env1, env2 []v1.EnvVar) error {
 	}
 	getList := func(arr []v1.EnvVar) []interface{} {
 		var objs []interface{}
-		skippedEnvs := []string{
-			"PX_TEMPLATE_VERSION",
-			"PORTWORX_CSIVERSION",
-			"CSI_ENDPOINT",
-			"NODE_NAME",
-			"PX_NAMESPACE",
-			"PX_SECRETS_NAMESPACE",
+		skippedEnvs := map[string]bool{
+			"PX_TEMPLATE_VERSION":  true,
+			"PORTWORX_CSIVERSION":  true,
+			"CSI_ENDPOINT":         true,
+			"NODE_NAME":            true,
+			"PX_NAMESPACE":         true,
+			"PX_SECRETS_NAMESPACE": true,
 		}
 		for _, obj := range arr {
-			shouldSkip := false
-			for _, env := range skippedEnvs {
-				if obj.Name == env {
-					shouldSkip = true
-					break
-				}
+			if skippedEnvs[obj.Name] {
+				continue
 			}
-			if !shouldSkip {
-				objs = append(objs, obj)
-			}
+			objs = append(objs, obj)
 		}
 		return objs
 	}

--- a/pkg/migration/dryrun.go
+++ b/pkg/migration/dryrun.go
@@ -1,0 +1,192 @@
+package migration
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/hashicorp/go-version"
+
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/util"
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
+
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+)
+
+func (h *Handler) dryRun(cluster *corev1.StorageCluster, ds *appsv1.DaemonSet) error {
+	k8sVersion, err := k8sutil.GetVersion()
+	if err != nil {
+		return err
+	}
+	minVer, err := version.NewVersion("1.16")
+	if err != nil {
+		return fmt.Errorf("error parsing version '1.16': %v", err)
+	}
+
+	if !k8sVersion.GreaterThanOrEqual(minVer) {
+		return fmt.Errorf("unsupported k8s version %v, please upgrade k8s to %s+ before migration", k8sVersion, minVer)
+	}
+
+	// We don't block migration if difference is found in spec. Instead
+	// raise an event and let user review before approving migration.
+	if err := h.validateSpec(cluster, ds); err != nil {
+		k8sutil.WarningEvent(h.ctrl.GetEventRecorder(), cluster, util.DryRunFailedReason,
+			fmt.Sprintf("Spec validation failed: %v", err))
+	} else {
+		k8sutil.InfoEvent(h.ctrl.GetEventRecorder(), cluster, util.DryRunCompletedReason,
+			"Spec validation completed successfully")
+	}
+
+	return nil
+}
+
+func (h *Handler) validateSpec(cluster *corev1.StorageCluster, ds *appsv1.DaemonSet) error {
+	var msg string
+	pod, err := h.ctrl.CreatePodTemplate(cluster, &v1.Node{}, "")
+	if err != nil {
+		return err
+	}
+
+	err = h.deepEqualPod(&ds.Spec.Template, &pod)
+	if err != nil {
+		msg += fmt.Sprintf("Validate portworx pod failed, %v\n", err)
+	}
+
+	if msg != "" {
+		return fmt.Errorf(msg)
+	}
+	return nil
+}
+
+// DeepEqualPod compares two pods.
+func (h *Handler) deepEqualPod(p1, p2 *v1.PodTemplateSpec) error {
+	var msg string
+
+	err := h.deepEqualVolumes(p1.Spec.Volumes, p2.Spec.Volumes)
+	if err != nil {
+		msg += fmt.Sprintf("Validate volumes failed: %s\n", err.Error())
+	}
+
+	err = h.deepEqualContainers(p1.Spec.Containers, p2.Spec.Containers)
+	if err != nil {
+		msg += fmt.Sprintf("Validate containers failed: %s\n", err.Error())
+	}
+
+	err = h.deepEqualContainers(p1.Spec.InitContainers, p2.Spec.InitContainers)
+	if err != nil {
+		msg += fmt.Sprintf("Validate init-containers failed: %s\n", err.Error())
+	}
+
+	if !reflect.DeepEqual(p1.Spec.ImagePullSecrets, p2.Spec.ImagePullSecrets) {
+		msg += fmt.Sprintf("ImagePullSecrets are different: first %+v, second: %+v\n", p1.Spec.ImagePullSecrets, p2.Spec.ImagePullSecrets)
+	}
+
+	if msg != "" {
+		return fmt.Errorf(msg)
+	}
+	return nil
+}
+
+func (h *Handler) deepEqualVolumes(vol1, vol2 []v1.Volume) error {
+	// Use host path as key, as volume name may be different but path is the same.
+	getVolumeKey := func(v interface{}) string {
+		vol := v.(v1.Volume)
+
+		if vol.HostPath != nil {
+			return vol.HostPath.Path
+		}
+
+		return vol.Name
+	}
+
+	getVolumeList := func(arr []v1.Volume) []interface{} {
+		var objs []interface{}
+		for _, obj := range arr {
+			// "crioconf" only exists with operator install.
+			// "dev" only exists with daemonset install.
+			if obj.Name == "crioconf" || obj.Name == "dev" {
+				continue
+			}
+			objs = append(objs, obj)
+		}
+		return objs
+	}
+
+	return util.DeepEqualObjects(
+		getVolumeList(vol1),
+		getVolumeList(vol2),
+		getVolumeKey,
+		h.deepEqualVolume)
+}
+
+func (h *Handler) deepEqualVolume(obj1, obj2 interface{}) error {
+	t1 := obj1.(v1.Volume)
+	t2 := obj2.(v1.Volume)
+
+	vol1 := t1.DeepCopy()
+	vol2 := t2.DeepCopy()
+
+	cleanupFields := func(vol v1.Volume) v1.Volume {
+		// We dont compare name, but only the content
+		// Ignore hostPath type as nil may represent default value.
+		vol.Name = ""
+		if vol.HostPath != nil {
+			vol.HostPath.Type = nil
+		}
+		return vol
+	}
+
+	return util.DeepEqualObject(cleanupFields(*vol1), cleanupFields(*vol2))
+}
+
+func (h *Handler) deepEqualContainers(c1, c2 []v1.Container) error {
+	getContainerName := func(v interface{}) string {
+		return v.(v1.Container).Name
+	}
+	getContainerList := func(arr []v1.Container) []interface{} {
+		objs := make([]interface{}, len(arr))
+		for i, obj := range arr {
+			objs[i] = obj
+		}
+		return objs
+	}
+
+	return util.DeepEqualObjects(
+		getContainerList(c1),
+		getContainerList(c2),
+		getContainerName,
+		h.deepEqualContainer)
+}
+
+// DeepEqualContainer compare two containers
+func (h *Handler) deepEqualContainer(obj1, obj2 interface{}) error {
+	t1 := obj1.(v1.Container)
+	t2 := obj2.(v1.Container)
+
+	c1 := t1.DeepCopy()
+	c2 := t2.DeepCopy()
+
+	msg := ""
+	if c1.Image != c2.Image {
+		msg += fmt.Sprintf("image is different: %s, %s\n", c1.Image, c2.Image)
+	}
+
+	sort.Strings(c1.Command)
+	sort.Strings(c2.Command)
+	if !reflect.DeepEqual(c1.Command, c2.Command) {
+		msg += fmt.Sprintf("command is different: %s, %s\n", t1.Command, t2.Command)
+	}
+
+	sort.Strings(c1.Args)
+	sort.Strings(c2.Args)
+	if !reflect.DeepEqual(c1.Args, c2.Args) {
+		msg += fmt.Sprintf("args is different: %s, %s\n", t1.Args, t2.Args)
+	}
+
+	if msg != "" {
+		return fmt.Errorf(msg)
+	}
+	return nil
+}

--- a/pkg/migration/dryrun_test.go
+++ b/pkg/migration/dryrun_test.go
@@ -1,0 +1,112 @@
+package migration
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sversion "k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+
+	"github.com/libopenstorage/operator/drivers/storage/portworx/manifest"
+	"github.com/libopenstorage/operator/drivers/storage/portworx/mock"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
+)
+
+func TestDryRun(t *testing.T) {
+	clusterName := "px-cluster"
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "portworx",
+			Namespace:       "portworx",
+			UID:             types.UID("1001"),
+			ResourceVersion: "100",
+			SelfLink:        "portworx/portworx",
+			Finalizers:      []string{"finalizer"},
+			OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
+			ClusterName:     "cluster-name",
+			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "manager"}},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Volumes: []v1.Volume{
+						{
+							Name: "test",
+							VolumeSource: v1.VolumeSource{
+								EmptyDir: &v1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+					Containers: []v1.Container{
+						{
+							Name:  "portworx",
+							Image: "pximage",
+							Args: []string{
+								"-c", clusterName,
+							},
+						},
+						{
+							Name:  pxutil.TelemetryContainerName,
+							Image: "telemetryImage",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(ds)
+	mockController := gomock.NewController(t)
+	driver := testutil.MockDriver(mockController)
+	ctrl := &storagecluster.Controller{
+		Driver: driver,
+	}
+	recorder := record.NewFakeRecorder(10)
+	ctrl.SetEventRecorder(recorder)
+	ctrl.SetKubernetesClient(k8sClient)
+	mockManifest := mock.NewMockManifest(mockController)
+	manifest.SetInstance(mockManifest)
+	mockManifest.EXPECT().CanAccessRemoteManifest(gomock.Any()).Return(true).AnyTimes()
+
+	// Change image pull secret in spec.
+	ds.Spec.Template.Spec.ImagePullSecrets = []v1.LocalObjectReference{
+		{
+			Name: "testSecret",
+		},
+	}
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(ds.Spec.Template.Spec, nil).AnyTimes()
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
+	driver.EXPECT().String().Return("mock-driver").AnyTimes()
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{
+		GitVersion: "v1.16.0",
+	}
+
+	migrator := New(ctrl)
+	go migrator.Start()
+
+	err := wait.PollImmediate(time.Millisecond*200, time.Second*5, func() (bool, error) {
+		if strings.Contains(reflect.ValueOf(<-recorder.Events).String(), "Spec validation failed") {
+			return true, nil
+		}
+
+		return false, nil
+	})
+	require.NoError(t, err)
+}

--- a/pkg/migration/dryrun_test.go
+++ b/pkg/migration/dryrun_test.go
@@ -12,7 +12,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8sversion "k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -30,15 +29,9 @@ func TestDryRun(t *testing.T) {
 	clusterName := "px-cluster"
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            "portworx",
-			Namespace:       "portworx",
-			UID:             types.UID("1001"),
-			ResourceVersion: "100",
-			SelfLink:        "portworx/portworx",
-			Finalizers:      []string{"finalizer"},
-			OwnerReferences: []metav1.OwnerReference{{Name: "owner"}},
-			ClusterName:     "cluster-name",
-			ManagedFields:   []metav1.ManagedFieldsEntry{{Manager: "manager"}},
+			Name:        "portworx",
+			Namespace:   "portworx",
+			ClusterName: "cluster-name",
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Template: v1.PodTemplateSpec{

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -93,7 +93,7 @@ func (h *Handler) Start() {
 
 		err = h.dryRun(cluster, pxDaemonSet)
 		if err != nil {
-			k8sutil.WarningEvent(h.ctrl.GetEventRecorder(), cluster, util.DryRunFailedReason,
+			k8sutil.WarningEvent(h.ctrl.GetEventRecorder(), cluster, util.MigrationDryRunFailedReason,
 				fmt.Sprintf("Dry-run failed: %v", err))
 			return false, nil
 		}

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -8,12 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/libopenstorage/operator/drivers/storage"
-	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/constants"
-	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
-	"github.com/libopenstorage/operator/pkg/util"
-	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -27,6 +21,13 @@ import (
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	pluginhelper "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/libopenstorage/operator/drivers/storage"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/controller/storagecluster"
+	"github.com/libopenstorage/operator/pkg/util"
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 )
 
 const (
@@ -87,6 +88,13 @@ func (h *Handler) Start() {
 		err = h.backup(CollectionConfigMapName, cluster.Namespace, true)
 		if err != nil {
 			logrus.Errorf("Failed to collect daemonset components. %v", err)
+			return false, nil
+		}
+
+		err = h.dryRun(cluster, pxDaemonSet)
+		if err != nil {
+			k8sutil.WarningEvent(h.ctrl.GetEventRecorder(), cluster, util.DryRunFailedReason,
+				fmt.Sprintf("Dry-run failed: %v", err))
 			return false, nil
 		}
 

--- a/pkg/mock/storagedriver.mock.go
+++ b/pkg/mock/storagedriver.mock.go
@@ -5,17 +5,16 @@
 package mock
 
 import (
-	"reflect"
+	reflect "reflect"
 
-	"github.com/golang/mock/gomock"
-	"github.com/libopenstorage/openstorage/api"
-	v10 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/libopenstorage/operator/drivers/storage"
+	gomock "github.com/golang/mock/gomock"
+	api "github.com/libopenstorage/openstorage/api"
+	storage "github.com/libopenstorage/operator/drivers/storage"
 	v1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	v10 "k8s.io/api/core/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
+	record "k8s.io/client-go/tools/record"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // MockDriver is a mock of Driver interface.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -41,10 +41,10 @@ const (
 	// MigrationCompletedReason is added to an event when the migration is completed.
 	MigrationCompletedReason = "MigrationCompleted"
 
-	// DryRunCompletedReason is added to an event when dry run is completed
-	DryRunCompletedReason = "DryRunCompleted"
-	// DryRunFailedReason is aded to an event when dry run fails.
-	DryRunFailedReason = "DryRunFailed"
+	// MigrationDryRunCompletedReason is added to an event when dry run is completed
+	MigrationDryRunCompletedReason = "MigrationDryRunCompleted"
+	// MigrationDryRunFailedReason is aded to an event when dry run fails.
+	MigrationDryRunFailedReason = "MigrationDryRunFailed"
 )
 
 var (


### PR DESCRIPTION
Dry run capability:
- Validate portworx pod spec before/after migration, raise warning event if the spec is different
- Block migration if k8s version is lower than 1.16