### PR TITLE
[OPERATOR-667] Node migration labels should be removed when deleting a StorageCluster.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli v1.22.2
-	golang.org/x/exp/typeparams v0.0.0-20220414153411-bcd21879b8fd // indirect
+	golang.org/x/exp/typeparams v0.0.0-20220426173459-3bcf042a4bf5 // indirect
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	google.golang.org/grpc v1.36.0

--- a/go.sum
+++ b/go.sum
@@ -1750,6 +1750,8 @@ golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e h1:qyrTQ++p1afMkO
 golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20220414153411-bcd21879b8fd h1:Xg87/3/fbBkSKtGJMW9b8TlKDdykH70G8MKRtcc2Q2k=
 golang.org/x/exp/typeparams v0.0.0-20220414153411-bcd21879b8fd/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
+golang.org/x/exp/typeparams v0.0.0-20220426173459-3bcf042a4bf5 h1:pKfHvPtBtqS0+V/V9Y0cZQa2h8HJV/qSRJiGgYu+LQA=
+golang.org/x/exp/typeparams v0.0.0-20220426173459-3bcf042a4bf5/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -3091,6 +3091,88 @@ func TestDeleteStorageClusterShouldDeleteStork(t *testing.T) {
 	require.Empty(t, deploymentList.Items)
 }
 
+func TestDeleteStorageClusterShouldRemoveMigrationLabels(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cluster := createStorageCluster()
+	deletionTimeStamp := metav1.Now()
+	cluster.DeletionTimestamp = &deletionTimeStamp
+
+	driverName := "mock-driver"
+	storageLabels := map[string]string{
+		constants.LabelKeyClusterName: cluster.Name,
+		constants.LabelKeyDriverName:  driverName,
+	}
+
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient := testutil.FakeK8sClient(cluster)
+	podControl := &k8scontroller.FakePodControl{}
+	recorder := record.NewFakeRecorder(10)
+	controller := Controller{
+		client:              k8sClient,
+		Driver:              driver,
+		podControl:          podControl,
+		recorder:            recorder,
+		kubernetesVersion:   k8sVersion,
+		lastPodCreationTime: make(map[string]time.Time),
+	}
+
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
+	condition := &corev1.ClusterCondition{
+		Type:   corev1.ClusterConditionTypeDelete,
+		Status: corev1.ClusterOperationCompleted,
+	}
+	driver.EXPECT().DeleteStorage(gomock.Any()).Return(condition, nil)
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return(driverName).AnyTimes()
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
+
+	// Migration done on node1
+	k8sNode1 := createK8sNode("k8s-node-1", 10)
+	k8sNode1.Labels[constants.LabelPortworxDaemonsetMigration] = constants.LabelValueMigrationDone
+	k8sClient.Create(context.TODO(), k8sNode1)
+	storagePod1 := createStoragePod(cluster, "pod-1", k8sNode1.Name, storageLabels)
+	k8sClient.Create(context.TODO(), storagePod1)
+
+	// Migration skipped/pending on node2/node3
+	k8sNode2 := createK8sNode("k8s-node-2", 10)
+	k8sNode2.Labels[constants.LabelPortworxDaemonsetMigration] = constants.LabelValueMigrationSkip
+	k8sClient.Create(context.TODO(), k8sNode2)
+	k8sNode3 := createK8sNode("k8s-node-3", 10)
+	k8sNode3.Labels[constants.LabelPortworxDaemonsetMigration] = constants.LabelValueMigrationPending
+	k8sClient.Create(context.TODO(), k8sNode3)
+
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+	result, err := controller.Reconcile(context.TODO(), request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+	require.Empty(t, recorder.Events)
+
+	updatedCluster := &corev1.StorageCluster{}
+	testutil.Get(k8sClient, updatedCluster, cluster.Name, cluster.Namespace)
+	require.Len(t, updatedCluster.Status.Conditions, 1)
+	require.Equal(t, *condition, updatedCluster.Status.Conditions[0])
+	require.Empty(t, updatedCluster.Finalizers)
+	require.NoError(t, err)
+	require.Empty(t, result)
+
+	nodeList := &v1.NodeList{}
+	err = k8sClient.List(context.TODO(), nodeList, &client.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, nodeList.Items, 3)
+	for _, node := range nodeList.Items {
+		_, ok := node.Labels[constants.LabelPortworxDaemonsetMigration]
+		require.False(t, ok)
+	}
+}
+
 func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -631,6 +631,9 @@ func (c *Controller) deleteStorageCluster(
 		}
 
 		if toDelete.Status.Conditions[foundIndex].Status == corev1.ClusterOperationCompleted {
+			if err := c.removeMigrationLabels(); err != nil {
+				return fmt.Errorf("failed to remove migration labels from nodes: %v", err)
+			}
 			newFinalizers := removeDeleteFinalizer(toDelete.Finalizers)
 			toDelete.Finalizers = newFinalizers
 			if err := c.client.Update(context.TODO(), toDelete); err != nil && !errors.IsNotFound(err) {
@@ -642,6 +645,22 @@ func (c *Controller) deleteStorageCluster(
 	if err := c.removeStork(cluster); err != nil {
 		msg := fmt.Sprintf("Failed to cleanup Stork. %v", err)
 		k8s.WarningEvent(c.recorder, cluster, util.FailedComponentReason, msg)
+	}
+	return nil
+}
+
+func (c *Controller) removeMigrationLabels() error {
+	nodeList := &v1.NodeList{}
+	if err := c.client.List(context.TODO(), nodeList, &client.ListOptions{}); err != nil {
+		return err
+	}
+	for _, node := range nodeList.Items {
+		if _, ok := node.Labels[constants.LabelPortworxDaemonsetMigration]; ok {
+			delete(node.Labels, constants.LabelPortworxDaemonsetMigration)
+			if err := c.client.Update(context.TODO(), &node, &client.UpdateOptions{}); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -249,7 +249,7 @@ golang.org/x/crypto/ed25519
 golang.org/x/crypto/ed25519/internal/edwards25519
 golang.org/x/crypto/pbkdf2
 golang.org/x/crypto/ssh/terminal
-# golang.org/x/exp/typeparams v0.0.0-20220414153411-bcd21879b8fd
+# golang.org/x/exp/typeparams v0.0.0-20220426173459-3bcf042a4bf5
 ## explicit
 # golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 golang.org/x/mod/internal/lazyregexp


### PR DESCRIPTION

Signed-off-by: Jiafeng Liao <jliao@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: When recovering to DaemonSet in case of migration failures, migration labels added by operator should be removed.

**Which issue(s) this PR fixes** (optional)
Closes # OPERATOR-667

**Special notes for your reviewer**:

