### PR TITLE
[OPERATOR-700] Fix wrong csi-external-provisioner args when using cus…

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -126,17 +126,12 @@ func GetImageURN(cluster *corev1.StorageCluster, image string) string {
 // GetImageMajorVersion returns the major version for a given image.
 // This allows you to make decisions based on the major version.
 func GetImageMajorVersion(image string) int {
-	if image == "" {
+	if !strings.Contains(image, ":") {
 		return -1
 	}
 
-	var tag string
 	parts := strings.Split(image, ":")
-	if len(parts) < 2 {
-		return -1
-	}
-
-	tag = parts[1]
+	tag := parts[len(parts)-1]
 	if tag == "" {
 		return -1
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -168,11 +168,26 @@ func TestGetImageMajorVersion(t *testing.T) {
 	ver = GetImageMajorVersion("quay.io/test/image")
 	require.Equal(t, -1, ver)
 
+	ver = GetImageMajorVersion("quay.io/test/image:")
+	require.Equal(t, -1, ver)
+
+	ver = GetImageMajorVersion(":5.1.0")
+	require.Equal(t, 5, ver)
+
+	ver = GetImageMajorVersion(":")
+	require.Equal(t, -1, ver)
+
 	ver = GetImageMajorVersion("")
 	require.Equal(t, -1, ver)
 
 	ver = GetImageMajorVersion("quay.io/a:v999.998.997")
 	require.Equal(t, 999, ver)
+
+	ver = GetImageMajorVersion("custom.registry:18443/repo:v1.2.3-beta1")
+	require.Equal(t, 1, ver)
+
+	ver = GetImageMajorVersion("custom.registry:18443/repo")
+	require.Equal(t, -1, ver)
 }
 
 func TestGetCustomAnnotations(t *testing.T) {


### PR DESCRIPTION
…tom registries with ports

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

