### PR TITLE
reduce log

### DIFF
--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -97,7 +97,7 @@ type DryRun struct {
 
 // Init performs required initialization
 func (d *DryRun) Init(kubeconfig, outputFolder, storageClusterFile string) error {
-	logrus.Infof("command line args, kubeconfig: %s, outputFolder: %s, storageClusterFile: %s", kubeconfig, outputFolder, storageClusterFile)
+	logrus.Debugf("command line args, kubeconfig: %s, outputFolder: %s, storageClusterFile: %s", kubeconfig, outputFolder, storageClusterFile)
 	var err error
 
 	k8sVersion := "v1.22.0"
@@ -263,7 +263,7 @@ func (d *DryRun) writeFiles(objs []client.Object) error {
 	defer f.Close()
 
 	for _, obj := range objs {
-		logrus.Infof("Operator will deploy %s %s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
+		logrus.Debugf("Operator will deploy %s %s", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
 		bytes, err := yaml.Marshal(obj)
 		if err != nil {
 			return err
@@ -351,12 +351,12 @@ func (d *DryRun) installAllComponents() error {
 		if skipComponents[comp.Name()] {
 			// Only log a warning if component is enabled but not supported.
 			if enabled {
-				logrus.Infof("component \"%s\": dry run is not supported yet, component enabled: %t.", comp.Name(), enabled)
+				logrus.Debugf("component \"%s\": dry run is not supported yet, component enabled: %t.", comp.Name(), enabled)
 			}
 			continue
 		}
 
-		logrus.Infof("component \"%s\" enabled: %t", comp.Name(), enabled)
+		logrus.Debugf("component \"%s\" enabled: %t", comp.Name(), enabled)
 		if enabled {
 			err := comp.Reconcile(d.cluster)
 			if ce, ok := err.(*component.Error); ok &&
@@ -523,15 +523,15 @@ func (d *DryRun) validateObjects(dsObjs, operatorObjs []client.Object, h *migrat
 		case "Service":
 			err = d.deepEqualService(dsObj.(*v1.Service), opObj.(*v1.Service))
 		default:
-			logrus.Infof("Object %s/%s exists before and after migration, but was not compared", kind, name)
+			logrus.Debugf("Object %s/%s exists before and after migration, but was not compared", kind, name)
 			continue
 		}
 
 		if err != nil {
 			lastErr = err
-			logrus.WithError(err).Warningf("failed to compare %s %s", kind, name)
+			logrus.Warningf("failed to compare %s %s, %s", kind, name, err.Error())
 		} else {
-			logrus.Infof("successfully compared %s %s", kind, name)
+			logrus.Debugf("successfully compared %s %s", kind, name)
 		}
 	}
 
@@ -595,7 +595,7 @@ func (d *DryRun) getRealK8sClient(kubeconfig string) (client.Client, error) {
 		if err == nil {
 			// When running inside of container, creating folder on root will get permission denied.
 			d.outputFolder = "/tmp/" + d.outputFolder
-			logrus.Infof("output folder is %s", d.outputFolder)
+			logrus.Debugf("output folder is %s", d.outputFolder)
 		}
 	}
 	if err != nil {

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -458,7 +458,7 @@ func (d *DryRun) validateObjects(dsObjs, operatorObjs []client.Object, h *migrat
 				}
 			}
 		} else if kind == "Prometheus" && name == "prometheus" {
-			logrus.Warning("Prometheus service name will change from prometheus to px-prometheus after migration")
+			logrus.Warning("Prometheus service name will change from prometheus to px-prometheus after migration, ok to proceed with migration")
 			name = "px-prometheus"
 		} else if kind == "Service" && name == "prometheus" {
 			name = "px-prometheus"
@@ -466,7 +466,7 @@ func (d *DryRun) validateObjects(dsObjs, operatorObjs []client.Object, h *migrat
 			// Operator does not create autopilot service
 			continue
 		} else if kind == "ServiceMonitor" && name == "portworx-prometheus-sm" {
-			logrus.Warningf("ServiceMonitor name will change from portworx-prometheus-sm to portworx after migration")
+			logrus.Warningf("ServiceMonitor name will change from portworx-prometheus-sm to portworx after migration, ok to proceed with migration")
 			name = "portworx"
 		}
 

--- a/pkg/dryrun/validation.go
+++ b/pkg/dryrun/validation.go
@@ -183,7 +183,7 @@ func (d *DryRun) deepEqualContainer(obj1, obj2 interface{}) error {
 
 	msg := ""
 	if c1.Image != c2.Image {
-		msg += fmt.Sprintf("image is different: before-migration %s, after-migration %s\n", c1.Image, c2.Image)
+		msg += fmt.Sprintf("image is different: before-migration %s, after-migration %s, please make sure the image exists if running on air-gapped env.\n", c1.Image, c2.Image)
 	}
 
 	sort.Strings(c1.Command)

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -37,18 +37,19 @@ const (
 
 var (
 	builtinPxVolumeNames = map[string]bool{
-		"containerddir": true,
-		"criosock":      true,
-		"dbusmount":     true,
-		"dev":           true,
-		"diagsdump":     true,
-		"dockersock":    true,
-		"etcpwx":        true,
-		"journalmount1": true,
-		"journalmount2": true,
-		"optpwx":        true,
-		"procmount":     true,
-		"sysdmount":     true,
+		"containerdsock": true,
+		"containerddir":  true,
+		"criosock":       true,
+		"dbusmount":      true,
+		"dev":            true,
+		"diagsdump":      true,
+		"dockersock":     true,
+		"etcpwx":         true,
+		"journalmount1":  true,
+		"journalmount2":  true,
+		"optpwx":         true,
+		"procmount":      true,
+		"sysdmount":      true,
 	}
 )
 


### PR DESCRIPTION
here is the new output of the tool:

```
operator# ksys exec -it portworx-operator-6977cdcbd4-5nzmx -- /dryrun
INFO[0001] k8s version is v1.20.15                      
INFO[0001] Reconciling StorageCluster                    Request.Name=px-cluster-ad6dc338-d754-49a8-ab42-a98ce7488f67 Request.Namespace=kube-system
WARN[0001] Found mountPath conflict for volume containerdsock at /run/containerd, volume will be ignored 
INFO[0001] Operator will deploy 60 objects, saved to folder /tmp/portworxSpecs 
INFO[0003] Got 41 objects from k8s cluster, will compare with objects installed by operator 
INFO[0003] Portworx will be deployed via Pod scheduled by operator (instead of DaemonSet) 
WARN[0003] failed to compare Deployment stork-scheduler, Containers are different: container stork-scheduler is different: image is different: before-migration k8s.gcr.io/kube-scheduler-amd64:v1.19.10, after-migration k8s.gcr.io/kube-scheduler-amd64:v1.20.15, please make sure the image exists if running on air-gapped env.

 
WARN[0003] ServiceMonitor name will change from portworx-prometheus-sm to portworx after migration, ok to proceed with migration 
WARN[0003] Prometheus service name will change from prometheus to px-prometheus after migration, ok to proceed with migration 
```