### PR TITLE
[OPERATOR-726] Add custom annotation support to different portworx services

### DIFF
--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -140,6 +140,8 @@ func (c *portworxAPI) createService(
 		},
 	}
 
+	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, PxAPIServiceName)
+
 	serviceType := pxutil.ServiceType(cluster)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -4,10 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-version"
-	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
-	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/constants"
-	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -18,6 +14,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/util"
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 )
 
 const (
@@ -471,6 +473,8 @@ func getPortworxServiceSpec(
 		newService.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	}
 
+	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, pxutil.PortworxServiceName)
+
 	serviceType := pxutil.ServiceType(cluster)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
@@ -520,6 +524,8 @@ func getPortworxKVDBServiceSpec(
 	if ownerRef != nil {
 		newService.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	}
+
+	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, pxutil.PortworxKVDBServiceName)
 
 	serviceType := pxutil.ServiceType(cluster)
 	if serviceType != "" {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12579,6 +12579,180 @@ func TestCSIAndPVCControllerDeploymentWithoutPodTopologySpreadConstraints(t *tes
 	require.Empty(t, deployment.Spec.Template.Spec.TopologySpreadConstraints)
 }
 
+func TestServiceCustomAnnotations(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	startPort := uint32(10001)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "false",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			StartPort: &startPort,
+			Placement: &corev1.PlacementSpec{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "px/enabled",
+										Operator: v1.NodeSelectorOpNotIn,
+										Values:   []string{"false"},
+									},
+									{
+										Key:      "node-role.kubernetes.io/master",
+										Operator: v1.NodeSelectorOpDoesNotExist,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	driver.SetDefaultsOnStorageCluster(cluster)
+
+	err := driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Portworx Service
+	expectedPXService := testutil.GetExpectedService(t, "portworxService.yaml")
+	pxService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedPXService.Name, pxService.Name)
+	require.Equal(t, expectedPXService.Namespace, pxService.Namespace)
+	require.Len(t, pxService.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, pxService.OwnerReferences[0].Name)
+	require.Equal(t, expectedPXService.Labels, pxService.Labels)
+	require.Equal(t, expectedPXService.Spec, pxService.Spec)
+	require.Nil(t, pxService.Annotations)
+
+	// Portworx KVDB Service
+	expectedPXKVDBService := testutil.GetExpectedService(t, "portworxKVDBService.yaml")
+	pxKVDBService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedPXKVDBService.Name, pxKVDBService.Name)
+	require.Equal(t, expectedPXKVDBService.Namespace, pxKVDBService.Namespace)
+	require.Len(t, pxKVDBService.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, pxKVDBService.OwnerReferences[0].Name)
+	require.Equal(t, expectedPXKVDBService.Labels, pxKVDBService.Labels)
+	require.Equal(t, expectedPXKVDBService.Spec, pxKVDBService.Spec)
+	require.Nil(t, pxKVDBService.Annotations)
+
+	// Portworx API Service
+	expectedPxAPIService := testutil.GetExpectedService(t, "portworxAPIService.yaml")
+	pxAPIService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedPxAPIService.Name, pxAPIService.Name)
+	require.Equal(t, expectedPxAPIService.Namespace, pxAPIService.Namespace)
+	require.Len(t, pxAPIService.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, pxAPIService.OwnerReferences[0].Name)
+	require.Equal(t, expectedPxAPIService.Labels, pxAPIService.Labels)
+	require.Equal(t, expectedPxAPIService.Spec, pxAPIService.Spec)
+	require.Nil(t, pxAPIService.Annotations)
+
+	// Portworx Proxy Service
+	expectedPxProxyService := testutil.GetExpectedService(t, "pxProxyService.yaml")
+	pxProxyService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, expectedPxProxyService.Name, pxProxyService.Name)
+	require.Equal(t, expectedPxProxyService.Namespace, pxProxyService.Namespace)
+	require.Empty(t, pxProxyService.OwnerReferences)
+	require.Equal(t, expectedPxProxyService.Labels, pxProxyService.Labels)
+	require.Equal(t, expectedPxProxyService.Spec, pxProxyService.Spec)
+	require.Nil(t, pxProxyService.Annotations)
+
+	// Add custom annotation to services
+	pxServiceAnnotations := map[string]string{"px-service-annotation-key": "px-service-annotation-val"}
+	pxKVDBServiceAnnotations := map[string]string{"px-kvdb-service-annotation-key": "px-kvdb-service-annotation-val"}
+	pxAPIServiceAnnotations := map[string]string{"px-api-service-annotation-key": "px-api-service-annotation-val"}
+	cluster.Spec.Metadata = &corev1.Metadata{
+		Annotations: map[string]map[string]string{
+			fmt.Sprintf("%s/%s", k8sutil.Service, pxutil.PortworxServiceName):     pxServiceAnnotations,
+			fmt.Sprintf("%s/%s", k8sutil.Service, pxutil.PortworxKVDBServiceName): pxKVDBServiceAnnotations,
+			fmt.Sprintf("%s/%s", k8sutil.Service, component.PxAPIServiceName):     pxAPIServiceAnnotations,
+		},
+	}
+	k8sClient.Update(context.TODO(), cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Portworx Service
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxServiceAnnotations, pxService.Annotations)
+
+	// Portworx KVDB Service
+	pxKVDBService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxKVDBServiceAnnotations, pxKVDBService.Annotations)
+
+	// Portworx API Service
+	pxAPIService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxAPIServiceAnnotations, pxAPIService.Annotations)
+
+	// Portworx Proxy Service
+	pxProxyService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, pxServiceAnnotations, pxService.Annotations)
+
+	// Update and remove custom annotations
+	pxServiceAnnotations["px-service-annotation-another-key"] = "px-service-annotation-another-val"
+	pxKVDBServiceAnnotations["px-kvdb-service-annotation-key"] = "px-kvdb-service-annotation-new-val"
+	cluster.Spec.Metadata = &corev1.Metadata{
+		Annotations: map[string]map[string]string{
+			fmt.Sprintf("%s/%s", k8sutil.Service, pxutil.PortworxServiceName):     pxServiceAnnotations,
+			fmt.Sprintf("%s/%s", k8sutil.Service, pxutil.PortworxKVDBServiceName): pxKVDBServiceAnnotations,
+		},
+	}
+	k8sClient.Update(context.TODO(), cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Portworx Service
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxServiceAnnotations, pxService.Annotations)
+
+	// Portworx KVDB Service
+	pxKVDBService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxKVDBServiceAnnotations, pxKVDBService.Annotations)
+
+	// Portworx API Service
+	pxAPIService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Nil(t, pxAPIService.Annotations)
+
+	// Portworx Proxy Service
+	pxProxyService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, pxServiceAnnotations, pxService.Annotations)
+}
+
 func contains(slice []string, val string) bool {
 	for _, v := range slice {
 		if v == val {

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -808,7 +808,8 @@ func CreateOrUpdateService(
 
 	modified := existingService.Spec.Type != service.Spec.Type ||
 		!reflect.DeepEqual(existingService.Labels, service.Labels) ||
-		!reflect.DeepEqual(existingService.Spec.Selector, service.Spec.Selector)
+		!reflect.DeepEqual(existingService.Spec.Selector, service.Spec.Selector) ||
+		!reflect.DeepEqual(existingService.Annotations, service.Annotations)
 
 	portMapping := make(map[string]v1.ServicePort)
 	for _, port := range service.Spec.Ports {
@@ -859,6 +860,7 @@ func CreateOrUpdateService(
 		existingService.Spec.Selector = service.Spec.Selector
 		existingService.Spec.Type = service.Spec.Type
 		existingService.Spec.Ports = servicePorts
+		existingService.Annotations = service.Annotations
 		logrus.Debugf("Updating %s/%s Service", service.Namespace, service.Name)
 		return k8sClient.Update(context.TODO(), existingService)
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -259,6 +259,15 @@ func TestGetCustomAnnotations(t *testing.T) {
 	require.Nil(t, GetCustomAnnotations(cluster, k8s.Pod, "invalid-component"))
 	require.Nil(t, GetCustomAnnotations(cluster, "invalid-kind", componentName))
 	require.Equal(t, podPortworxAnnotations, GetCustomAnnotations(cluster, k8s.Pod, componentName))
+
+	componentName = "portworx-service"
+	serviceAnnotations := map[string]string{
+		"annotation-key": "annotation-val",
+	}
+	cluster.Spec.Metadata.Annotations = map[string]map[string]string{
+		"service/portworx-service": serviceAnnotations,
+	}
+	require.Equal(t, serviceAnnotations, GetCustomAnnotations(cluster, k8s.Service, componentName))
 }
 
 func TestGetCustomLabels(t *testing.T) {


### PR DESCRIPTION


Signed-off-by: Jiafeng Liao <jliao@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Support custom annotation for services: portworx-service, portworx-api, portworx-kvdb-service

**Which issue(s) this PR fixes** (optional)
Closes # OPERATOR-726

**Special notes for your reviewer**:

