### PR TITLE
[OPERATOR-725] Add granular control over service types

### DIFF
--- a/drivers/storage/portworx/component/lighthouse.go
+++ b/drivers/storage/portworx/component/lighthouse.go
@@ -274,7 +274,7 @@ func (c *lighthouse) createService(
 		},
 	}
 
-	serviceType := pxutil.ServiceType(cluster)
+	serviceType := pxutil.ServiceType(cluster, LhServiceName)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
 	} else if !pxutil.IsAKS(cluster) && !pxutil.IsGKE(cluster) && !pxutil.IsEKS(cluster) {

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -142,7 +142,7 @@ func (c *portworxAPI) createService(
 
 	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, PxAPIServiceName)
 
-	serviceType := pxutil.ServiceType(cluster)
+	serviceType := pxutil.ServiceType(cluster, PxAPIServiceName)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
 	}

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -475,7 +475,7 @@ func getPortworxServiceSpec(
 
 	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, pxutil.PortworxServiceName)
 
-	serviceType := pxutil.ServiceType(cluster)
+	serviceType := pxutil.ServiceType(cluster, pxutil.PortworxServiceName)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
 	}
@@ -527,7 +527,7 @@ func getPortworxKVDBServiceSpec(
 
 	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, pxutil.PortworxKVDBServiceName)
 
-	serviceType := pxutil.ServiceType(cluster)
+	serviceType := pxutil.ServiceType(cluster, pxutil.PortworxKVDBServiceName)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
 	}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12753,6 +12753,223 @@ func TestServiceCustomAnnotations(t *testing.T) {
 	require.Equal(t, pxServiceAnnotations, pxService.Annotations)
 }
 
+func TestServiceTypeAnnotation(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	startPort := uint32(10001)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			StartPort: &startPort,
+			UserInterface: &corev1.UserInterfaceSpec{
+				Enabled: true,
+			},
+		},
+	}
+	driver.SetDefaultsOnStorageCluster(cluster)
+	err := driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Test default service types
+	// Portworx Service
+	pxService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxService.Spec.Type)
+	// Portworx KVDB Service
+	pxKVDBService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxKVDBService.Spec.Type)
+	// Portworx API Service
+	pxAPIService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxAPIService.Spec.Type)
+	// Portworx Proxy Service
+	pxProxyService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxProxyService.Spec.Type)
+	// Lighthouse Service
+	lhService := &v1.Service{}
+	err = testutil.Get(k8sClient, lhService, component.LhServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeNodePort, lhService.Spec.Type)
+
+	// Test add service type annotation in backward compatible format
+	expectedServiceType := v1.ServiceTypeLoadBalancer
+	cluster.Annotations = map[string]string{
+		pxutil.AnnotationServiceType: string(expectedServiceType),
+	}
+	k8sClient.Update(context.TODO(), cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	// Portworx Service
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, pxService.Spec.Type)
+	// Portworx KVDB Service
+	pxKVDBService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, pxKVDBService.Spec.Type)
+	// Portworx API Service
+	pxAPIService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, pxAPIService.Spec.Type)
+	// Portworx Proxy Service
+	pxProxyService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, pxProxyService.Spec.Type)
+	// Lighthouse Service
+	lhService = &v1.Service{}
+	err = testutil.Get(k8sClient, lhService, component.LhServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, lhService.Spec.Type)
+
+	// Test update service type annotation to new format, services not specified should use their default values
+	cluster.Annotations = map[string]string{
+		pxutil.AnnotationServiceType: "portworx-service:LoadBalancer;portworx-api:NodePort;",
+	}
+	k8sClient.Update(context.TODO(), cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	// Portworx Service
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeLoadBalancer, pxService.Spec.Type)
+	// Portworx KVDB Service
+	pxKVDBService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxKVDBService.Spec.Type)
+	// Portworx API Service
+	pxAPIService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeNodePort, pxAPIService.Spec.Type)
+	// Portworx Proxy Service
+	pxProxyService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeLoadBalancer, pxProxyService.Spec.Type)
+	// Lighthouse Service
+	lhService = &v1.Service{}
+	err = testutil.Get(k8sClient, lhService, component.LhServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeNodePort, lhService.Spec.Type)
+
+	// Test update service type annotation values, services not specified should use their default values
+	cluster.Annotations = map[string]string{
+		pxutil.AnnotationServiceType: "portworx-service:NodePort;portworx-kvdb-service:LoadBalancer",
+	}
+	k8sClient.Update(context.TODO(), cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	// Portworx Service
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeNodePort, pxService.Spec.Type)
+	// Portworx KVDB Service
+	pxKVDBService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeLoadBalancer, pxKVDBService.Spec.Type)
+	// Portworx API Service
+	pxAPIService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxAPIService.Spec.Type)
+	// Portworx Proxy Service
+	pxProxyService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeNodePort, pxProxyService.Spec.Type)
+	// Lighthouse Service
+	lhService = &v1.Service{}
+	err = testutil.Get(k8sClient, lhService, component.LhServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeNodePort, lhService.Spec.Type)
+
+	// Test update service type annotation back to backward compatible format
+	expectedServiceType = v1.ServiceTypeExternalName
+	cluster.Annotations = map[string]string{
+		pxutil.AnnotationServiceType: string(expectedServiceType),
+	}
+	k8sClient.Update(context.TODO(), cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	// Portworx Service
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, pxService.Spec.Type)
+	// Portworx KVDB Service
+	pxKVDBService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, pxKVDBService.Spec.Type)
+	// Portworx API Service
+	pxAPIService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, pxAPIService.Spec.Type)
+	// Portworx Proxy Service
+	pxProxyService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, pxProxyService.Spec.Type)
+	// Lighthouse Service
+	lhService = &v1.Service{}
+	err = testutil.Get(k8sClient, lhService, component.LhServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedServiceType, lhService.Spec.Type)
+
+	// Test remove service type annotation
+	cluster.Annotations = nil
+	k8sClient.Update(context.TODO(), cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	// Portworx Service
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxService.Spec.Type)
+	// Portworx KVDB Service
+	pxKVDBService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxKVDBService.Spec.Type)
+	// Portworx API Service
+	pxAPIService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxAPIService.Spec.Type)
+	// Portworx Proxy Service
+	pxProxyService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeClusterIP, pxProxyService.Spec.Type)
+	// Lighthouse Service
+	lhService = &v1.Service{}
+	err = testutil.Get(k8sClient, lhService, component.LhServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, v1.ServiceTypeNodePort, lhService.Spec.Type)
+}
+
 func contains(slice []string, val string) bool {
 	for _, v := range slice {
 		if v == val {

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -127,7 +127,7 @@ func newTemplate(
 	t.isPKS = pxutil.IsPKS(cluster)
 	t.isIKS = pxutil.IsIKS(cluster)
 	t.isOpenshift = pxutil.IsOpenshift(cluster)
-	t.serviceType = pxutil.ServiceType(cluster)
+	t.serviceType = pxutil.ServiceType(cluster, "")
 	t.imagePullPolicy = pxutil.ImagePullPolicy(cluster)
 	t.startPort = pxutil.StartPort(cluster)
 

--- a/drivers/storage/portworx/util/util_test.go
+++ b/drivers/storage/portworx/util/util_test.go
@@ -4,10 +4,13 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
-	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetOciMonArgumentsForTLS(t *testing.T) {
@@ -250,6 +253,70 @@ func TestIsEmptyOrNilCertLocation(t *testing.T) {
 	obj = nil
 	assert.True(t, IsEmptyOrNilCertLocation(obj))
 
+}
+
+func TestGetServiceTypeFromAnnotation(t *testing.T) {
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "px-cluster",
+		},
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: ";",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: ":",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "ClusterIP",
+	}
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, PortworxKVDBServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "Invalid",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxKVDBServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "portworx-service:LoadBalancer",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceTypeLoadBalancer, ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxKVDBServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "portworx-kvdb-service:ClusterIP;",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, PortworxKVDBServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "portworx-service:LoadBalancer;portworx-kvdb-service:ClusterIP;other-services:Invalid",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceTypeLoadBalancer, ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, PortworxKVDBServiceName))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, "other-services"))
 }
 
 func createClusterWithAuth() *corev1.StorageCluster {

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -1124,7 +1124,6 @@ func (h *Handler) handleCustomImageRegistry(cluster *corev1.StorageCluster) erro
 	componentImages = append(componentImages, desiredImages.Telemetry)
 	componentImages = append(componentImages, desiredImages.MetricsCollector)
 	componentImages = append(componentImages, desiredImages.MetricsCollectorProxy)
-	componentImages = append(componentImages, desiredImages.PxRepo)
 
 	cluster.Spec.CustomImageRegistry, cluster.Spec.PreserveFullCustomImageRegistry = parseCustomImageRegistry(cluster.Spec.Image, componentImages)
 

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -2996,7 +2996,266 @@ func TestStorageClusterWithExtraListOfVolumes(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestStorageClusterWithServiceTypeAnnotation(t *testing.T) {
+func TestStorageClusterServiceTypeBothDefault(t *testing.T) {
+	clusterName := "px-cluster"
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx",
+			Namespace: "kube-system",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "portworx",
+							Image: "portworx/test:version",
+							Args: []string{
+								"-c", clusterName,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	pxService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx-service",
+			Namespace: "kube-system",
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+		},
+	}
+	pxAPIService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx-api",
+			Namespace: "kube-system",
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeClusterIP,
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(ds, pxService, pxAPIService)
+	mockController := gomock.NewController(t)
+	driver := testutil.MockDriver(mockController)
+	ctrl := &storagecluster.Controller{
+		Driver: driver,
+	}
+	ctrl.SetEventRecorder(record.NewFakeRecorder(10))
+	ctrl.SetKubernetesClient(k8sClient)
+	mockManifest := mock.NewMockManifest(mockController)
+	manifest.SetInstance(mockManifest)
+	mockManifest.EXPECT().CanAccessRemoteManifest(gomock.Any()).Return(false).AnyTimes()
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(ds.Spec.Template.Spec, nil).AnyTimes()
+	driver.EXPECT().GetSelectorLabels().AnyTimes()
+	driver.EXPECT().String().AnyTimes()
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{
+		GitVersion: "v1.16.0",
+	}
+	expectedCluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: ds.Namespace,
+			Annotations: map[string]string{
+				constants.AnnotationMigrationApproved: "false",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/test:version",
+			CommonConfig: corev1.CommonConfig{
+				Env: []v1.EnvVar{
+					{
+						Name:  "PX_SECRETS_NAMESPACE",
+						Value: "portworx",
+					},
+				},
+			},
+			CSI: &corev1.CSISpec{
+				Enabled: false,
+			},
+			Stork: &corev1.StorkSpec{
+				Enabled: false,
+			},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: false,
+			},
+			Monitoring: &corev1.MonitoringSpec{
+				Prometheus: &corev1.PrometheusSpec{
+					ExportMetrics: false,
+					Enabled:       false,
+					AlertManager: &corev1.AlertManagerSpec{
+						Enabled: false,
+					},
+				},
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: false,
+				},
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			Phase: constants.PhaseAwaitingApproval,
+		},
+	}
+
+	migrator := New(ctrl)
+	go migrator.Start()
+	cluster := &corev1.StorageCluster{}
+	err := wait.PollImmediate(time.Millisecond*200, time.Second*15, func() (bool, error) {
+		err := testutil.Get(k8sClient, cluster, clusterName, ds.Namespace)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedCluster.Annotations, cluster.Annotations)
+	require.ElementsMatch(t, expectedCluster.Spec.Env, cluster.Spec.Env)
+	expectedCluster.Spec.Env = nil
+	cluster.Spec.Env = nil
+	require.Equal(t, expectedCluster.Spec, cluster.Spec)
+	require.Equal(t, expectedCluster.Status.Phase, cluster.Status.Phase)
+
+	// Stop the migration process by removing the daemonset
+	err = testutil.Delete(k8sClient, ds)
+	require.NoError(t, err)
+}
+
+func TestStorageClusterServiceTypeBothNotDefault(t *testing.T) {
+	clusterName := "px-cluster"
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx",
+			Namespace: "kube-system",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "portworx",
+							Image: "portworx/test:version",
+							Args: []string{
+								"-c", clusterName,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	pxService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx-service",
+			Namespace: "kube-system",
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeNodePort,
+		},
+	}
+	pxAPIService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx-api",
+			Namespace: "kube-system",
+		},
+		Spec: v1.ServiceSpec{
+			Type: v1.ServiceTypeLoadBalancer,
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(ds, pxService, pxAPIService)
+	mockController := gomock.NewController(t)
+	driver := testutil.MockDriver(mockController)
+	ctrl := &storagecluster.Controller{
+		Driver: driver,
+	}
+	ctrl.SetEventRecorder(record.NewFakeRecorder(10))
+	ctrl.SetKubernetesClient(k8sClient)
+	mockManifest := mock.NewMockManifest(mockController)
+	manifest.SetInstance(mockManifest)
+	mockManifest.EXPECT().CanAccessRemoteManifest(gomock.Any()).Return(false).AnyTimes()
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(ds.Spec.Template.Spec, nil).AnyTimes()
+	driver.EXPECT().GetSelectorLabels().AnyTimes()
+	driver.EXPECT().String().AnyTimes()
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{
+		GitVersion: "v1.16.0",
+	}
+	expectedCluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: ds.Namespace,
+			Annotations: map[string]string{
+				constants.AnnotationMigrationApproved: "false",
+				pxutil.AnnotationServiceType:          "portworx-service:NodePort;portworx-api:LoadBalancer",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/test:version",
+			CommonConfig: corev1.CommonConfig{
+				Env: []v1.EnvVar{
+					{
+						Name:  "PX_SECRETS_NAMESPACE",
+						Value: "portworx",
+					},
+				},
+			},
+			CSI: &corev1.CSISpec{
+				Enabled: false,
+			},
+			Stork: &corev1.StorkSpec{
+				Enabled: false,
+			},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: false,
+			},
+			Monitoring: &corev1.MonitoringSpec{
+				Prometheus: &corev1.PrometheusSpec{
+					ExportMetrics: false,
+					Enabled:       false,
+					AlertManager: &corev1.AlertManagerSpec{
+						Enabled: false,
+					},
+				},
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: false,
+				},
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			Phase: constants.PhaseAwaitingApproval,
+		},
+	}
+
+	migrator := New(ctrl)
+	go migrator.Start()
+	cluster := &corev1.StorageCluster{}
+	err := wait.PollImmediate(time.Millisecond*200, time.Second*15, func() (bool, error) {
+		err := testutil.Get(k8sClient, cluster, clusterName, ds.Namespace)
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedCluster.Annotations, cluster.Annotations)
+	require.ElementsMatch(t, expectedCluster.Spec.Env, cluster.Spec.Env)
+	expectedCluster.Spec.Env = nil
+	cluster.Spec.Env = nil
+	require.Equal(t, expectedCluster.Spec, cluster.Spec)
+	require.Equal(t, expectedCluster.Status.Phase, cluster.Status.Phase)
+
+	// Stop the migration process by removing the daemonset
+	err = testutil.Delete(k8sClient, ds)
+	require.NoError(t, err)
+}
+
+func TestStorageClusterServiceTypeOneNotDefault(t *testing.T) {
 	clusterName := "px-cluster"
 	ds := &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3063,7 +3322,7 @@ func TestStorageClusterWithServiceTypeAnnotation(t *testing.T) {
 			Namespace: ds.Namespace,
 			Annotations: map[string]string{
 				constants.AnnotationMigrationApproved: "false",
-				pxutil.AnnotationServiceType:          "LoadBalancer",
+				pxutil.AnnotationServiceType:          "portworx-api:LoadBalancer",
 			},
 		},
 		Spec: corev1.StorageClusterSpec{

--- a/pkg/util/k8s/k8s_test.go
+++ b/pkg/util/k8s/k8s_test.go
@@ -2598,6 +2598,100 @@ func TestServiceChangeSelector(t *testing.T) {
 	require.Empty(t, actualService.Spec.Selector)
 }
 
+func TestServiceChangeAnnotations(t *testing.T) {
+	k8sClient := testutil.FakeK8sClient()
+
+	expectedService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-ns",
+		},
+	}
+
+	err := CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService := &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Empty(t, actualService.Annotations)
+
+	// Add new annotations
+	expectedService.Annotations = map[string]string{"key": "value"}
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, expectedService.Annotations, actualService.Annotations)
+
+	// Change annotations
+	expectedService.Annotations = map[string]string{"key": "newvalue"}
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, expectedService.Annotations, actualService.Annotations)
+
+	// Remove annotations
+	expectedService.Annotations = nil
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Empty(t, actualService.Annotations)
+}
+
+func TestServiceChangeType(t *testing.T) {
+	k8sClient := testutil.FakeK8sClient()
+
+	serviceType := v1.ServiceTypeClusterIP
+	expectedService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-ns",
+		},
+		Spec: v1.ServiceSpec{
+			Type: serviceType,
+		},
+	}
+
+	err := CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService := &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, serviceType, actualService.Spec.Type)
+
+	// Change service type
+	serviceType = v1.ServiceTypeLoadBalancer
+	expectedService.Spec.Type = serviceType
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, serviceType, actualService.Spec.Type)
+
+	// Remove service type
+	serviceType = v1.ServiceTypeClusterIP
+	expectedService.Spec.Type = ""
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, serviceType, actualService.Spec.Type)
+}
+
 func TestGetCRDFromFile(t *testing.T) {
 	tests := []struct {
 		dir         string


### PR DESCRIPTION
Signed-off-by: Jiafeng Liao <jliao@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Allow to use service type annotation to control multiple services, backward compatible.

**Which issue(s) this PR fixes** (optional)
Closes # OPERATOR-725

**Special notes for your reviewer**:

