### PR TITLE
[OPERATOR-719] Enable CSI snapshot controller by default

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -165,7 +165,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			}
 		}
 
-		SetPortworxDefaults(toUpdate)
+		SetPortworxDefaults(toUpdate, p.k8sVersion)
 	}
 
 	removeDeprecatedFields(toUpdate)
@@ -600,7 +600,7 @@ func (p *portworx) storageNodeToCloudSpec(storageNodes []*corev1.StorageNode, cl
 }
 
 // SetPortworxDefaults populates default storage cluster spec values
-func SetPortworxDefaults(toUpdate *corev1.StorageCluster) {
+func SetPortworxDefaults(toUpdate *corev1.StorageCluster, k8sVersion *version.Version) {
 	t, err := newTemplate(toUpdate, "")
 	if err != nil {
 		return
@@ -711,6 +711,13 @@ func SetPortworxDefaults(toUpdate *corev1.StorageCluster) {
 			toUpdate.Spec.CSI = &corev1.CSISpec{
 				Enabled: true,
 			}
+		}
+	}
+
+	// Enable CSI snapshot controller by default if it's not configured on k8s 1.17+
+	if pxutil.IsCSIEnabled(toUpdate) && toUpdate.Spec.CSI.InstallSnapshotController == nil {
+		if k8sVersion != nil && k8sVersion.GreaterThanOrEqual(k8sutil.K8sVer1_17) {
+			toUpdate.Spec.CSI.InstallSnapshotController = boolPtr(true)
 		}
 	}
 

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
@@ -76,14 +76,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        - name: csi-snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v1.2.3
-          imagePullPolicy: Always
-          args:
-          - --v=3
-          - --leader-election=true
       volumes:
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/pxd.portworx.com
+            path: /var/lib/kubelet/csi-plugins/pxd.portworx.com
             type: DirectoryOrCreate

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
@@ -77,6 +77,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        - name: csi-snapshot-controller
+          image: quay.io/k8scsi/snapshot-controller:v1.2.3
+          imagePullPolicy: Always
+          args:
+            - --v=3
+            - --leader-election=true
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
@@ -76,12 +76,6 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-        - name: csi-snapshot-controller
-          image: quay.io/k8scsi/snapshot-controller:v1.2.3
-          imagePullPolicy: Always
-          args:
-            - --v=3
-            - --leader-election=true
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
@@ -76,6 +76,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+        - name: csi-snapshot-controller
+          image: quay.io/k8scsi/snapshot-controller:v1.2.3
+          imagePullPolicy: Always
+          args:
+            - --v=3
+            - --leader-election=true
         - name: csi-health-monitor-controller
           image: quay.io/k8scsi/csi-health-monitor-controller:v1.2.3
           imagePullPolicy: Always

--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -354,7 +354,8 @@ func BasicUpgradeStorageCluster(tc *types.TestCase) func(*testing.T) {
 				require.NoError(t, err)
 
 				// Set defaults
-				portworx.SetPortworxDefaults(cluster)
+				k8sVersion, _ := version.NewVersion(ci_utils.K8sVersion)
+				portworx.SetPortworxDefaults(cluster, k8sVersion)
 
 				// Update live StorageCluster
 				cluster, err = ci_utils.UpdateStorageCluster(cluster)

--- a/test/integration_test/pxrepo_test.go
+++ b/test/integration_test/pxrepo_test.go
@@ -57,7 +57,8 @@ var pxrepoTestCases = []types.TestCase{
 				require.True(t, ok)
 
 				// Populate default values to empty fields first
-				portworx.SetPortworxDefaults(cluster)
+				k8sVersion, _ := version.NewVersion(ci_utils.K8sVersion)
+				portworx.SetPortworxDefaults(cluster, k8sVersion)
 				// Record pre-deploy timestamp
 				installTime := time.Now()
 				// Deploy cluster

--- a/test/integration_test/utils/storagecluster.go
+++ b/test/integration_test/utils/storagecluster.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
@@ -134,7 +135,8 @@ func CreateStorageCluster(cluster *corev1.StorageCluster) (*corev1.StorageCluste
 // DeployAndValidateStorageCluster creates and validates the storage cluster
 func DeployAndValidateStorageCluster(cluster *corev1.StorageCluster, pxSpecImages map[string]string, t *testing.T) *corev1.StorageCluster {
 	// Populate default values to empty fields first
-	portworx.SetPortworxDefaults(cluster)
+	k8sVersion, _ := version.NewVersion(K8sVersion)
+	portworx.SetPortworxDefaults(cluster, k8sVersion)
 	// Deploy cluster
 	cluster, err := CreateStorageCluster(cluster)
 	require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Jiafeng Liao <jliao@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* Enable csi snapshot controller by default
* Scan all pods once on operator start to find if there's a snapshot controller preinstalled
* Skip installing the snapshot controller if found preinstalled controller
* User need to delete existing controller and restart operator to use operator managed controller

**Which issue(s) this PR fixes** (optional)
Closes #OPERATOR-719

**Special notes for your reviewer**:

