### PR TITLE
OPERATOR-774: fixing customImageRegistry image paths

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -64,7 +64,7 @@ var (
 		"topology.kubernetes.io/zone",
 	}
 	// pxVer211 corresponds to version "2.11.0"
-	pxVer211 = version.Must(version.NewVersion("2.10.0"))
+	pxVer211 = version.Must(version.NewVersion("2.11.0"))
 )
 
 func getMergedCommonRegistries(cluster *corev1.StorageCluster) map[string]bool {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -108,6 +108,25 @@ func TestImageURN(t *testing.T) {
 
 	out = getImageURN("gcr.io,k8s.gcr.io", "registry.io", "testrepo/pause:3.1")
 	require.Equal(t, "registry.io/testrepo/pause:3.1", out)
+
+	// check px-2.11 image expansions
+	out = getImageURNPx211("gcr.io", "registry.io", "k8s.gcr.io/pause:3.1")
+	require.Equal(t, "registry.io/pause:3.1", out)
+
+	out = getImageURNPx211("", "registry.io//", "k8s.gcr.io/pause:3.1")
+	require.Equal(t, "registry.io/pause:3.1", out)
+
+	out = getImageURNPx211("", "registry.io//", "gcr.io/pause:3.1")
+	require.Equal(t, "registry.io/pause:3.1", out)
+
+	out = getImageURNPx211("gcr.io,k8s.gcr.io", "registry.io", "gcr.io/pause:3.1")
+	require.Equal(t, "registry.io/pause:3.1", out)
+
+	out = getImageURNPx211("gcr.io,k8s.gcr.io", "registry.io", "k8s.gcr.io/pause:3.1")
+	require.Equal(t, "registry.io/pause:3.1", out)
+
+	out = getImageURNPx211("gcr.io,k8s.gcr.io", "registry.io", "testrepo/pause:3.1")
+	require.Equal(t, "registry.io/testrepo/pause:3.1", out)
 }
 
 func TestImageURNPreserved(t *testing.T) {
@@ -146,6 +165,13 @@ func setUpCluster(commonRegistries string, customImageRegistry string, image str
 
 func getImageURN(commonRegistries string, customImageRegistry string, image string) string {
 	cluster := setUpCluster(commonRegistries, customImageRegistry, image)
+	cluster.Spec.Version = "2.9.1.4"
+	return GetImageURN(&cluster, image)
+}
+
+func getImageURNPx211(commonRegistries string, customImageRegistry string, image string) string {
+	cluster := setUpCluster(commonRegistries, customImageRegistry, image)
+	cluster.Spec.Version = "2.11.0"
 	return GetImageURN(&cluster, image)
 }
 


### PR DESCRIPTION
* starting with px-2.11.0, will no longer use `k8s.gcr.io` in image-path, when customImageRegistry is used

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

We had inconsistent behavior when private registry server used (e.g. `customImageRegistry: myregistry.net:5443`) :
```
# kubectl get pods -A -o yaml | /bin/grep image: | sed -e 's/- image:/  image:/' | sort -u

image: docker.io/rancher/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
image: docker.io/rancher/mirrored-flannelcni-flannel:v0.18.1
image: k8s.gcr.io/coredns/coredns:v1.8.6
image: k8s.gcr.io/kube-apiserver:v1.24.1
image: k8s.gcr.io/kube-controller-manager:v1.24.1
image: k8s.gcr.io/kube-proxy:v1.24.1
image: k8s.gcr.io/kube-scheduler:v1.24.1
image: myregistry.net:5443/k8s.gcr.io/kube-scheduler-amd64:v1.21.4				<< BUG
image: myregistry.net:5443/k8s.gcr.io/pause:3.1							<< BUG
image: myregistry.net:5443/k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.4.0	<< BUG
image: myregistry.net:5443/k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0		<< BUG
image: myregistry.net:5443/k8s.gcr.io/sig-storage/csi-resizer:v1.3.0				<< BUG
image: myregistry.net:5443/k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1				<< BUG
image: myregistry.net:5443/openstorage/csi-provisioner:v3.0.0-1
image: myregistry.net:5443/openstorage/stork:2.9.0
image: myregistry.net:5443/portworx/autopilot:1.3.2
image: myregistry.net:5443/portworx/oci-monitor:2.10.2
image: myregistry.net:5443/portworx/px-operator:1.8.0
image: myregistry.net:5443/prometheus-operator/prometheus-config-reloader:v0.50.0
image: myregistry.net:5443/prometheus-operator/prometheus-operator:v0.50.0
image: myregistry.net:5443/prometheus/prometheus:v2.29.1
image: myregistry.net:5443/purestorage/ccm-service:3.1.1
image: rancher/mirrored-flannelcni-flannel-cni-plugin:v1.1.0
image: rancher/mirrored-flannelcni-flannel:v0.18.1
```
* note, the overridden images should not include `.../k8s.gcr.io/...` in the image-path
* also note that the legacy daemonset deployments are already using uniform image-paths (no `.../k8s.gcr.io/...` in the image-path), finally
* we have a [PWX-24295](https://portworx.atlassian.net/browse/PWX-24295) ticket to make the image-paths consistent for air-gapped bootstrap script

**Which issue(s) this PR fixes** (optional)
Closes # OPERATOR-774

**Special notes for your reviewer**:
This change has been isolated to px-2.11.0 version (or higher) -- the older px-versions will still include `.../k8s.gcr.io/...` in the image-path.