### PR TITLE
[CP][OPERATOR-725][OPERATOR-726] Granular service type control and custom service annotations

### DIFF
--- a/drivers/storage/portworx/component/lighthouse.go
+++ b/drivers/storage/portworx/component/lighthouse.go
@@ -274,7 +274,7 @@ func (c *lighthouse) createService(
 		},
 	}
 
-	serviceType := pxutil.ServiceType(cluster)
+	serviceType := pxutil.ServiceType(cluster, LhServiceName)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
 	} else if !pxutil.IsAKS(cluster) && !pxutil.IsGKE(cluster) && !pxutil.IsEKS(cluster) {

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -142,7 +142,7 @@ func (c *portworxAPI) createService(
 
 	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, PxAPIServiceName)
 
-	serviceType := pxutil.ServiceType(cluster)
+	serviceType := pxutil.ServiceType(cluster, PxAPIServiceName)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
 	}

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -140,6 +140,8 @@ func (c *portworxAPI) createService(
 		},
 	}
 
+	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, PxAPIServiceName)
+
 	serviceType := pxutil.ServiceType(cluster)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -4,10 +4,6 @@ import (
 	"context"
 
 	"github.com/hashicorp/go-version"
-	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
-	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/constants"
-	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -18,6 +14,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/util"
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 )
 
 const (
@@ -471,6 +473,8 @@ func getPortworxServiceSpec(
 		newService.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	}
 
+	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, pxutil.PortworxServiceName)
+
 	serviceType := pxutil.ServiceType(cluster)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
@@ -520,6 +524,8 @@ func getPortworxKVDBServiceSpec(
 	if ownerRef != nil {
 		newService.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	}
+
+	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, pxutil.PortworxKVDBServiceName)
 
 	serviceType := pxutil.ServiceType(cluster)
 	if serviceType != "" {

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -475,7 +475,7 @@ func getPortworxServiceSpec(
 
 	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, pxutil.PortworxServiceName)
 
-	serviceType := pxutil.ServiceType(cluster)
+	serviceType := pxutil.ServiceType(cluster, pxutil.PortworxServiceName)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
 	}
@@ -527,7 +527,7 @@ func getPortworxKVDBServiceSpec(
 
 	newService.Annotations = util.GetCustomAnnotations(cluster, k8sutil.Service, pxutil.PortworxKVDBServiceName)
 
-	serviceType := pxutil.ServiceType(cluster)
+	serviceType := pxutil.ServiceType(cluster, pxutil.PortworxKVDBServiceName)
 	if serviceType != "" {
 		newService.Spec.Type = serviceType
 	}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -11813,6 +11813,180 @@ func TestCSIAndPVCControllerDeploymentWithoutPodTopologySpreadConstraints(t *tes
 	require.Empty(t, deployment.Spec.Template.Spec.TopologySpreadConstraints)
 }
 
+func TestServiceCustomAnnotations(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	startPort := uint32(10001)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "false",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			StartPort: &startPort,
+			Placement: &corev1.PlacementSpec{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "px/enabled",
+										Operator: v1.NodeSelectorOpNotIn,
+										Values:   []string{"false"},
+									},
+									{
+										Key:      "node-role.kubernetes.io/master",
+										Operator: v1.NodeSelectorOpDoesNotExist,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	driver.SetDefaultsOnStorageCluster(cluster)
+
+	err := driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Portworx Service
+	expectedPXService := testutil.GetExpectedService(t, "portworxService.yaml")
+	pxService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedPXService.Name, pxService.Name)
+	require.Equal(t, expectedPXService.Namespace, pxService.Namespace)
+	require.Len(t, pxService.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, pxService.OwnerReferences[0].Name)
+	require.Equal(t, expectedPXService.Labels, pxService.Labels)
+	require.Equal(t, expectedPXService.Spec, pxService.Spec)
+	require.Nil(t, pxService.Annotations)
+
+	// Portworx KVDB Service
+	expectedPXKVDBService := testutil.GetExpectedService(t, "portworxKVDBService.yaml")
+	pxKVDBService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedPXKVDBService.Name, pxKVDBService.Name)
+	require.Equal(t, expectedPXKVDBService.Namespace, pxKVDBService.Namespace)
+	require.Len(t, pxKVDBService.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, pxKVDBService.OwnerReferences[0].Name)
+	require.Equal(t, expectedPXKVDBService.Labels, pxKVDBService.Labels)
+	require.Equal(t, expectedPXKVDBService.Spec, pxKVDBService.Spec)
+	require.Nil(t, pxKVDBService.Annotations)
+
+	// Portworx API Service
+	expectedPxAPIService := testutil.GetExpectedService(t, "portworxAPIService.yaml")
+	pxAPIService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedPxAPIService.Name, pxAPIService.Name)
+	require.Equal(t, expectedPxAPIService.Namespace, pxAPIService.Namespace)
+	require.Len(t, pxAPIService.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, pxAPIService.OwnerReferences[0].Name)
+	require.Equal(t, expectedPxAPIService.Labels, pxAPIService.Labels)
+	require.Equal(t, expectedPxAPIService.Spec, pxAPIService.Spec)
+	require.Nil(t, pxAPIService.Annotations)
+
+	// Portworx Proxy Service
+	expectedPxProxyService := testutil.GetExpectedService(t, "pxProxyService.yaml")
+	pxProxyService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, expectedPxProxyService.Name, pxProxyService.Name)
+	require.Equal(t, expectedPxProxyService.Namespace, pxProxyService.Namespace)
+	require.Empty(t, pxProxyService.OwnerReferences)
+	require.Equal(t, expectedPxProxyService.Labels, pxProxyService.Labels)
+	require.Equal(t, expectedPxProxyService.Spec, pxProxyService.Spec)
+	require.Nil(t, pxProxyService.Annotations)
+
+	// Add custom annotation to services
+	pxServiceAnnotations := map[string]string{"px-service-annotation-key": "px-service-annotation-val"}
+	pxKVDBServiceAnnotations := map[string]string{"px-kvdb-service-annotation-key": "px-kvdb-service-annotation-val"}
+	pxAPIServiceAnnotations := map[string]string{"px-api-service-annotation-key": "px-api-service-annotation-val"}
+	cluster.Spec.Metadata = &corev1.Metadata{
+		Annotations: map[string]map[string]string{
+			fmt.Sprintf("%s/%s", k8sutil.Service, pxutil.PortworxServiceName):     pxServiceAnnotations,
+			fmt.Sprintf("%s/%s", k8sutil.Service, pxutil.PortworxKVDBServiceName): pxKVDBServiceAnnotations,
+			fmt.Sprintf("%s/%s", k8sutil.Service, component.PxAPIServiceName):     pxAPIServiceAnnotations,
+		},
+	}
+	k8sClient.Update(context.TODO(), cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Portworx Service
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxServiceAnnotations, pxService.Annotations)
+
+	// Portworx KVDB Service
+	pxKVDBService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxKVDBServiceAnnotations, pxKVDBService.Annotations)
+
+	// Portworx API Service
+	pxAPIService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxAPIServiceAnnotations, pxAPIService.Annotations)
+
+	// Portworx Proxy Service
+	pxProxyService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, pxServiceAnnotations, pxService.Annotations)
+
+	// Update and remove custom annotations
+	pxServiceAnnotations["px-service-annotation-another-key"] = "px-service-annotation-another-val"
+	pxKVDBServiceAnnotations["px-kvdb-service-annotation-key"] = "px-kvdb-service-annotation-new-val"
+	cluster.Spec.Metadata = &corev1.Metadata{
+		Annotations: map[string]map[string]string{
+			fmt.Sprintf("%s/%s", k8sutil.Service, pxutil.PortworxServiceName):     pxServiceAnnotations,
+			fmt.Sprintf("%s/%s", k8sutil.Service, pxutil.PortworxKVDBServiceName): pxKVDBServiceAnnotations,
+		},
+	}
+	k8sClient.Update(context.TODO(), cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Portworx Service
+	pxService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxServiceAnnotations, pxService.Annotations)
+
+	// Portworx KVDB Service
+	pxKVDBService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxKVDBService, pxutil.PortworxKVDBServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, pxKVDBServiceAnnotations, pxKVDBService.Annotations)
+
+	// Portworx API Service
+	pxAPIService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Nil(t, pxAPIService.Annotations)
+
+	// Portworx Proxy Service
+	pxProxyService = &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, pxServiceAnnotations, pxService.Annotations)
+}
+
 func contains(slice []string, val string) bool {
 	for _, v := range slice {
 		if v == val {

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -119,7 +119,7 @@ func newTemplate(
 	t.isPKS = pxutil.IsPKS(cluster)
 	t.isIKS = pxutil.IsIKS(cluster)
 	t.isOpenshift = pxutil.IsOpenshift(cluster)
-	t.serviceType = pxutil.ServiceType(cluster)
+	t.serviceType = pxutil.ServiceType(cluster, "")
 	t.imagePullPolicy = pxutil.ImagePullPolicy(cluster)
 	t.startPort = pxutil.StartPort(cluster)
 

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -287,17 +287,36 @@ func PodSecurityPolicyEnabled(cluster *corev1.StorageCluster) bool {
 }
 
 // ServiceType returns the k8s service type from cluster annotations if present
-func ServiceType(cluster *corev1.StorageCluster) v1.ServiceType {
+// 1. backward compatible format: "LoadBalancer", "ClusterIP" or "NodePort"
+// 2. control different services: "portworx-service:LoadBalancer;portworx-api:ClusterIP;portworx-kvdb-service:NodePort"
+func ServiceType(cluster *corev1.StorageCluster, serviceName string) v1.ServiceType {
 	var serviceType v1.ServiceType
-	if val, exists := cluster.Annotations[AnnotationServiceType]; exists {
-		st := v1.ServiceType(val)
-		if st == v1.ServiceTypeClusterIP ||
-			st == v1.ServiceTypeNodePort ||
-			st == v1.ServiceTypeLoadBalancer {
-			serviceType = st
+	val, exist := cluster.Annotations[AnnotationServiceType]
+	if !exist || val == "" {
+		return serviceType
+	}
+
+	valParts := strings.Split(val, ";")
+	for _, p := range valParts {
+		annotationParts := strings.Split(p, ":")
+		if len(annotationParts) == 1 {
+			// No ":" found, so we expect this to be the backward compatible case
+			serviceType = v1.ServiceType(annotationParts[0])
+			break
+		} else if (len(annotationParts) == 2) && (annotationParts[0] == serviceName) {
+			serviceType = v1.ServiceType(annotationParts[1])
+			break
 		}
 	}
-	return serviceType
+
+	if serviceType == v1.ServiceTypeClusterIP ||
+		serviceType == v1.ServiceTypeNodePort ||
+		serviceType == v1.ServiceTypeLoadBalancer ||
+		serviceType == v1.ServiceTypeExternalName {
+		return serviceType
+	}
+
+	return ""
 }
 
 // MiscArgs returns the miscellaneous arguments from the cluster's annotations

--- a/drivers/storage/portworx/util/util_test.go
+++ b/drivers/storage/portworx/util/util_test.go
@@ -1,0 +1,75 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+)
+
+func TestGetServiceTypeFromAnnotation(t *testing.T) {
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "px-cluster",
+		},
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: ";",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: ":",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "ClusterIP",
+	}
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, PortworxKVDBServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "Invalid",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxKVDBServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "portworx-service:LoadBalancer",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceTypeLoadBalancer, ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxKVDBServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "portworx-kvdb-service:ClusterIP;",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, PortworxKVDBServiceName))
+
+	cluster.Annotations = map[string]string{
+		AnnotationServiceType: "portworx-service:LoadBalancer;portworx-kvdb-service:ClusterIP;other-services:Invalid",
+	}
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, ""))
+	require.Equal(t, v1.ServiceTypeLoadBalancer, ServiceType(cluster, PortworxServiceName))
+	require.Equal(t, v1.ServiceTypeClusterIP, ServiceType(cluster, PortworxKVDBServiceName))
+	require.Equal(t, v1.ServiceType(""), ServiceType(cluster, "other-services"))
+}

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -806,7 +806,8 @@ func CreateOrUpdateService(
 
 	modified := existingService.Spec.Type != service.Spec.Type ||
 		!reflect.DeepEqual(existingService.Labels, service.Labels) ||
-		!reflect.DeepEqual(existingService.Spec.Selector, service.Spec.Selector)
+		!reflect.DeepEqual(existingService.Spec.Selector, service.Spec.Selector) ||
+		!reflect.DeepEqual(existingService.Annotations, service.Annotations)
 
 	portMapping := make(map[string]v1.ServicePort)
 	for _, port := range service.Spec.Ports {
@@ -857,6 +858,7 @@ func CreateOrUpdateService(
 		existingService.Spec.Selector = service.Spec.Selector
 		existingService.Spec.Type = service.Spec.Type
 		existingService.Spec.Ports = servicePorts
+		existingService.Annotations = service.Annotations
 		logrus.Debugf("Updating %s/%s Service", service.Namespace, service.Name)
 		return k8sClient.Update(context.TODO(), existingService)
 	}

--- a/pkg/util/k8s/k8s_test.go
+++ b/pkg/util/k8s/k8s_test.go
@@ -2598,6 +2598,100 @@ func TestServiceChangeSelector(t *testing.T) {
 	require.Empty(t, actualService.Spec.Selector)
 }
 
+func TestServiceChangeAnnotations(t *testing.T) {
+	k8sClient := testutil.FakeK8sClient()
+
+	expectedService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-ns",
+		},
+	}
+
+	err := CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService := &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Empty(t, actualService.Annotations)
+
+	// Add new annotations
+	expectedService.Annotations = map[string]string{"key": "value"}
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, expectedService.Annotations, actualService.Annotations)
+
+	// Change annotations
+	expectedService.Annotations = map[string]string{"key": "newvalue"}
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, expectedService.Annotations, actualService.Annotations)
+
+	// Remove annotations
+	expectedService.Annotations = nil
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Empty(t, actualService.Annotations)
+}
+
+func TestServiceChangeType(t *testing.T) {
+	k8sClient := testutil.FakeK8sClient()
+
+	serviceType := v1.ServiceTypeClusterIP
+	expectedService := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test-ns",
+		},
+		Spec: v1.ServiceSpec{
+			Type: serviceType,
+		},
+	}
+
+	err := CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService := &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, serviceType, actualService.Spec.Type)
+
+	// Change service type
+	serviceType = v1.ServiceTypeLoadBalancer
+	expectedService.Spec.Type = serviceType
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, serviceType, actualService.Spec.Type)
+
+	// Remove service type
+	serviceType = v1.ServiceTypeClusterIP
+	expectedService.Spec.Type = ""
+	err = CreateOrUpdateService(k8sClient, expectedService, nil)
+	require.NoError(t, err)
+
+	actualService = &v1.Service{}
+	err = testutil.Get(k8sClient, actualService, "test", "test-ns")
+	require.NoError(t, err)
+	require.Equal(t, serviceType, actualService.Spec.Type)
+}
+
 func TestGetCRDFromFile(t *testing.T) {
 	tests := []struct {
 		dir         string

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -213,6 +213,15 @@ func TestGetCustomAnnotations(t *testing.T) {
 	require.Nil(t, GetCustomAnnotations(cluster, k8s.Pod, "invalid-component"))
 	require.Nil(t, GetCustomAnnotations(cluster, "invalid-kind", componentName))
 	require.Equal(t, podPortworxAnnotations, GetCustomAnnotations(cluster, k8s.Pod, componentName))
+
+	componentName = "portworx-service"
+	serviceAnnotations := map[string]string{
+		"annotation-key": "annotation-val",
+	}
+	cluster.Spec.Metadata.Annotations = map[string]map[string]string{
+		"service/portworx-service": serviceAnnotations,
+	}
+	require.Equal(t, serviceAnnotations, GetCustomAnnotations(cluster, k8s.Service, componentName))
 }
 
 func TestGetCustomLabels(t *testing.T) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Cherry-picked from 1.9.0 branch to 1.8.1. Service type migration change is not added as some dependencies required are not in 1.8.1.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

