### PR TITLE
PWX-24421: Adding azure disk encryption integration test.

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -2818,6 +2818,30 @@ func ValidateStorageClusterFailedEvents(
 		return err
 	}
 
+	return validateK8Events(clusterSpec, timeout, interval, eventsFieldSelector, eventsNewerThan)
+}
+
+// ValidateStorageClusterInstallFailedWithEvents checks a StorageCluster installation failed with a logged event
+func ValidateStorageClusterInstallFailedWithEvents(
+	clusterSpec *corev1.StorageCluster,
+	timeout, interval time.Duration,
+	eventsFieldSelector string,
+	eventsNewerThan time.Time,
+) error {
+	// Validate StorageCluster started Initializing  (note: will be stuck in this phase...)
+	err := validateStorageClusterIsInitializing(clusterSpec, timeout, interval)
+	if err != nil {
+		return err
+	}
+	logrus.Debug("Validating K8 event for NodeStartFailure")
+	return validateK8Events(clusterSpec, timeout, interval, eventsFieldSelector, eventsNewerThan)
+}
+
+func validateK8Events(
+	clusterSpec *corev1.StorageCluster,
+	timeout, interval time.Duration,
+	eventsFieldSelector string,
+	eventsNewerThan time.Time) error {
 	// List newer events -- ensure requested `eventsFieldSelector` is listed
 	t := func() (interface{}, bool, error) {
 		tmout := int64(timeout.Seconds() / 2)

--- a/test/integration_test/azure_disk_test.go
+++ b/test/integration_test/azure_disk_test.go
@@ -109,6 +109,7 @@ func EncryptedDiskInstallPass(tc *types.TestCase) func(*testing.T) {
 		}
 		if encryptedDiskParam == false {
 			logrus.Warn("Failed to validate the presence of diskEncryptionSetID in deviceSpec")
+			return
 		}
 
 		// Deploy PX and validate

--- a/test/integration_test/azure_disk_test.go
+++ b/test/integration_test/azure_disk_test.go
@@ -1,0 +1,123 @@
+//go:build integrationtest
+// +build integrationtest
+
+package integrationtest
+
+import (
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/util/test"
+	"github.com/libopenstorage/operator/test/integration_test/types"
+	ci_utils "github.com/libopenstorage/operator/test/integration_test/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	disksEnc = []string{"type=Premium_LRS,size=100,diskEncryptionSetID=invalid"}
+)
+
+var TestAzureDiskEncryptionCases = []types.TestCase{
+	{
+		TestName:        "InstallWithInvalidDiskEncryptionSetID",
+		TestrailCaseIDs: []string{"C82917"},
+		TestSpec: func(t *testing.T) interface{} {
+			cluster := &corev1.StorageCluster{}
+			cluster.Name = "px-cluster-azure-incorrect-enc"
+			err := ci_utils.ConstructStorageCluster(cluster, ci_utils.PxSpecGenURL, ci_utils.PxSpecImages)
+			require.NoError(t, err)
+
+			cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{
+				CloudStorageCommon: corev1.CloudStorageCommon{
+					DeviceSpecs: &disksEnc,
+				},
+			}
+			cluster.Spec.DeleteStrategy = &corev1.StorageClusterDeleteStrategy{
+				Type: corev1.UninstallAndWipeStorageClusterStrategyType,
+			}
+			return cluster
+		},
+		TestFunc: EncryptedDiskInstallFail,
+	},
+	{
+		TestName:        "InstallWithDiskEncryptionSetID",
+		TestrailCaseIDs: []string{"C82915"},
+		TestSpec: func(t *testing.T) interface{} {
+			cluster := &corev1.StorageCluster{}
+			cluster.Name = "px-cluster-azure-enc"
+			err := ci_utils.ConstructStorageCluster(cluster, ci_utils.PxSpecGenURL, ci_utils.PxSpecImages)
+			require.NoError(t, err)
+
+			cluster.Spec.DeleteStrategy = &corev1.StorageClusterDeleteStrategy{
+				Type: corev1.UninstallAndWipeStorageClusterStrategyType,
+			}
+			return cluster
+		},
+		TestFunc: EncryptedDiskInstallPass,
+	},
+}
+
+func EncryptedDiskInstallFail(tc *types.TestCase) func(*testing.T) {
+	return func(t *testing.T) {
+		testSpec := tc.TestSpec(t)
+		cluster, ok := testSpec.(*corev1.StorageCluster)
+		require.True(t, ok)
+
+		// Record pre-deploy timestamp
+		installTime := time.Now()
+		// Deploy cluster
+		logrus.Infof("Deploy StorageCluster %s", cluster.Name)
+		_, err := ci_utils.CreateStorageCluster(cluster)
+		require.NoError(t, err)
+
+		// Validate cluster deployment
+		logrus.Infof("Validate StorageCluster %s has failed events", cluster.Name)
+		err = test.ValidateStorageClusterInstallFailedWithEvents(cluster, ci_utils.DefaultValidateDeployTimeout, ci_utils.DefaultValidateDeployRetryInterval, "reason=NodeStartFailure", installTime)
+		require.NoError(t, err)
+
+		// Wipe PX and validate
+		logrus.Infof("Uninstall StorageCluster %s", cluster.Name)
+		ci_utils.UninstallAndValidateStorageCluster(cluster, t)
+	}
+}
+
+func EncryptedDiskInstallPass(tc *types.TestCase) func(*testing.T) {
+	return func(t *testing.T) {
+		testSpec := tc.TestSpec(t)
+		cluster, ok := testSpec.(*corev1.StorageCluster)
+		require.True(t, ok)
+
+		encryptedDiskParam := false
+		// Validate if a diskEncryptionSetID param is present in deviceSpec
+		logrus.Infof("Checking if a diskEncryptionSetID param is present in deviceSpec")
+		if cluster.Spec.CloudStorage != nil {
+			if cluster.Spec.CloudStorage.DeviceSpecs != nil {
+				deviceSpecs := *cluster.Spec.CloudStorage.DeviceSpecs
+				for _, s := range deviceSpecs {
+					if strings.Contains(s, "diskEncryptionSetID=") {
+						encryptedDiskParam = true
+						logrus.Infof("Param diskEncryptionSetID is present in deviceSpec")
+						break
+					}
+				}
+			}
+		}
+		require.True(t, encryptedDiskParam, "failed to validate the presence of diskEncryptionSetID in deviceSpec")
+
+		// Deploy PX and validate
+		logrus.Infof("Deploy and validate StorageCluster %s ", cluster.Name)
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
+
+		// Wipe PX and validate
+		logrus.Infof("Uninstall StorageCluster %s", cluster.Name)
+		ci_utils.UninstallAndValidateStorageCluster(cluster, t)
+	}
+}
+
+func TestAzure(t *testing.T) {
+	for _, testCase := range TestAzureDiskEncryptionCases {
+		testCase.RunTest(t)
+	}
+}

--- a/test/integration_test/main_test.go
+++ b/test/integration_test/main_test.go
@@ -1,3 +1,4 @@
+//go:build integrationtest
 // +build integrationtest
 
 package integrationtest
@@ -80,6 +81,10 @@ func setup() error {
 		"is-eks",
 		false,
 		"Is this EKS")
+	flag.BoolVar(&ci_utils.IsAks,
+		"is-aks",
+		false,
+		"Is this AKS")
 	flag.StringVar(&logLevel,
 		"log-level",
 		"",

--- a/test/integration_test/operator-test-pod-template.yaml
+++ b/test/integration_test/operator-test-pod-template.yaml
@@ -60,6 +60,7 @@ spec:
     - -portworx-env-vars=PORTWORX_ENV_VARS
     - -is-ocp=IS_OCP
     - -is-eks=IS_EKS
+    - -is-aks=IS_AKS
     - -cloud-provider=CLOUD_PROVIDER
     - -px-upgrade-hops-url-list=PX_UPGRADE_HOPS_URL_LIST
     - -operator-upgrade-hops-image-list=OPERATOR_UPGRADE_HOPS_IMAGE_LIST

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -15,6 +15,7 @@ portworx_image_override=""
 cloud_provider=""
 is_ocp=false
 is_eks=false
+is_aks=false
 portworx_device_specs=""
 portworx_kvdb_spec=""
 portworx_env_vars=""
@@ -85,6 +86,12 @@ case $i in
     --is-eks)
         echo "Flag for EKS: $2"
         is_eks=$2
+        shift
+        shift
+        ;;
+    --is-aks)
+        echo "Flag for AKS: $2"
+        is_aks=$2
         shift
         shift
         ;;
@@ -186,6 +193,14 @@ if [ "$is_eks" != "" ]; then
     sed -i 's|'IS_EKS'|'"$is_eks"'|g' $test_pod_spec
 else
     sed -i 's|'IS_EKS'|''|g' $test_pod_spec
+fi
+
+# Set AKS
+if [ "$is_aks" != "" ]; then
+    echo "This is AKS cluster: $is_aks"
+    sed -i 's|'IS_AKS'|'"$is_aks"'|g' $test_pod_spec
+else
+    sed -i 's|'IS_AKS'|''|g' $test_pod_spec
 fi
 
 # Set Portworx Spec Generator URL

--- a/test/integration_test/utils/constants.go
+++ b/test/integration_test/utils/constants.go
@@ -49,6 +49,9 @@ var (
 
 	// IsEks is an indication that this is EKS cluster or not
 	IsEks bool
+
+	// IsAks is an indication that this is AKS cluster or not
+	IsAks bool
 )
 
 const (

--- a/test/integration_test/utils/storagecluster.go
+++ b/test/integration_test/utils/storagecluster.go
@@ -79,6 +79,14 @@ func ConstructStorageCluster(cluster *corev1.StorageCluster, specGenURL string, 
 		cluster.Annotations["portworx.io/is-eks"] = "true"
 	}
 
+	// Add AKS annotation
+	if IsAks {
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string)
+		}
+		cluster.Annotations["portworx.io/is-aks"] = "true"
+	}
+
 	// Populate cloud storage
 	if len(PxDeviceSpecs) != 0 {
 		pxDeviceSpecs := strings.Split(PxDeviceSpecs, ";")


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
disEncryptionSetID can be passed in the StorageCluster deviceSpecs to use the specific key associated with this disk encryption set for encryption in an AKS cluster. With this PR we are adding two test cases to test PX installation with this param.

**Which issue(s) this PR fixes** (optional)
Closes #PWX-24421

**Special notes for your reviewer**:
Test [**InstallWithInvalidDiskEncryptionSetID**] : Pass "invalid" diskEncryptionSetID in the device spec and check for NodeStartFailure event from K8.
Test[**InstallWithInvalidDiskEncryptionSetID**] : Pass a valid diskEncryptionSetID using --portworx-device-specs in the integration test param and PX installation should succeed.
