### PR TITLE
[OPERATOR-816] Handle clusterID with special characters during migration

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -772,7 +772,7 @@ func (t *template) getCloudProvider() string {
 
 func (t *template) getArguments() []string {
 	args := []string{
-		"-c", t.cluster.Name,
+		"-c", pxutil.GetClusterID(t.cluster),
 		"-x", "kubernetes",
 	}
 

--- a/drivers/storage/portworx/status.go
+++ b/drivers/storage/portworx/status.go
@@ -109,7 +109,8 @@ func (p *portworx) updateStorageNodes(
 	// If cluster is running internal kvdb, get current bootstrap nodes
 	kvdbNodeMap := make(map[string]*kvdb_api.BootstrapEntry)
 	if cluster.Spec.Kvdb != nil && cluster.Spec.Kvdb.Internal {
-		strippedClusterName := strings.ToLower(configMapNameRegex.ReplaceAllString(cluster.Name, ""))
+		clusterID := pxutil.GetClusterID(cluster)
+		strippedClusterName := strings.ToLower(configMapNameRegex.ReplaceAllString(clusterID, ""))
 		cmName := fmt.Sprintf("%s%s", internalEtcdConfigMapPrefix, strippedClusterName)
 
 		cm := &v1.ConfigMap{}

--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -135,7 +135,8 @@ func (u *uninstallPortworx) WipeMetadata() error {
 		return err
 	}
 
-	strippedClusterName := strings.ToLower(configMapNameRegex.ReplaceAllString(u.cluster.Name, ""))
+	clusterID := pxutil.GetClusterID(u.cluster)
+	strippedClusterName := strings.ToLower(configMapNameRegex.ReplaceAllString(clusterID, ""))
 
 	configMaps := []string{
 		fmt.Sprintf("%s%s", internalEtcdConfigMapPrefix, strippedClusterName),
@@ -164,7 +165,7 @@ func (u *uninstallPortworx) WipeMetadata() error {
 		return err
 	}
 
-	return kv.DeleteTree(u.cluster.Name)
+	return kv.DeleteTree(clusterID)
 }
 
 func (u *uninstallPortworx) RunNodeWiper(

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -123,6 +123,8 @@ const (
 	AnnotationHostPid = pxAnnotationPrefix + "/host-pid"
 	// AnnotationDNSPolicy configures dns policy for portworx pod.
 	AnnotationDNSPolicy = pxAnnotationPrefix + "/dns-policy"
+	// AnnotationClusterID overwrites portworx cluster ID, which is the storage cluster name by default
+	AnnotationClusterID = pxAnnotationPrefix + "/cluster-id"
 
 	// EnvKeyPXImage key for the environment variable that specifies Portworx image
 	EnvKeyPXImage = "PX_IMAGE"
@@ -1012,4 +1014,12 @@ func ApplyStorageClusterSettings(cluster *corev1.StorageCluster, deployment *app
 			}
 		}
 	}
+}
+
+// GetClusterID returns portworx instance cluster ID
+func GetClusterID(cluster *corev1.StorageCluster) string {
+	if cluster.Annotations[AnnotationClusterID] != "" {
+		return cluster.Annotations[AnnotationClusterID]
+	}
+	return cluster.Name
 }

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -717,7 +717,7 @@ func getPortworxClusterName(ds *appsv1.DaemonSet) string {
 	c := getPortworxContainer(ds)
 	for i, arg := range c.Args {
 		if arg == "-c" {
-			return c.Args[i+1]
+			return getStorageClusterNameFromClusterID(c.Args[i+1])
 		}
 	}
 	return ""


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: During migration if the cluster ID in DaemonSet cannot be a valid k8s object name, format the ID and save the original ID to STC annotation, so kvdb path and existing configmap names are not messed up.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

