### PR TITLE
ccm-go integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ downloads: getconfigs get-release-manifest
 cleanconfigs:
 	rm -rf bin/configs
 
-# ccm config templates need to be synced with repo: https://github.dev.purestorage.com/parts/ccm-go
+# TODO: import ccm-go repo as a git submodule: https://github.dev.purestorage.com/parts/ccm-go
 getccmconfigs:
 	mkdir -p bin/configs
 	cp deploy/ccm/* bin/configs/

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,12 @@ downloads: getconfigs get-release-manifest
 cleanconfigs:
 	rm -rf bin/configs
 
-getconfigs: cleanconfigs
+# ccm config templates need to be synced with repo: https://github.dev.purestorage.com/parts/ccm-go
+getccmconfigs:
+	mkdir -p bin/configs
+	cp deploy/ccm/* bin/configs/
+
+getconfigs: cleanconfigs getccmconfigs
 	wget -q '$(PX_DOC_HOST)/samples/k8s/pxc/portworx-prometheus-rule.yaml' -P bin/configs --no-check-certificate
 	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-alertmanagerconfigs.yaml' -O bin/configs/prometheus-crd-alertmanagerconfigs.yaml
 	wget -q '$(PROMETHEUS_OPERATOR_CRD_URL_PREFIX)/crd-alertmanagers.yaml' -O bin/configs/prometheus-crd-alertmanagers.yaml

--- a/deploy/ccm/ccm.properties
+++ b/deploy/ccm/ccm.properties
@@ -1,0 +1,44 @@
+{
+    "product_name": "portworx",
+    "port": PORTWORX_PORT,
+    "node_name_key": "K8S_NODE_NAME",
+    "logupload": {
+      "logfile_patterns": [
+        "/var/cores/*diags*",
+        "/var/cores/auto/*diags*",
+        "/var/cores/*px-cores*",
+        "/var/cores/*.heap",
+        "/var/cores/*.stack",
+        "/var/cores/.alerts/alerts*"
+      ],
+      "skip_patterns": [
+        "/var/cores/*skip*",
+        "/var/cores/auto/*skip*"
+      ],
+      "additional_files": [
+        "/etc/pwx/config.json",
+        "/var/cores/.alerts/alerts.log",
+        "/var/cores/px_etcd_watch.log",
+        "/var/cores/px_cache_mon.log",
+        "/var/cores/px_cache_mon_watch.log",
+        "/var/cores/px_healthmon_watch.log",
+        "/var/cores/px_event_watch.log"
+      ],
+      "phonehome_hour_range": 8760,
+      "phonehome_sent": "/var/logs/phonehome.sent",
+      "always_scan_range_days": 7,
+      "max_retry_per_hour": 5,
+      "phonehome_max_retry_upload_days": 10
+    },
+    "bookkeeping": {
+        "logupload_book_path": "/var/cache/ccm/log_upload.book",
+        "logupload_map_path": "/var/cache/ccm/log_upload.map"
+    },
+    "standalone": {
+      "version": "1.0.0",
+      "controller_sn": "SA-0",
+      "component_name":"SA-0",
+      "product_name": "portworx",
+      "appliance_id_path": "/etc/pwx/cluster_uuid"
+    }
+  }

--- a/deploy/ccm/config_properties_px.yaml
+++ b/deploy/ccm/config_properties_px.yaml
@@ -1,0 +1,32 @@
+actKeyRequired: false
+cert:
+  keySize: 2048
+  renewWindowInDays: 30
+  registrationEnabled: true
+  renewEnabled: true
+  keyAlgorithm: "RSA"
+  noRelCertEnabled: true
+  release:
+    staging: 
+      private: "/opt/ccm/cert/rel_priv_staging.pem"
+    production:
+      private: "/opt/ccm/cert/rel_priv.pem"
+subscription:
+  useApplianceId: true
+  accountType: "UNKNOWN"
+standalone:
+  applianceIdPath: "/var/cache/appliance_id"
+  generateApplianceIdEnabled: false
+envoy:
+  protocol: "http"
+  registrationHost: "localhost"
+  registrationPort: "12001"
+  renewalHost: "localhost"
+  renewalPort: "12002"
+cloud:
+  auth:
+    version: "1.0"
+productName: "portworx"
+k8s:
+  certSecretName: "pure-telemetry-certs"
+  certSecretNamespace: CERT_SECRET_NAMESPACE

--- a/deploy/ccm/envoy-config-register-customer-proxy.yaml
+++ b/deploy/ccm/envoy-config-register-customer-proxy.yaml
@@ -1,0 +1,198 @@
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9901
+node:
+  id: "id_rest"
+  cluster: "cluster_rest"
+static_resources:
+  listeners:
+  - name: listener_cloud_support
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 12002
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          http_filters:
+          - name: envoy.filters.http.router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                request_headers_to_add:
+                - header:
+                   key: "product-name"
+                   value: "portworx"
+                - header:
+                   key: "appliance-id"
+                   value: APPLIANCE_ID
+                - header:
+                   key: "component-sn"
+                   value: COMPONENT-SN
+                - header:
+                   key: "product-version"
+                   value: PRODUCT_VERSION
+                route:
+                  host_rewrite_literal: REST_PROXY_URL
+                  cluster: cluster_cloud_support
+  - "@type": type.googleapis.com/envoy.config.listener.v3.Listener  
+    name: listener_cloud_support_tcp_proxy  
+    address:  
+      socket_address: 
+        protocol: TCP 
+        address: 127.0.0.1  
+        port_value: 12003 
+    filter_chains:  
+    - filters:  
+      - name: envoy.filters.network.tcp_proxy 
+        typed_config: 
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy 
+          stat_prefix: ingress_tcp_proxy  
+          access_log: 
+          - name: envoy.access_loggers.stdout 
+            typed_config: 
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog  
+          cluster: cluster_cloud_support_tcp_proxy
+  - name: listener_customer_proxy_envoy_internal_redirect
+    address:
+      socket_address:
+        protocol: TCP
+        address: 127.0.0.1
+        port_value: 12004
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: ingress_customer_proxy_envoy_internal_redirect
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          cluster: cluster_customer_proxy
+          tunneling_config:
+            hostname: REST_PROXY_URL:443
+            headers_to_add:
+            - header:
+                key: "product-name"
+                value: "portworx"
+            - header:
+               key: "appliance-id"
+               value: APPLIANCE_ID
+            - header:
+               key: "component-sn"
+               value: COMPONENT_SN
+            - header:
+               key: "product-version"
+               value: PRODUCT_VERSION
+  - name: listener_customer_proxy_envoy_internal_redirect_2
+    address:
+      socket_address:
+        protocol: TCP
+        address: 127.0.0.1
+        port_value: 12005
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.tcp_proxy
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
+          stat_prefix: ingress_customer_proxy_envoy_internal_redirect_2
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          cluster: cluster_customer_proxy
+          tunneling_config:
+            hostname: rest2.cloud-support.purestorage.com:443
+            headers_to_add:
+            - header:
+                key: "product-name"
+                value: "portworx"
+            - header:
+               key: "appliance-id"
+               value: APPLIANCE_ID
+            - header:
+               key: "component-sn"
+               value: COMPONENT_SN
+            - header:
+               key: "product-version"
+               value: PRODUCT_VERSION
+  clusters:
+  - name: cluster_cloud_support
+    type: STRICT_DNS
+    dns_lookup_family: AUTO
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: cluster_cloud_support
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: localhost
+                port_value: 12005
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificate_sds_secret_configs:
+            name: tls_sds
+            sds_config:
+              path: /etc/envoy/tls_certificate_sds_secret.yaml
+  - "@type": type.googleapis.com/envoy.config.cluster.v3.Cluster  
+    name: cluster_cloud_support_tcp_proxy 
+    type: STRICT_DNS  
+    dns_lookup_family: AUTO  
+    lb_policy: ROUND_ROBIN  
+    load_assignment:  
+      cluster_name: cluster_cloud_support_tcp_proxy 
+      endpoints:  
+      - lb_endpoints: 
+        - endpoint: 
+            address:  
+              socket_address: 
+                address: localhost 
+                port_value: 12004 
+    transport_socket: 
+      name: envoy.transport_sockets.tls 
+      typed_config: 
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext 
+        common_tls_context: 
+          tls_certificate_sds_secret_configs:
+            name: tls_sds
+            sds_config:
+              path: /etc/envoy/tls_certificate_sds_secret.yaml
+  - name: cluster_customer_proxy
+    type: STRICT_DNS
+    dns_lookup_family: AUTO
+    lb_policy: ROUND_ROBIN
+    # This ensures HTTP/1.1 CONNECT is used for establishing the tunnel.
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+        explicit_http_config:
+          http_protocol_options: {}
+    load_assignment:
+      cluster_name: cluster_customer_proxy
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: CUSTOM_PROXY_ADDRESS
+                port_value: CUSTOM_PROXY_PORT

--- a/deploy/ccm/envoy-config-register.yaml
+++ b/deploy/ccm/envoy-config-register.yaml
@@ -1,0 +1,73 @@
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9901
+
+static_resources:
+  listeners:
+  - name: listener_register_cloud_support
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 12001
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                request_headers_to_add:
+                - header:
+                   key: "product-name"
+                   value: "portworx"
+                - header:
+                   key: "appliance-id"
+                   value: APPLIANCE_ID
+                - header:
+                   key: "component-sn"
+                   value: COMPONENT_SN
+                - header:
+                   key: "product-version"
+                   value: PRODUCT_VERSION
+                route:
+                  host_rewrite_literal: REGISTER_PROXY_URL
+                  cluster: cluster_register_cloud_support
+  clusters:
+  - name: cluster_register_cloud_support
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: cluster_register_cloud_support
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: REGISTER_PROXY_URL
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+            private_key:

--- a/deploy/ccm/envoy-config-rest.yaml
+++ b/deploy/ccm/envoy-config-rest.yaml
@@ -1,0 +1,73 @@
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9901
+node:
+  id: "id_rest"
+  cluster: "cluster_rest"
+static_resources:
+  listeners:
+  - name: listener_cloud_support
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 12002
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                request_headers_to_add:
+                - header:
+                   key: "product-name"
+                   value: "portworx"
+                - header:
+                   key: "appliance-id"
+                   value: APPLIANCE_ID
+                - header:
+                   key: "product-version"
+                   value: PRODUCT_VERSION
+                route:
+                  host_rewrite_literal: REST_PROXY_URL
+                  cluster: cluster_cloud_support
+  clusters:
+  - name: cluster_cloud_support
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: cluster_cloud_support
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: REST_PROXY_URL
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificate_sds_secret_configs:
+            name: tls_sds
+            sds_config:
+              path: /etc/envoy/tls_certificate_sds_secret.yaml

--- a/deploy/ccm/phonehome-cluster.yaml
+++ b/deploy/ccm/phonehome-cluster.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: log-upload-service
-          image: pureezhang/log-upload:0.0.11
+          image: purestorage/log-upload:1.0.0
           volumeMounts:
           - name: etcpwx
             mountPath: /etc/pwx

--- a/deploy/ccm/phonehome-cluster.yaml
+++ b/deploy/ccm/phonehome-cluster.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: phonehome-cluster
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      role: phonehome-cluster
+  template:
+    metadata:
+      labels:
+        role: phonehome-cluster
+    spec:
+      containers:
+        - name: log-upload-service
+          image: pureezhang/log-upload:0.0.11
+          volumeMounts:
+          - name: etcpwx
+            mountPath: /etc/pwx
+          - mountPath: /var/cache
+            name: varcache
+          - mountPath: /var/log
+            name: journalmount2
+            readOnly: true
+          - mountPath: /var/cores
+            name: varcores
+          - readOnly: true
+            mountPath: /config
+            name: ccm-config
+          env:
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - name: loguploader
+              containerPort: 9090
+              hostPort: 9090
+              protocol: TCP
+          imagePullPolicy: Always
+        - name: envoy
+          image: envoyproxy/envoy:v1.22.2
+          securityContext:
+            runAsUser: 1111
+          volumeMounts:
+          - readOnly: true
+            mountPath: /config
+            name: proxy-config
+          - readOnly: true
+            mountPath: /etc/envoy/
+            name: tls-certificate
+          - readOnly: true
+            mountPath: /appliance-cert
+            name: pure-telemetry-certs
+          args:
+          - "envoy"
+          - "--config-path"
+          - "/config/envoy-config-rest.yaml"
+          ports:
+            - name: envoy
+              containerPort: 12002
+              hostPort: 12002
+              protocol: TCP
+      initContainers:
+        - name: init-cont
+          image: bitnami/kubectl:1.24.3
+          command: ['/bin/bash', '-c', "cert=$(kubectl get secrets -n kube-system --field-selector=metadata.name=pure-telemetry-certs -ojson |jq .items[0].data.cert); until [[ ${#cert} -gt 4 ]]; do echo waiting for cert generation; sleep 4; cert=$(kubectl get secrets -n kube-system --field-selector=metadata.name=pure-telemetry-certs -ojson |jq .items[0].data.cert); done;"]
+      volumes:
+        - name: etcpwx
+          hostPath:
+            path: /etc/pwx
+        - hostPath:
+            path: /var/cache
+          name: varcache
+        - name: varcores
+          hostPath:
+            path: /var/cores
+        - name: journalmount2
+          hostPath:
+            path: /var/log
+        - configMap:
+            items:
+              - key: ccm.properties
+                path: ccm.properties
+              - key: location
+                path: location
+            name: px-telemetry-config
+          name: ccm-config
+        - name: proxy-config
+          configMap:
+            name: proxy-config-rest
+        - name: tls-certificate
+          configMap:
+            name: tls-certificate
+        - name: pure-telemetry-certs
+          secret:
+            secretName: pure-telemetry-certs

--- a/deploy/ccm/registration-service.yaml
+++ b/deploy/ccm/registration-service.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registration-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: registration-service
+  template:
+    metadata:
+      labels:
+        role: registration-service
+    spec:
+      hostNetwork: true
+      containers:
+        - name: registration
+          image: pureezhang/ccm-go:0.0.8
+          env:
+          - name: CONFIG
+            value: "config/config_properties_px.yaml"
+          volumeMounts:
+          - readOnly: true
+            mountPath: /config
+            name: registration-config
+          ports:
+            - name: registration
+              containerPort: 80
+              protocol: TCP
+          imagePullPolicy: Always
+        - name: envoy
+          image: envoyproxy/envoy:v1.22.2
+          securityContext:
+            runAsUser: 1111
+          volumeMounts:
+          - readOnly: true
+            mountPath: /config
+            name: proxy-config
+          args:
+          - "envoy"
+          - "--config-path"
+          - "/config/envoy-config-register.yaml"
+      volumes:
+        - name: registration-config
+          configMap:
+            name: registration-config
+        - name: proxy-config
+          configMap:
+            name: proxy-config-register

--- a/deploy/ccm/registration-service.yaml
+++ b/deploy/ccm/registration-service.yaml
@@ -15,7 +15,7 @@ spec:
       hostNetwork: true
       containers:
         - name: registration
-          image: pureezhang/ccm-go:0.0.8
+          image: purestorage/ccm-go:1.0.0
           env:
           - name: CONFIG
             value: "config/config_properties_px.yaml"

--- a/deploy/ccm/secret-manager-role-binding.yaml
+++ b/deploy/ccm/secret-manager-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: registerrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: secret-manager
+subjects:
+- kind: ServiceAccount
+  name: default
+  apiGroup: ""
+  namespace: kube-system

--- a/deploy/ccm/secret-manager-role.yaml
+++ b/deploy/ccm/secret-manager-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: secret-manager
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "update"]

--- a/deploy/ccm/stc-reader-role-binding.yaml
+++ b/deploy/ccm/stc-reader-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: stcrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: stc-reader
+subjects:
+- kind: ServiceAccount
+  name: default
+  apiGroup: ""
+  namespace: kube-system

--- a/deploy/ccm/stc-reader-role.yaml
+++ b/deploy/ccm/stc-reader-role.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: stc-reader
+rules:
+- apiGroups: ["core.libopenstorage.org"]
+  resources: ["storageclusters"]
+  verbs: ["get", "list"]

--- a/deploy/ccm/tls_certificate_sds_secret.yaml
+++ b/deploy/ccm/tls_certificate_sds_secret.yaml
@@ -1,0 +1,8 @@
+resources:
+  - "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.Secret"
+    name: tls_sds
+    tls_certificate:
+      certificate_chain:
+        filename: /appliance-cert/cert
+      private_key:
+        filename: /appliance-cert/private_key

--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -926,7 +926,7 @@ spec:
                       image:
                         type: string
                         description: Docker image of the telemetry container.
-                      imageLogUpload:
+                      logUploaderImage:
                         type: string
                         description: Docker image of the log-upload-service container.
               security:
@@ -1472,7 +1472,7 @@ spec:
                     description: Desired image for metrics collector proxy.
                   telemetryProxy:
                     type: string
-                    description: Desired image for telemetry.
+                    description: Desired image for telemetry proxy.
                   logUploader:
                     type: string
                     description: Desired image for log uploader.

--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -926,6 +926,9 @@ spec:
                       image:
                         type: string
                         description: Docker image of the telemetry container.
+                      imageLogUpload:
+                        type: string
+                        description: Docker image of the log-upload-service container.
               security:
                 type: object
                 description: Contains security configuration for the storage cluster.
@@ -1467,6 +1470,12 @@ spec:
                   metricsCollectorProxy:
                     type: string
                     description: Desired image for metrics collector proxy.
+                  telemetryProxy:
+                    type: string
+                    description: Desired image for telemetry.
+                  logUploader:
+                    type: string
+                    description: Desired image for log uploader.
                   pxRepo:
                     type: string
                     description: Desired image for pxRepo.

--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -1,14 +1,11 @@
 package component
 
 import (
-	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	v1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,13 +13,11 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/libopenstorage/openstorage/api"
 	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
-	coreops "github.com/portworx/sched-ops/k8s/core"
 )
 
 const (
@@ -111,55 +106,10 @@ func (c *disruptionBudget) createPortworxPodDisruptionBudget(
 		return err
 	}
 
-	nodeClient := api.NewOpenStorageNodeClient(c.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, c.k8sClient)
+	storageNodesCount, err := pxutil.CountStorageNodes(cluster, c.sdkConn, c.k8sClient)
 	if err != nil {
 		c.closeSdkConn()
 		return err
-	}
-
-	nodeEnumerateResponse, err := nodeClient.EnumerateWithFilters(
-		ctx,
-		&api.SdkNodeEnumerateWithFiltersRequest{},
-	)
-	if err != nil {
-		c.closeSdkConn()
-		return fmt.Errorf("failed to enumerate nodes: %v", err)
-	}
-
-	k8sNodeList := &v1.NodeList{}
-	err = c.k8sClient.List(context.TODO(), k8sNodeList)
-	if err != nil {
-		return err
-	}
-	k8sNodesStoragePodCouldRun := make(map[string]bool)
-	for _, node := range k8sNodeList.Items {
-		shouldRun, shouldContinueRunning, err := k8sutil.CheckPredicatesForStoragePod(&node, cluster, nil)
-		if err != nil {
-			return err
-		}
-		if shouldRun || shouldContinueRunning {
-			k8sNodesStoragePodCouldRun[node.Name] = true
-		}
-	}
-
-	storageNodesCount := 0
-	for _, node := range nodeEnumerateResponse.Nodes {
-		if node.SchedulerNodeName == "" {
-			k8sNode, err := coreops.Instance().SearchNodeByAddresses(
-				[]string{node.DataIp, node.MgmtIp, node.Hostname},
-			)
-			if err != nil {
-				logrus.Warnf("Unable to find kubernetes node name for nodeID %v: %v", node.Id, err)
-				continue
-			}
-			node.SchedulerNodeName = k8sNode.Name
-		}
-		if len(node.Pools) > 0 && node.Pools[0] != nil {
-			if _, ok := k8sNodesStoragePodCouldRun[node.SchedulerNodeName]; ok {
-				storageNodesCount++
-			}
-		}
 	}
 
 	// Create PDB only if there are at least 3 nodes. With 2 nodes are less, if 1

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -10,11 +10,9 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,49 +21,11 @@ import (
 
 	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 )
 
 const (
-	// TelemetryComponentName name of the telemetry component
-	TelemetryComponentName = "Portworx Telemetry"
-	// TelemetryCCMProxyConfigMapName is the name of the config map that stores the PX_HTTP(S)_PROXY env var
-	TelemetryCCMProxyConfigMapName = "px-ccm-service-proxy-config"
-	// TelemetryCCMProxyFilePath path of the http proxy file
-	TelemetryCCMProxyFilePath = "/cache/network/http_proxy"
-	// TelemetryCCMProxyFileName name of the http proxy file
-	TelemetryCCMProxyFileName = "http_proxy"
-	// CollectorRoleName is name of the Role for metrics collector.
-	CollectorRoleName = "px-metrics-collector"
-	// CollectorRoleBindingName is name of the role binding for metrics collector.
-	CollectorRoleBindingName = "px-metrics-collector"
-	// CollectorClusterRoleName name of the metrics collector cluster role
-	CollectorClusterRoleName = "px-metrics-collector"
-	// CollectorClusterRoleBindingName name of the metrics collector cluster role binding
-	CollectorClusterRoleBindingName = "px-metrics-collector"
-	// CollectorConfigFileName is file name of the collector pod config.
-	CollectorConfigFileName = "portworx.yaml"
-	// CollectorProxyConfigFileName is file name of envoy config.
-	CollectorProxyConfigFileName = "envoy-config.yaml"
-	// CollectorConfigMapName is name of config map for metrics collector.
-	CollectorConfigMapName = "px-collector-config"
-	// CollectorProxyConfigMapName is name of the config map for envoy proxy.
-	CollectorProxyConfigMapName = "px-collector-proxy-config"
-	// CollectorDeploymentName is name of metrics collector deployment.
-	CollectorDeploymentName = "px-metrics-collector"
-	// CollectorServiceAccountName is name of the metrics collector service account
-	CollectorServiceAccountName = "px-metrics-collector"
-	// TelemetryConfigMapName is the name of the config map that stores the telemetry configuration for CCM
-	TelemetryConfigMapName = "px-telemetry-config"
-	// TelemetryPropertiesFilename is the name of the CCM properties file
-	TelemetryPropertiesFilename = "ccm.properties"
-	// TelemetryArcusLocationFilename is name of the file storing the location of arcus endpoint to use
-	TelemetryArcusLocationFilename = "location"
-	// TelemetryCertName is name of the telemetry cert.
-	TelemetryCertName = "pure-telemetry-certs"
-
 	// RoleNameSecretManager is name of role secret-manager
 	RoleNameSecretManager = "secret-manager"
 	// RoleBindingNameSecretManager is name of role binding registerrolebinding
@@ -124,16 +84,14 @@ const (
 
 	// port for log uploader, avoid 1970 as used by old ccm service, to be configurable in the future
 	logUploaderPort = 9090
-
-	defaultCollectorMemoryRequest = "64Mi"
-	defaultCollectorMemoryLimit   = "128Mi"
-	defaultCollectorCPU           = "0.2"
 )
 
 type telemetry struct {
-	k8sClient                    client.Client
-	sdkConn                      *grpc.ClientConn
-	isCollectorDeploymentCreated bool
+	k8sClient                              client.Client
+	sdkConn                                *grpc.ClientConn
+	isCollectorDeploymentCreated           bool
+	isDeploymentRegistrationServiceCreated bool
+	isDeploymentPhonehonmeClusterCreated   bool
 }
 
 func (t *telemetry) Name() string {
@@ -158,6 +116,8 @@ func (t *telemetry) IsEnabled(cluster *corev1.StorageCluster) bool {
 
 func (t *telemetry) MarkDeleted() {
 	t.isCollectorDeploymentCreated = false
+	t.isDeploymentRegistrationServiceCreated = false
+	t.isDeploymentPhonehonmeClusterCreated = false
 }
 
 // RegisterTelemetryComponent registers the telemetry  component
@@ -171,7 +131,7 @@ func (t *telemetry) Reconcile(cluster *corev1.StorageCluster) error {
 		return err
 	}
 
-	if pxutil.RunCCMGo(cluster) {
+	if pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster)) {
 		// Remove old ccm components first if exist
 		if err := t.deleteCCMJava(cluster, ownerRef); err != nil {
 			return err
@@ -197,6 +157,7 @@ func (t *telemetry) Delete(cluster *corev1.StorageCluster) error {
 	}
 
 	t.closeSdkConn()
+	t.MarkDeleted()
 	return nil
 }
 
@@ -212,29 +173,11 @@ func (t *telemetry) closeSdkConn() {
 	t.sdkConn = nil
 }
 
-// reconcileCCMJava installs CCM Java on older px versions
-func (t *telemetry) reconcileCCMJava(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	if err := t.createCCMJavaConfigMap(cluster, ownerRef); err != nil {
-		return err
-	}
-	if err := t.reconcileCCMJavaProxyConfigMap(cluster, ownerRef); err != nil {
-		return err
-	}
-	if err := t.deployMetricsCollector(cluster, ownerRef); err != nil {
-		return err
-	}
-	return nil
-}
-
 // reconcileCCMGo installs CCM Go on px 2.12+
 func (t *telemetry) reconcileCCMGo(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	logrus.Infof("JLIAO: reconcile new ccm-go")
 	if err := t.reconcileCCMGoRolesAndRoleBindings(cluster, ownerRef); err != nil {
 		return err
 	}
@@ -269,7 +212,7 @@ func (t *telemetry) setTelemetryCertOwnerRef(
 
 	// The cert is created after ccm container starts, so we may not have it for a while.
 	if errors.IsNotFound(err) {
-		logrus.Infof("JLIAO: not found")
+		logrus.Infof("telemetry cert %s/%s not found", cluster.Namespace, TelemetryCertName)
 		return nil
 	} else if err != nil {
 		return err
@@ -284,21 +227,6 @@ func (t *telemetry) setTelemetryCertOwnerRef(
 	secret.OwnerReferences = append(secret.OwnerReferences, *ownerRef)
 
 	return t.k8sClient.Update(context.TODO(), secret)
-}
-
-func (t *telemetry) deleteCCMJava(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef); err != nil {
-		return err
-	}
-
-	if err := t.deleteMetricsCollector(cluster.Namespace, ownerRef); err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (t *telemetry) deleteCCMGo(
@@ -338,661 +266,6 @@ func (t *telemetry) deleteCCMGo(
 	return nil
 }
 
-func (t *telemetry) deleteMetricsCollector(namespace string, ownerRef *metav1.OwnerReference) error {
-	if err := k8sutil.DeleteServiceAccount(t.k8sClient, CollectorServiceAccountName, namespace, *ownerRef); err != nil {
-		return err
-	}
-
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, CollectorProxyConfigMapName, namespace, *ownerRef); err != nil {
-		return err
-	}
-
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, CollectorConfigMapName, namespace, *ownerRef); err != nil {
-		return err
-	}
-
-	if err := k8sutil.DeleteRole(t.k8sClient, CollectorRoleName, namespace, *ownerRef); err != nil {
-		return err
-	}
-
-	if err := k8sutil.DeleteRoleBinding(t.k8sClient, CollectorRoleBindingName, namespace, *ownerRef); err != nil {
-		return err
-	}
-
-	if err := k8sutil.DeleteClusterRole(t.k8sClient, CollectorClusterRoleName); err != nil {
-		return err
-	}
-
-	if err := k8sutil.DeleteClusterRoleBinding(t.k8sClient, CollectorClusterRoleBindingName); err != nil {
-		return err
-	}
-
-	if err := k8sutil.DeleteDeployment(t.k8sClient, CollectorDeploymentName, namespace, *ownerRef); err != nil {
-		return err
-	}
-
-	t.isCollectorDeploymentCreated = false
-	return nil
-}
-
-func (t *telemetry) deployMetricsCollector(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	pxVer2_9_1, _ := version.NewVersion("2.9.1")
-	pxVersion := pxutil.GetPortworxVersion(cluster)
-	if pxVersion.LessThan(pxVer2_9_1) {
-		// Run metrics collector only for portworx version 2.9.1+
-		return nil
-	}
-
-	if len(cluster.Status.ClusterUID) == 0 {
-		logrus.Warn("clusterUID is empty, wait for it to fill collector proxy config")
-		return nil
-	}
-
-	if err := t.createCollectorServiceAccount(cluster.Namespace, ownerRef); err != nil {
-		return err
-	}
-
-	if err := t.createCCMJavaProxyConfigMap(cluster, ownerRef); err != nil {
-		return err
-	}
-
-	if err := t.createCollectorConfigMap(cluster, ownerRef); err != nil {
-		return err
-	}
-
-	if err := t.createCollectorRole(cluster, ownerRef); err != nil {
-		return err
-	}
-
-	if err := t.createCollectorRoleBinding(cluster, ownerRef); err != nil {
-		return err
-	}
-
-	if err := t.createCollectorClusterRole(); err != nil {
-		return err
-	}
-
-	if err := t.createCollectorClusterRoleBinding(cluster.Namespace); err != nil {
-		return err
-	}
-
-	if err := t.createCollectorDeployment(cluster, ownerRef); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (t *telemetry) createCollectorClusterRole() error {
-	return k8sutil.CreateOrUpdateClusterRole(
-		t.k8sClient,
-		&rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: CollectorClusterRoleName,
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups:     []string{"security.openshift.io"},
-					Resources:     []string{"securitycontextconstraints"},
-					ResourceNames: []string{PxSCCName},
-					Verbs:         []string{"use"},
-				},
-				{
-					APIGroups:     []string{"policy"},
-					Resources:     []string{"podsecuritypolicies"},
-					ResourceNames: []string{constants.PrivilegedPSPName},
-					Verbs:         []string{"use"},
-				},
-			},
-		},
-	)
-}
-
-func (t *telemetry) createCollectorClusterRoleBinding(
-	clusterNamespace string,
-) error {
-	return k8sutil.CreateOrUpdateClusterRoleBinding(
-		t.k8sClient,
-		&rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: CollectorClusterRoleBindingName,
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      CollectorServiceAccountName,
-					Namespace: clusterNamespace,
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				Kind:     "ClusterRole",
-				Name:     CollectorClusterRoleName,
-				APIGroup: "rbac.authorization.k8s.io",
-			},
-		},
-	)
-}
-
-func (t *telemetry) createCollectorDeployment(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	deployment, err := t.getCollectorDeployment(cluster, ownerRef)
-	if err != nil {
-		return err
-	}
-
-	existingDeployment := &appsv1.Deployment{}
-	err = t.k8sClient.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      CollectorDeploymentName,
-			Namespace: cluster.Namespace,
-		},
-		existingDeployment,
-	)
-	if err != nil && !errors.IsNotFound(err) {
-		return err
-	}
-
-	modified := false
-	if equal, _ := util.DeepEqualDeployment(deployment, existingDeployment); !equal {
-		modified = true
-	}
-
-	if !t.isCollectorDeploymentCreated || modified {
-		logrus.WithFields(logrus.Fields{
-			"isCreated": t.isCollectorDeploymentCreated,
-			"modified":  modified,
-		}).Info("will create/update the deployment.")
-		if err = k8sutil.CreateOrUpdateDeployment(t.k8sClient, deployment, ownerRef); err != nil {
-			return err
-		}
-	}
-
-	t.isCollectorDeploymentCreated = true
-	return nil
-}
-
-func (t *telemetry) createCollectorServiceAccount(
-	clusterNamespace string,
-	ownerRef *metav1.OwnerReference,
-) error {
-	return k8sutil.CreateOrUpdateServiceAccount(
-		t.k8sClient,
-		&v1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            CollectorServiceAccountName,
-				Namespace:       clusterNamespace,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-		},
-		ownerRef,
-	)
-}
-
-func (t *telemetry) getCollectorDeployment(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) (*appsv1.Deployment, error) {
-	collectorImage, err := getDesiredCollectorImage(cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	collectorProxyImage, err := getDesiredProxyImage(cluster)
-	if err != nil {
-		return nil, err
-	}
-
-	replicas := int32(1)
-	labels := map[string]string{
-		"role": "realtime-metrics-collector",
-	}
-	runAsUser := int64(1111)
-	cpuQuantity, err := resource.ParseQuantity(defaultCollectorCPU)
-	if err != nil {
-		return nil, err
-	}
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            CollectorDeploymentName,
-			Namespace:       cluster.Namespace,
-			OwnerReferences: []metav1.OwnerReference{*ownerRef},
-		},
-		Spec: appsv1.DeploymentSpec{
-			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
-				Spec: v1.PodSpec{
-					ServiceAccountName: CollectorServiceAccountName,
-					Containers: []v1.Container{
-						{
-							Name:  "collector",
-							Image: collectorImage,
-							SecurityContext: &v1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
-							Resources: v1.ResourceRequirements{
-								Requests: v1.ResourceList{
-									v1.ResourceMemory: resource.MustParse(defaultCollectorMemoryRequest),
-									v1.ResourceCPU:    cpuQuantity,
-								},
-								Limits: v1.ResourceList{
-									v1.ResourceMemory: resource.MustParse(defaultCollectorMemoryLimit),
-								},
-							},
-
-							Env: []v1.EnvVar{
-								{
-									Name:  "CONFIG",
-									Value: "config/" + CollectorConfigFileName,
-								},
-							},
-							VolumeMounts: []v1.VolumeMount{
-								{
-									Name:      CollectorConfigMapName,
-									MountPath: "/config",
-									ReadOnly:  true,
-								},
-							},
-							Ports: []v1.ContainerPort{
-								{
-									Name:          "collector",
-									ContainerPort: 80,
-									Protocol:      "TCP",
-								},
-							},
-						},
-						{
-							Name:  "envoy",
-							Image: collectorProxyImage,
-							SecurityContext: &v1.SecurityContext{
-								RunAsUser: &runAsUser,
-							},
-							VolumeMounts: []v1.VolumeMount{
-								{
-									Name:      CollectorProxyConfigMapName,
-									MountPath: "/config",
-									ReadOnly:  true,
-								},
-								{
-									Name:      TelemetryCertName,
-									MountPath: "/appliance-cert",
-									ReadOnly:  true,
-								},
-							},
-							Args: []string{
-								"envoy",
-								"--config-path",
-								"/config/envoy-config.yaml",
-							},
-						},
-					},
-					Volumes: []v1.Volume{
-						{
-							Name: CollectorConfigMapName,
-							VolumeSource: v1.VolumeSource{
-								ConfigMap: &v1.ConfigMapVolumeSource{
-									LocalObjectReference: v1.LocalObjectReference{
-										Name: CollectorConfigMapName,
-									},
-								},
-							},
-						},
-						{
-							Name: CollectorProxyConfigMapName,
-							VolumeSource: v1.VolumeSource{
-								ConfigMap: &v1.ConfigMapVolumeSource{
-									LocalObjectReference: v1.LocalObjectReference{
-										Name: CollectorProxyConfigMapName,
-									},
-								},
-							},
-						},
-						{
-							Name: TelemetryCertName,
-							VolumeSource: v1.VolumeSource{
-								Secret: &v1.SecretVolumeSource{
-									SecretName: TelemetryCertName,
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	pxutil.ApplyStorageClusterSettings(cluster, deployment)
-
-	return deployment, nil
-}
-
-func (t *telemetry) createCollectorRole(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	return k8sutil.CreateOrUpdateRole(
-		t.k8sClient,
-		&rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            CollectorRoleName,
-				Namespace:       cluster.Namespace,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{""},
-					Resources: []string{"pods"},
-					Verbs:     []string{"get", "list"},
-				},
-			},
-		},
-		ownerRef,
-	)
-}
-
-func (t *telemetry) createCollectorRoleBinding(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	return k8sutil.CreateOrUpdateRoleBinding(
-		t.k8sClient,
-		&rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            CollectorRoleBindingName,
-				Namespace:       cluster.Namespace,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind:      "ServiceAccount",
-					Name:      CollectorServiceAccountName,
-					Namespace: cluster.Namespace,
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				Kind:     "Role",
-				Name:     CollectorRoleName,
-				APIGroup: "rbac.authorization.k8s.io",
-			},
-		},
-		ownerRef,
-	)
-}
-
-func (t *telemetry) createCCMJavaProxyConfigMap(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	arcusRestProxyURL := getArcusRestProxyURL(cluster)
-	config := fmt.Sprintf(
-		`
-admin:
-  address:
-    socket_address:
-      address: 127.0.0.1
-      port_value: 9901
-
-static_resources:
-  listeners:
-  - name: listener_cloud_support
-    address:
-      socket_address:
-        address: 127.0.0.1
-        port_value: 10000
-    filter_chains:
-    - filters:
-      - name: envoy.filters.network.http_connection_manager
-        typed_config:
-          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-          stat_prefix: ingress_http
-          access_log:
-          - name: envoy.access_loggers.stdout
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
-          http_filters:
-          - name: envoy.filters.http.router
-          route_config:
-            name: local_route
-            virtual_hosts:
-            - name: local_service
-              domains: ["*"]
-              routes:
-              - match:
-                  prefix: "/"
-                request_headers_to_add:
-                - header:
-                   key: "product-name"
-                   value: "portworx"
-                - header:
-                   key: "appliance-id"
-                   value: "%s"
-                - header:
-                   key: "component-sn"
-                   value: "portworx-metrics-node"
-                - header:
-                   key: "product-version"
-                   value: "%s"
-                route:
-                  host_rewrite_literal: %s
-                  cluster: cluster_cloud_support
-  clusters:
-  - name: cluster_cloud_support
-    type: STRICT_DNS
-    dns_lookup_family: V4_ONLY
-    lb_policy: ROUND_ROBIN
-    load_assignment:
-      cluster_name: cluster_cloud_support
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: %s
-                port_value: 443
-    transport_socket:
-      name: envoy.transport_sockets.tls
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        common_tls_context:
-          tls_certificates:
-          - certificate_chain:
-              filename: /appliance-cert/cert
-            private_key:
-              filename: /appliance-cert/private_key
-`, cluster.Status.ClusterUID, pxutil.GetPortworxVersion(cluster), arcusRestProxyURL, arcusRestProxyURL)
-
-	data := map[string]string{
-		CollectorProxyConfigFileName: config,
-	}
-
-	return k8sutil.CreateOrUpdateConfigMap(
-		t.k8sClient,
-		&v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            CollectorProxyConfigMapName,
-				Namespace:       cluster.Namespace,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-			Data: data,
-		},
-		ownerRef,
-	)
-}
-
-func (t *telemetry) createCollectorConfigMap(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	pxSelectorLabels := pxutil.SelectorLabels()
-	var selectorStr string
-	for k, v := range pxSelectorLabels {
-		selectorStr += fmt.Sprintf("\n        %s: %s", k, v)
-	}
-
-	port := pxutil.StartPort(cluster)
-
-	config := fmt.Sprintf(
-		`
-scrapeConfig:
-  interval: 10
-  k8sConfig:
-    pods:
-    - podSelector:%s
-      namespace: %s
-      endpoint: metrics
-      port: %d
-forwardConfig:
-  url: http://localhost:10000/metrics/1.0/pure1-metrics-pb`,
-		selectorStr,
-		cluster.Namespace,
-		port)
-
-	data := map[string]string{
-		CollectorConfigFileName: config,
-	}
-
-	return k8sutil.CreateOrUpdateConfigMap(
-		t.k8sClient,
-		&v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            CollectorConfigMapName,
-				Namespace:       cluster.Namespace,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-			Data: data,
-		},
-		ownerRef,
-	)
-}
-
-func (t *telemetry) createCCMJavaConfigMap(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	config := fmt.Sprintf(`{
-      "product_name": "portworx",
-       "logging": {
-         "array_info_path": "/dev/null"
-       },
-       "features": {
-         "appliance_info": "config",
-         "cert_store": "k8s",
-         "config_reload": "file",
-         "env_info": "file",
-         "scheduled_log_uploader":"disabled",
-         "upload": "enabled"
-       },
-      "cert": {
-        "activation": {
-              "private": "/dev/null",
-              "public": "/dev/null"
-        },
-        "registration_enabled": "true",
-        "no_rel_cert_enabled": "true",
-        "appliance": {
-          "current_cert_dir": "/etc/pwx/ccm/cert"
-        }
-      },
-      "k8s": {
-        "cert_secret_name": "pure-telemetry-certs",
-        "cert_secret_namespace": "%s"
-     },
-     "cloud": {
-       "array_loc_file_path": "/etc/ccm/%s"
-     },
-      "server": {
-        "hostname": "0.0.0.0"
-      },
-      "logupload": {
-        "logfile_patterns": [
-            "/var/cores/*diags*",
-            "/var/cores/auto/*diags*",
-            "/var/cores/*px-cores*",
-            "/var/cores/*.heap",
-            "/var/cores/*.stack",
-            "/var/cores/.alerts/alerts*"
-        ],
-        "skip_patterns": [],
-        "additional_files": [
-            "/etc/pwx/config.json",
-            "/var/cores/.alerts/alerts.log",
-            "/var/cores/px_etcd_watch.log",
-            "/var/cores/px_cache_mon.log",
-            "/var/cores/px_cache_mon_watch.log",
-            "/var/cores/px_healthmon_watch.log",
-            "/var/cores/px_event_watch.log"
-        ],
-        "phonehome_sent": "/var/cache/phonehome.sent"
-      },
-      "xml_rpc": {},
-      "standalone": {
-        "version": "1.0.0",
-        "controller_sn": "SA-0",
-        "component_name": "SA-0",
-        "product_name": "portworx",
-        "appliance_id_path": "/etc/pwx/cluster_uuid"
-      },
-      "subscription": {
-        "use_appliance_id": "true"
-      },
-      "proxy": {
-        "path": "/cache/network/http_proxy"
-      }
-    }
-`, cluster.Namespace, TelemetryArcusLocationFilename)
-
-	data := map[string]string{
-		TelemetryPropertiesFilename:    config,
-		TelemetryArcusLocationFilename: getArcusTelemetryLocation(cluster),
-	}
-
-	return k8sutil.CreateOrUpdateConfigMap(
-		t.k8sClient,
-		&v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            TelemetryConfigMapName,
-				Namespace:       cluster.Namespace,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-			Data: data,
-		},
-		ownerRef,
-	)
-}
-
-func (t *telemetry) reconcileCCMJavaProxyConfigMap(
-	cluster *corev1.StorageCluster,
-	ownerRef *metav1.OwnerReference,
-) error {
-	proxy := pxutil.GetPxProxyEnvVarValue(cluster)
-	// Delete the existing config map if portworx proxy is empty
-	if proxy == "" {
-		return k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef)
-	}
-
-	return k8sutil.CreateOrUpdateConfigMap(
-		t.k8sClient,
-		&v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            TelemetryCCMProxyConfigMapName,
-				Namespace:       cluster.Namespace,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-			Data: map[string]string{
-				TelemetryCCMProxyFileName: proxy,
-			},
-		},
-		ownerRef,
-	)
-}
-
 func (t *telemetry) reconcileCCMGoRolesAndRoleBindings(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
@@ -1029,13 +302,11 @@ func (t *telemetry) reconcileCCMGoConfigMaps(
 		logrus.WithError(err).Error("failed to create cm registration-config from config_properties_px.yaml ")
 		return err
 	}
-	logrus.Infof("JLIAO: create cm registration-config from config_properties_px.yaml")
 	// Create cm proxy-config-register from envoy-config-register.yaml
 	if err := t.createCCMGoConfigMapProxyConfigRegister(cluster, ownerRef); err != nil {
 		logrus.WithError(err).Error("failed to create cm proxy-config-register from envoy-config-register.yaml")
 		return err
 	}
-	logrus.Infof("JLIAO: create cm proxy-config-register from envoy-config-register.yaml")
 
 	// Reconcile config maps for log uploader
 	// Creat cm proxy-config-rest from envoy-config-rest.yaml
@@ -1043,20 +314,17 @@ func (t *telemetry) reconcileCCMGoConfigMaps(
 		logrus.WithError(err).Error("failed to creat cm proxy-config-rest from envoy-config-rest.yaml")
 		return err
 	}
-	logrus.Infof("JLIAO: creat cm proxy-config-rest from envoy-config-rest.yaml")
 	// Create cm tls-certificate from tls_certificate_sds_secret.yaml
 	if err := t.createCCMGoConfigMapTLSCertificate(cluster, ownerRef); err != nil {
 		logrus.WithError(err).Error("failed to creat cm proxy-config-rest from envoy-config-rest.yaml")
 		return err
 	}
-	logrus.Infof("JLIAO: create cm tls-certificate from tls_certificate_sds_secret.yaml")
 	// Create cm px-telemetry-config from ccm.properties and location
 	// CCM Java creates this cm as well, let's delete it and create a new one
 	if err := t.createCCMGoConfigMapPXTelemetryConfig(cluster, ownerRef); err != nil {
 		logrus.WithError(err).Error("failed to create cm px-telemetry-config from ccm.properties and location")
 		return err
 	}
-	logrus.Infof("JLIAO: create cm px-telemetry-config from ccm.properties and location")
 
 	return nil
 }
@@ -1070,13 +338,11 @@ func (t *telemetry) reconcileCCMGoDeployments(
 		logrus.WithError(err).Errorf("failed to create deployment %s/%s", cluster.Namespace, DeploymentNameRegistrationService)
 		return err
 	}
-	logrus.Infof("JLIAO: create deployment registration-service")
 	// create deployment phonehone-cluster
 	if err := t.createDeploymentPhonehomeCluster(cluster, ownerRef); err != nil {
 		logrus.WithError(err).Errorf("failed to create deployment %s/%s", cluster.Namespace, DeploymentNamePhonehomeCluster)
 		return err
 	}
-	logrus.Infof("JLIAO: create deployment phonehone-cluster")
 	return nil
 }
 
@@ -1263,10 +529,28 @@ func (t *telemetry) createDeploymentRegistrationService(
 		containers = append(containers, *c.DeepCopy())
 	}
 	deployment.Name = DeploymentNameRegistrationService
-	deployment.Namespace = cluster.Namespace
 	deployment.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	deployment.Spec.Template.Spec.Containers = containers
-	return k8sutil.CreateOrUpdateDeployment(t.k8sClient, deployment, ownerRef)
+	pxutil.ApplyStorageClusterSettings(cluster, deployment)
+
+	existingDeployment, err := k8sutil.GetDeployment(t.k8sClient, deployment)
+	if err != nil {
+		return err
+	}
+
+	equal, _ := util.DeepEqualDeployment(deployment, existingDeployment)
+	if !t.isDeploymentRegistrationServiceCreated || !equal {
+		logrus.WithFields(logrus.Fields{
+			"isCreated": t.isDeploymentRegistrationServiceCreated,
+			"equal":     equal,
+		}).Infof("will create/update the deployment %s/%s", deployment.Namespace, deployment.Name)
+		if err := k8sutil.CreateOrUpdateDeployment(t.k8sClient, deployment, ownerRef); err != nil {
+			return err
+		}
+	}
+
+	t.isDeploymentRegistrationServiceCreated = true
+	return nil
 }
 
 func (t *telemetry) createDeploymentPhonehomeCluster(
@@ -1304,11 +588,7 @@ func (t *telemetry) createDeploymentPhonehomeCluster(
 		containers = append(containers, *c.DeepCopy())
 	}
 	deployment.Name = DeploymentNamePhonehomeCluster
-	deployment.Namespace = cluster.Namespace
 	deployment.OwnerReferences = []metav1.OwnerReference{*ownerRef}
-	deployment.Spec.Template.Spec.Affinity = &v1.Affinity{
-		NodeAffinity: cluster.Spec.Placement.NodeAffinity,
-	}
 	deployment.Spec.Template.Spec.Containers = containers
 	deployment.Spec.Template.Spec.InitContainers = []v1.Container{{
 		Name:  "init-cont",
@@ -1334,8 +614,26 @@ func (t *telemetry) createDeploymentPhonehomeCluster(
 	}
 	num := int32(replicasCount)
 	deployment.Spec.Replicas = &num
+	pxutil.ApplyStorageClusterSettings(cluster, deployment)
 
-	return k8sutil.CreateOrUpdateDeployment(t.k8sClient, deployment, ownerRef)
+	existingDeployment, err := k8sutil.GetDeployment(t.k8sClient, deployment)
+	if err != nil {
+		return err
+	}
+
+	equal, _ := util.DeepEqualDeployment(deployment, existingDeployment)
+	if !t.isDeploymentPhonehonmeClusterCreated || !equal {
+		logrus.WithFields(logrus.Fields{
+			"isCreated": t.isDeploymentRegistrationServiceCreated,
+			"equal":     equal,
+		}).Infof("will create/update the deployment %s/%s", deployment.Namespace, deployment.Name)
+		if err := k8sutil.CreateOrUpdateDeployment(t.k8sClient, deployment, ownerRef); err != nil {
+			return err
+		}
+	}
+
+	t.isDeploymentRegistrationServiceCreated = true
+	return nil
 }
 
 func getArcusTelemetryLocation(cluster *corev1.StorageCluster) string {
@@ -1364,28 +662,26 @@ func getArcusRegisterProxyURL(cluster *corev1.StorageCluster) string {
 
 // GetDesiredTelemetryImage returns desired telemetry container image
 func GetDesiredTelemetryImage(cluster *corev1.StorageCluster) (string, error) {
-	if pxutil.IsTelemetryEnabled(cluster.Spec) {
-		if cluster.Spec.Monitoring.Telemetry.Image != "" {
-			return util.GetImageURN(cluster, cluster.Spec.Monitoring.Telemetry.Image), nil
-		}
-
-		if cluster.Status.DesiredImages != nil {
-			return util.GetImageURN(cluster, cluster.Status.DesiredImages.Telemetry), nil
-		}
+	if cluster.Spec.Monitoring.Telemetry.Image != "" {
+		return util.GetImageURN(cluster, cluster.Spec.Monitoring.Telemetry.Image), nil
 	}
+
+	if cluster.Status.DesiredImages != nil {
+		return util.GetImageURN(cluster, cluster.Status.DesiredImages.Telemetry), nil
+	}
+
 	return "", fmt.Errorf("telemetry image is empty")
 }
 
 func getDesiredLogUploaderImage(cluster *corev1.StorageCluster) (string, error) {
-	if pxutil.IsTelemetryEnabled(cluster.Spec) {
-		if cluster.Spec.Monitoring.Telemetry.ImageLogUpload != "" {
-			return util.GetImageURN(cluster, cluster.Spec.Monitoring.Telemetry.ImageLogUpload), nil
-		}
-
-		if cluster.Status.DesiredImages != nil {
-			return util.GetImageURN(cluster, cluster.Status.DesiredImages.LogUploader), nil
-		}
+	if cluster.Spec.Monitoring.Telemetry.LogUploaderImage != "" {
+		return util.GetImageURN(cluster, cluster.Spec.Monitoring.Telemetry.LogUploaderImage), nil
 	}
+
+	if cluster.Status.DesiredImages != nil {
+		return util.GetImageURN(cluster, cluster.Status.DesiredImages.LogUploader), nil
+	}
+
 	return "", fmt.Errorf("log uploader image is empty")
 }
 

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -1,0 +1,752 @@
+package component
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-version"
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/util"
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
+)
+
+const (
+	// TelemetryComponentName name of the telemetry component
+	TelemetryComponentName = "Portworx Telemetry"
+	// TelemetryCCMProxyConfigMapName is the name of the config map that stores the PX_HTTP(S)_PROXY env var
+	TelemetryCCMProxyConfigMapName = "px-ccm-service-proxy-config"
+	// TelemetryCCMProxyFilePath path of the http proxy file
+	TelemetryCCMProxyFilePath = "/cache/network/http_proxy"
+	// TelemetryCCMProxyFileName name of the http proxy file
+	TelemetryCCMProxyFileName = "http_proxy"
+	// CollectorRoleName is name of the Role for metrics collector.
+	CollectorRoleName = "px-metrics-collector"
+	// CollectorRoleBindingName is name of the role binding for metrics collector.
+	CollectorRoleBindingName = "px-metrics-collector"
+	// CollectorClusterRoleName name of the metrics collector cluster role
+	CollectorClusterRoleName = "px-metrics-collector"
+	// CollectorClusterRoleBindingName name of the metrics collector cluster role binding
+	CollectorClusterRoleBindingName = "px-metrics-collector"
+	// CollectorConfigFileName is file name of the collector pod config.
+	CollectorConfigFileName = "portworx.yaml"
+	// CollectorProxyConfigFileName is file name of envoy config.
+	CollectorProxyConfigFileName = "envoy-config.yaml"
+	// CollectorConfigMapName is name of config map for metrics collector.
+	CollectorConfigMapName = "px-collector-config"
+	// CollectorProxyConfigMapName is name of the config map for envoy proxy.
+	CollectorProxyConfigMapName = "px-collector-proxy-config"
+	// CollectorDeploymentName is name of metrics collector deployment.
+	CollectorDeploymentName = "px-metrics-collector"
+	// CollectorServiceAccountName is name of the metrics collector service account
+	CollectorServiceAccountName = "px-metrics-collector"
+	// TelemetryConfigMapName is the name of the config map that stores the telemetry configuration for CCM
+	TelemetryConfigMapName = "px-telemetry-config"
+	// TelemetryPropertiesFilename is the name of the CCM properties file
+	TelemetryPropertiesFilename = "ccm.properties"
+	// TelemetryArcusLocationFilename is name of the file storing the location of arcus endpoint to use
+	TelemetryArcusLocationFilename = "location"
+	// TelemetryCertName is name of the telemetry cert.
+	TelemetryCertName = "pure-telemetry-certs"
+
+	defaultCollectorMemoryRequest = "64Mi"
+	defaultCollectorMemoryLimit   = "128Mi"
+	defaultCollectorCPU           = "0.2"
+)
+
+// reconcileCCMJava installs CCM Java on older px versions
+func (t *telemetry) reconcileCCMJava(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	if err := t.createCCMJavaConfigMap(cluster, ownerRef); err != nil {
+		return err
+	}
+	if err := t.reconcileCCMJavaProxyConfigMap(cluster, ownerRef); err != nil {
+		return err
+	}
+	if err := t.deployMetricsCollector(cluster, ownerRef); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *telemetry) deleteCCMJava(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
+
+	if err := t.deleteMetricsCollector(cluster.Namespace, ownerRef); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *telemetry) deleteMetricsCollector(namespace string, ownerRef *metav1.OwnerReference) error {
+	if err := k8sutil.DeleteServiceAccount(t.k8sClient, CollectorServiceAccountName, namespace, *ownerRef); err != nil {
+		return err
+	}
+
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, CollectorProxyConfigMapName, namespace, *ownerRef); err != nil {
+		return err
+	}
+
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, CollectorConfigMapName, namespace, *ownerRef); err != nil {
+		return err
+	}
+
+	if err := k8sutil.DeleteRole(t.k8sClient, CollectorRoleName, namespace, *ownerRef); err != nil {
+		return err
+	}
+
+	if err := k8sutil.DeleteRoleBinding(t.k8sClient, CollectorRoleBindingName, namespace, *ownerRef); err != nil {
+		return err
+	}
+
+	if err := k8sutil.DeleteClusterRole(t.k8sClient, CollectorClusterRoleName); err != nil {
+		return err
+	}
+
+	if err := k8sutil.DeleteClusterRoleBinding(t.k8sClient, CollectorClusterRoleBindingName); err != nil {
+		return err
+	}
+
+	if err := k8sutil.DeleteDeployment(t.k8sClient, CollectorDeploymentName, namespace, *ownerRef); err != nil {
+		return err
+	}
+
+	t.isCollectorDeploymentCreated = false
+	return nil
+}
+
+func (t *telemetry) deployMetricsCollector(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	pxVer2_9_1, _ := version.NewVersion("2.9.1")
+	pxVersion := pxutil.GetPortworxVersion(cluster)
+	if pxVersion.LessThan(pxVer2_9_1) {
+		// Run metrics collector only for portworx version 2.9.1+
+		return nil
+	}
+
+	if len(cluster.Status.ClusterUID) == 0 {
+		logrus.Warn("clusterUID is empty, wait for it to fill collector proxy config")
+		return nil
+	}
+
+	if err := t.createCollectorServiceAccount(cluster.Namespace, ownerRef); err != nil {
+		return err
+	}
+
+	if err := t.createCCMJavaProxyConfigMap(cluster, ownerRef); err != nil {
+		return err
+	}
+
+	if err := t.createCollectorConfigMap(cluster, ownerRef); err != nil {
+		return err
+	}
+
+	if err := t.createCollectorRole(cluster, ownerRef); err != nil {
+		return err
+	}
+
+	if err := t.createCollectorRoleBinding(cluster, ownerRef); err != nil {
+		return err
+	}
+
+	if err := t.createCollectorClusterRole(); err != nil {
+		return err
+	}
+
+	if err := t.createCollectorClusterRoleBinding(cluster.Namespace); err != nil {
+		return err
+	}
+
+	if err := t.createCollectorDeployment(cluster, ownerRef); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (t *telemetry) createCollectorClusterRole() error {
+	return k8sutil.CreateOrUpdateClusterRole(
+		t.k8sClient,
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: CollectorClusterRoleName,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups:     []string{"security.openshift.io"},
+					Resources:     []string{"securitycontextconstraints"},
+					ResourceNames: []string{PxSCCName},
+					Verbs:         []string{"use"},
+				},
+				{
+					APIGroups:     []string{"policy"},
+					Resources:     []string{"podsecuritypolicies"},
+					ResourceNames: []string{constants.PrivilegedPSPName},
+					Verbs:         []string{"use"},
+				},
+			},
+		},
+	)
+}
+
+func (t *telemetry) createCollectorClusterRoleBinding(
+	clusterNamespace string,
+) error {
+	return k8sutil.CreateOrUpdateClusterRoleBinding(
+		t.k8sClient,
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: CollectorClusterRoleBindingName,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      CollectorServiceAccountName,
+					Namespace: clusterNamespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				Name:     CollectorClusterRoleName,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+	)
+}
+
+func (t *telemetry) createCollectorDeployment(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	deployment, err := t.getCollectorDeployment(cluster, ownerRef)
+	if err != nil {
+		return err
+	}
+
+	existingDeployment := &appsv1.Deployment{}
+	err = t.k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      CollectorDeploymentName,
+			Namespace: cluster.Namespace,
+		},
+		existingDeployment,
+	)
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	modified := false
+	if equal, _ := util.DeepEqualDeployment(deployment, existingDeployment); !equal {
+		modified = true
+	}
+
+	if !t.isCollectorDeploymentCreated || modified {
+		logrus.WithFields(logrus.Fields{
+			"isCreated": t.isCollectorDeploymentCreated,
+			"modified":  modified,
+		}).Info("will create/update the deployment.")
+		if err = k8sutil.CreateOrUpdateDeployment(t.k8sClient, deployment, ownerRef); err != nil {
+			return err
+		}
+	}
+
+	t.isCollectorDeploymentCreated = true
+	return nil
+}
+
+func (t *telemetry) createCollectorServiceAccount(
+	clusterNamespace string,
+	ownerRef *metav1.OwnerReference,
+) error {
+	return k8sutil.CreateOrUpdateServiceAccount(
+		t.k8sClient,
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            CollectorServiceAccountName,
+				Namespace:       clusterNamespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+		},
+		ownerRef,
+	)
+}
+
+func (t *telemetry) getCollectorDeployment(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) (*appsv1.Deployment, error) {
+	collectorImage, err := getDesiredCollectorImage(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	collectorProxyImage, err := getDesiredProxyImage(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	replicas := int32(1)
+	labels := map[string]string{
+		"role": "realtime-metrics-collector",
+	}
+	runAsUser := int64(1111)
+	cpuQuantity, err := resource.ParseQuantity(defaultCollectorCPU)
+	if err != nil {
+		return nil, err
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            CollectorDeploymentName,
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*ownerRef},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec: v1.PodSpec{
+					ServiceAccountName: CollectorServiceAccountName,
+					Containers: []v1.Container{
+						{
+							Name:  "collector",
+							Image: collectorImage,
+							SecurityContext: &v1.SecurityContext{
+								RunAsUser: &runAsUser,
+							},
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse(defaultCollectorMemoryRequest),
+									v1.ResourceCPU:    cpuQuantity,
+								},
+								Limits: v1.ResourceList{
+									v1.ResourceMemory: resource.MustParse(defaultCollectorMemoryLimit),
+								},
+							},
+
+							Env: []v1.EnvVar{
+								{
+									Name:  "CONFIG",
+									Value: "config/" + CollectorConfigFileName,
+								},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      CollectorConfigMapName,
+									MountPath: "/config",
+									ReadOnly:  true,
+								},
+							},
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "collector",
+									ContainerPort: 80,
+									Protocol:      "TCP",
+								},
+							},
+						},
+						{
+							Name:  "envoy",
+							Image: collectorProxyImage,
+							SecurityContext: &v1.SecurityContext{
+								RunAsUser: &runAsUser,
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      CollectorProxyConfigMapName,
+									MountPath: "/config",
+									ReadOnly:  true,
+								},
+								{
+									Name:      TelemetryCertName,
+									MountPath: "/appliance-cert",
+									ReadOnly:  true,
+								},
+							},
+							Args: []string{
+								"envoy",
+								"--config-path",
+								"/config/envoy-config.yaml",
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: CollectorConfigMapName,
+							VolumeSource: v1.VolumeSource{
+								ConfigMap: &v1.ConfigMapVolumeSource{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: CollectorConfigMapName,
+									},
+								},
+							},
+						},
+						{
+							Name: CollectorProxyConfigMapName,
+							VolumeSource: v1.VolumeSource{
+								ConfigMap: &v1.ConfigMapVolumeSource{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: CollectorProxyConfigMapName,
+									},
+								},
+							},
+						},
+						{
+							Name: TelemetryCertName,
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: TelemetryCertName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	pxutil.ApplyStorageClusterSettings(cluster, deployment)
+
+	return deployment, nil
+}
+
+func (t *telemetry) createCollectorRole(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	return k8sutil.CreateOrUpdateRole(
+		t.k8sClient,
+		&rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            CollectorRoleName,
+				Namespace:       cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get", "list"},
+				},
+			},
+		},
+		ownerRef,
+	)
+}
+
+func (t *telemetry) createCollectorRoleBinding(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	return k8sutil.CreateOrUpdateRoleBinding(
+		t.k8sClient,
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            CollectorRoleBindingName,
+				Namespace:       cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      CollectorServiceAccountName,
+					Namespace: cluster.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				Kind:     "Role",
+				Name:     CollectorRoleName,
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+		ownerRef,
+	)
+}
+
+func (t *telemetry) createCCMJavaProxyConfigMap(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	arcusRestProxyURL := getArcusRestProxyURL(cluster)
+	config := fmt.Sprintf(
+		`
+admin:
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 9901
+
+static_resources:
+  listeners:
+  - name: listener_cloud_support
+    address:
+      socket_address:
+        address: 127.0.0.1
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          access_log:
+          - name: envoy.access_loggers.stdout
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
+          http_filters:
+          - name: envoy.filters.http.router
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/"
+                request_headers_to_add:
+                - header:
+                   key: "product-name"
+                   value: "portworx"
+                - header:
+                   key: "appliance-id"
+                   value: "%s"
+                - header:
+                   key: "component-sn"
+                   value: "portworx-metrics-node"
+                - header:
+                   key: "product-version"
+                   value: "%s"
+                route:
+                  host_rewrite_literal: %s
+                  cluster: cluster_cloud_support
+  clusters:
+  - name: cluster_cloud_support
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: cluster_cloud_support
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: %s
+                port_value: 443
+    transport_socket:
+      name: envoy.transport_sockets.tls
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+        common_tls_context:
+          tls_certificates:
+          - certificate_chain:
+              filename: /appliance-cert/cert
+            private_key:
+              filename: /appliance-cert/private_key
+`, cluster.Status.ClusterUID, pxutil.GetPortworxVersion(cluster), arcusRestProxyURL, arcusRestProxyURL)
+
+	data := map[string]string{
+		CollectorProxyConfigFileName: config,
+	}
+
+	return k8sutil.CreateOrUpdateConfigMap(
+		t.k8sClient,
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            CollectorProxyConfigMapName,
+				Namespace:       cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Data: data,
+		},
+		ownerRef,
+	)
+}
+
+func (t *telemetry) createCollectorConfigMap(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	pxSelectorLabels := pxutil.SelectorLabels()
+	var selectorStr string
+	for k, v := range pxSelectorLabels {
+		selectorStr += fmt.Sprintf("\n        %s: %s", k, v)
+	}
+
+	port := pxutil.StartPort(cluster)
+
+	config := fmt.Sprintf(
+		`
+scrapeConfig:
+  interval: 10
+  k8sConfig:
+    pods:
+    - podSelector:%s
+      namespace: %s
+      endpoint: metrics
+      port: %d
+forwardConfig:
+  url: http://localhost:10000/metrics/1.0/pure1-metrics-pb`,
+		selectorStr,
+		cluster.Namespace,
+		port)
+
+	data := map[string]string{
+		CollectorConfigFileName: config,
+	}
+
+	return k8sutil.CreateOrUpdateConfigMap(
+		t.k8sClient,
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            CollectorConfigMapName,
+				Namespace:       cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Data: data,
+		},
+		ownerRef,
+	)
+}
+
+func (t *telemetry) createCCMJavaConfigMap(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	config := fmt.Sprintf(`{
+      "product_name": "portworx",
+       "logging": {
+         "array_info_path": "/dev/null"
+       },
+       "features": {
+         "appliance_info": "config",
+         "cert_store": "k8s",
+         "config_reload": "file",
+         "env_info": "file",
+         "scheduled_log_uploader":"disabled",
+         "upload": "enabled"
+       },
+      "cert": {
+        "activation": {
+              "private": "/dev/null",
+              "public": "/dev/null"
+        },
+        "registration_enabled": "true",
+        "no_rel_cert_enabled": "true",
+        "appliance": {
+          "current_cert_dir": "/etc/pwx/ccm/cert"
+        }
+      },
+      "k8s": {
+        "cert_secret_name": "pure-telemetry-certs",
+        "cert_secret_namespace": "%s"
+     },
+     "cloud": {
+       "array_loc_file_path": "/etc/ccm/%s"
+     },
+      "server": {
+        "hostname": "0.0.0.0"
+      },
+      "logupload": {
+        "logfile_patterns": [
+            "/var/cores/*diags*",
+            "/var/cores/auto/*diags*",
+            "/var/cores/*px-cores*",
+            "/var/cores/*.heap",
+            "/var/cores/*.stack",
+            "/var/cores/.alerts/alerts*"
+        ],
+        "skip_patterns": [],
+        "additional_files": [
+            "/etc/pwx/config.json",
+            "/var/cores/.alerts/alerts.log",
+            "/var/cores/px_etcd_watch.log",
+            "/var/cores/px_cache_mon.log",
+            "/var/cores/px_cache_mon_watch.log",
+            "/var/cores/px_healthmon_watch.log",
+            "/var/cores/px_event_watch.log"
+        ],
+        "phonehome_sent": "/var/cache/phonehome.sent"
+      },
+      "xml_rpc": {},
+      "standalone": {
+        "version": "1.0.0",
+        "controller_sn": "SA-0",
+        "component_name": "SA-0",
+        "product_name": "portworx",
+        "appliance_id_path": "/etc/pwx/cluster_uuid"
+      },
+      "subscription": {
+        "use_appliance_id": "true"
+      },
+      "proxy": {
+        "path": "/cache/network/http_proxy"
+      }
+    }
+`, cluster.Namespace, TelemetryArcusLocationFilename)
+
+	data := map[string]string{
+		TelemetryPropertiesFilename:    config,
+		TelemetryArcusLocationFilename: getArcusTelemetryLocation(cluster),
+	}
+
+	return k8sutil.CreateOrUpdateConfigMap(
+		t.k8sClient,
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            TelemetryConfigMapName,
+				Namespace:       cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Data: data,
+		},
+		ownerRef,
+	)
+}
+
+func (t *telemetry) reconcileCCMJavaProxyConfigMap(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+) error {
+	proxy := pxutil.GetPxProxyEnvVarValue(cluster)
+	// Delete the existing config map if portworx proxy is empty
+	if proxy == "" {
+		return k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef)
+	}
+
+	return k8sutil.CreateOrUpdateConfigMap(
+		t.k8sClient,
+		&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            TelemetryCCMProxyConfigMapName,
+				Namespace:       cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Data: map[string]string{
+				TelemetryCCMProxyFileName: proxy,
+			},
+		},
+		ownerRef,
+	)
+}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12418,11 +12418,30 @@ func TestTelemetryCCMProxy(t *testing.T) {
 }
 
 func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
-	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
-	reregisterComponents()
-	k8sClient := testutil.FakeK8sClient()
-	driver := portworx{}
-	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockNodeServer := mock.NewMockOpenStorageNodeServer(mockCtrl)
+	sdkServerIP := "127.0.0.1"
+	sdkServerPort := 9020
+	mockSdk := mock.NewSdkServer(mock.SdkServers{
+		Node: mockNodeServer,
+	})
+	mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
+	defer mockSdk.Stop()
+
+	fakeK8sNodes := &v1.NodeList{Items: []v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+	}}
+	expectedNodeEnumerateResp := &osdapi.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*osdapi.StorageNode{
+			{SchedulerNodeName: "node1"},
+		},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &osdapi.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		AnyTimes()
 
 	cluster := &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -12441,6 +12460,26 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 			ClusterUID: "test-clusteruid",
 		},
 	}
+	k8sClient := testutil.FakeK8sClient(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pxutil.PortworxServiceName,
+			Namespace: cluster.Namespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: sdkServerIP,
+			Ports: []v1.ServicePort{
+				{
+					Name: pxutil.PortworxSDKPortName,
+					Port: int32(sdkServerPort),
+				},
+			},
+		},
+	}, fakeK8sNodes)
+
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
 
 	// This cert is created by ccm container outside of operator, let's simulate it.
 	k8sClient.Create(
@@ -12597,11 +12636,30 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 }
 
 func TestTelemetryCCMGoUpgrade(t *testing.T) {
-	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
-	reregisterComponents()
-	k8sClient := testutil.FakeK8sClient()
-	driver := portworx{}
-	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockNodeServer := mock.NewMockOpenStorageNodeServer(mockCtrl)
+	sdkServerIP := "127.0.0.1"
+	sdkServerPort := 9020
+	mockSdk := mock.NewSdkServer(mock.SdkServers{
+		Node: mockNodeServer,
+	})
+	mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
+	defer mockSdk.Stop()
+
+	fakeK8sNodes := &v1.NodeList{Items: []v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+	}}
+	expectedNodeEnumerateResp := &osdapi.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*osdapi.StorageNode{
+			{SchedulerNodeName: "node1"},
+		},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &osdapi.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		AnyTimes()
 
 	// Deploy px with CCM Java enabled and telemetry image specified
 	cluster := &corev1.StorageCluster{
@@ -12622,6 +12680,26 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 			ClusterUID: "test-clusteruid",
 		},
 	}
+	k8sClient := testutil.FakeK8sClient(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pxutil.PortworxServiceName,
+			Namespace: cluster.Namespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: sdkServerIP,
+			Ports: []v1.ServicePort{
+				{
+					Name: pxutil.PortworxSDKPortName,
+					Port: int32(sdkServerPort),
+				},
+			},
+		},
+	}, fakeK8sNodes)
+
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
 
 	// This cert is created by ccm container outside of operator, let's simulate it.
 	k8sClient.Create(

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -287,7 +287,7 @@ func (p *portworx) GetStoragePodSpec(
 		}
 	}
 
-	if pxutil.IsTelemetryEnabled(cluster.Spec) {
+	if pxutil.IsTelemetryEnabled(cluster.Spec) && !pxutil.RunCCMGo(cluster) {
 		telemetryContainer := t.telemetryContainer()
 		if telemetryContainer != nil {
 			if len(telemetryContainer.Image) == 0 {
@@ -296,7 +296,6 @@ func (p *portworx) GetStoragePodSpec(
 				p.warningEvent(cluster, util.FailedComponentReason, msg)
 			} else {
 				podSpec.Containers = append(podSpec.Containers, *telemetryContainer)
-
 			}
 		}
 	}
@@ -601,12 +600,10 @@ func (t *template) csiRegistrarContainer() *v1.Container {
 }
 
 func (t *template) telemetryContainer() *v1.Container {
+	telemetryImage, _ := component.GetDesiredTelemetryImage(t.cluster)
 	container := v1.Container{
-		Name: pxutil.TelemetryContainerName,
-		Image: util.GetImageURN(
-			t.cluster,
-			t.getDesiredTelemetryImage(t.cluster),
-		),
+		Name:            pxutil.TelemetryContainerName,
+		Image:           telemetryImage,
 		ImagePullPolicy: t.imagePullPolicy,
 		Resources: v1.ResourceRequirements{
 			Requests: v1.ResourceList{
@@ -1542,20 +1539,6 @@ func (t *template) loadKvdbAuth() map[string]string {
 		t.kvdb[k] = string(v)
 	}
 	return t.kvdb
-}
-
-func (t *template) getDesiredTelemetryImage(cluster *corev1.StorageCluster) string {
-	if pxutil.IsTelemetryEnabled(cluster.Spec) {
-		if cluster.Spec.Monitoring.Telemetry.Image != "" {
-			return cluster.Spec.Monitoring.Telemetry.Image
-		}
-
-		if cluster.Status.DesiredImages != nil {
-			return cluster.Status.DesiredImages.Telemetry
-		}
-	}
-
-	return ""
 }
 
 func (t *template) setOSImage(osImage string) {

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -287,7 +287,7 @@ func (p *portworx) GetStoragePodSpec(
 		}
 	}
 
-	if pxutil.IsTelemetryEnabled(cluster.Spec) && !pxutil.RunCCMGo(cluster) {
+	if pxutil.IsTelemetryEnabled(cluster.Spec) && !pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster)) {
 		telemetryContainer := t.telemetryContainer()
 		if telemetryContainer != nil {
 			if len(telemetryContainer.Image) == 0 {

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2503,16 +2503,10 @@ func TestPodWithTelemetryUpgrade(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 	assertPodSpecEqual(t, expected, &actual)
 
-	// Upgrade px version, ccm upgrade should be blocked as telemetry image specified
+	// Upgrade px version, ccm should upgrade and reset telemetry image specified, ccm container should be removed
 	cluster.Spec.Image = "portworx/oci-monitor:2.12.0"
 	driver.SetDefaultsOnStorageCluster(cluster)
-	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
-	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
-	require.Equal(t, len(expected.Containers), len(actual.Containers))
-
-	// Remove telemetry image, ccm should upgrade and telemetry container should be removed from px pod
-	cluster.Spec.Monitoring.Telemetry.Image = ""
-	driver.SetDefaultsOnStorageCluster(cluster)
+	require.Empty(t, cluster.Spec.Monitoring.Telemetry.Image)
 	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 	require.Equal(t, len(expected.Containers)-1, len(actual.Containers))

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2469,6 +2469,63 @@ func TestPodWithTelemetry(t *testing.T) {
 	assertPodSpecEqual(t, expected, &actual)
 }
 
+func TestPodWithTelemetryUpgrade(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.18.4",
+	}
+	expected := getExpectedPodSpecFromDaemonset(t, "testspec/px_telemetry.yaml")
+	nodeName := "testNode"
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-system",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/oci-monitor:2.8.0",
+			Monitoring: &corev1.MonitoringSpec{
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: true,
+					Image:   "portworx/px-telemetry:2.1.2",
+				},
+			},
+			CSI: &corev1.CSISpec{
+				Enabled: false,
+			},
+		},
+	}
+	driver := portworx{}
+	driver.SetDefaultsOnStorageCluster(cluster)
+
+	actual, err := driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+	assertPodSpecEqual(t, expected, &actual)
+
+	// Upgrade px version, ccm upgrade should be blocked as telemetry image specified
+	cluster.Spec.Image = "portworx/oci-monitor:2.12.0"
+	driver.SetDefaultsOnStorageCluster(cluster)
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+	require.Equal(t, len(expected.Containers), len(actual.Containers))
+
+	// Remove telemetry image, ccm should upgrade and telemetry container should be removed from px pod
+	cluster.Spec.Monitoring.Telemetry.Image = ""
+	driver.SetDefaultsOnStorageCluster(cluster)
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+	require.Equal(t, len(expected.Containers)-1, len(actual.Containers))
+
+	// Disable telemetry
+	expected = getExpectedPodSpecFromDaemonset(t, "testspec/px_disable_telemetry.yaml")
+	cluster.Spec.Monitoring.Telemetry.Enabled = false
+	driver.SetDefaultsOnStorageCluster(cluster)
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+	require.Equal(t, len(expected.Containers), len(actual.Containers))
+}
+
 func TestPodSpecWhenRunningOnMasterEnabled(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	expected := getExpectedPodSpecFromDaemonset(t, "testspec/px_master.yaml")

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -20,7 +20,7 @@ import (
 const (
 	// envKeyReleaseManifestURL is an environment variable to override the
 	// default release manifest download URL
-	envKeyReleaseManifestURL             = "PX_RELEASE_MANIFEST_URL"
+	envKeyReleaseManifestURL             = pxutil.EnvKeyPXReleaseManifestURL
 	envKeyReleaseManifestRefreshInterval = "PX_RELEASE_MANIFEST_REFRESH_INTERVAL_MINS"
 	// DefaultPortworxVersion is the default portworx version that will be used
 	// if none specified and if version manifest could not be fetched
@@ -311,8 +311,7 @@ func fillTelemetryDefaults(
 	rel *Version,
 ) {
 	pxVersion, err := version.NewSemver(rel.PortworxVersion)
-	if err != nil || !pxutil.IsCCMGoSupported(pxVersion) {
-		// Old CCM Java telemetry
+	if err == nil && !pxutil.IsCCMGoSupported(pxVersion) {
 		if rel.Components.Telemetry == "" {
 			rel.Components.Telemetry = defaultCCMJavaImage
 		}
@@ -323,7 +322,6 @@ func fillTelemetryDefaults(
 			rel.Components.MetricsCollectorProxy = defaultCollectorProxyImage
 		}
 	} else {
-		// New CCM Go telemetry
 		if rel.Components.Telemetry == "" {
 			rel.Components.Telemetry = defaultCCMGoImage
 		}

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -29,9 +29,12 @@ const (
 	defaultAutopilotImage      = "portworx/autopilot:1.3.2.1"
 	defaultLighthouseImage     = "portworx/px-lighthouse:2.0.7"
 	defaultNodeWiperImage      = "portworx/px-node-wiper:2.10.0"
-	defaultTelemetryImage      = "purestorage/ccm-service:3.2.11"
+	defaultCCMJavaImage        = "purestorage/ccm-service:3.2.11"
 	defaultCollectorProxyImage = "envoyproxy/envoy:v1.21.4"
 	defaultCollectorImage      = "purestorage/realtime-metrics:1.0.1"
+	defaultCCMGoImage          = "purestorage/ccm-go:1.0.0"
+	defaultLogUploaderImage    = "purestorage/log-upload:1.0.0"
+	defaultCCMGoProxyImage     = "envoyproxy/envoy:v1.22.2"
 	defaultPxRepoImage         = "portworx/px-repo:1.1.0"
 
 	// DefaultPrometheusOperatorImage is the default Prometheus operator image for k8s 1.21 and below
@@ -77,6 +80,8 @@ type Release struct {
 	Telemetry                  string `yaml:"telemetry,omitempty"`
 	MetricsCollector           string `yaml:"metricsCollector,omitempty"`
 	MetricsCollectorProxy      string `yaml:"metricsCollectorProxy,omitempty"`
+	LogUploader                string `yaml:"logUploader,omitempty"`
+	TelemetryProxy             string `yaml:"telemetryProxy,omitempty"` // Use a new field for easy backward compatibility
 	PxRepo                     string `yaml:"pxRepo,omitempty"`
 }
 
@@ -205,18 +210,16 @@ func defaultRelease(
 	rel := &Version{
 		PortworxVersion: DefaultPortworxVersion,
 		Components: Release{
-			Stork:                 defaultStorkImage,
-			Autopilot:             defaultAutopilotImage,
-			Lighthouse:            defaultLighthouseImage,
-			NodeWiper:             defaultNodeWiperImage,
-			Telemetry:             defaultTelemetryImage,
-			MetricsCollector:      defaultCollectorImage,
-			MetricsCollectorProxy: defaultCollectorProxyImage,
-			PxRepo:                defaultPxRepoImage,
+			Stork:      defaultStorkImage,
+			Autopilot:  defaultAutopilotImage,
+			Lighthouse: defaultLighthouseImage,
+			NodeWiper:  defaultNodeWiperImage,
+			PxRepo:     defaultPxRepoImage,
 		},
 	}
 	fillCSIDefaults(rel, k8sVersion)
 	fillPrometheusDefaults(rel, k8sVersion)
+	fillTelemetryDefaults(rel)
 	return rel
 }
 
@@ -236,20 +239,12 @@ func fillDefaults(
 	if rel.Components.NodeWiper == "" {
 		rel.Components.NodeWiper = defaultNodeWiperImage
 	}
-	if rel.Components.Telemetry == "" {
-		rel.Components.Telemetry = defaultTelemetryImage
-	}
-	if rel.Components.MetricsCollector == "" {
-		rel.Components.MetricsCollector = defaultCollectorImage
-	}
-	if rel.Components.MetricsCollectorProxy == "" {
-		rel.Components.MetricsCollectorProxy = defaultCollectorProxyImage
-	}
 	if rel.Components.PxRepo == "" {
 		rel.Components.PxRepo = defaultPxRepoImage
 	}
 	fillCSIDefaults(rel, k8sVersion)
 	fillPrometheusDefaults(rel, k8sVersion)
+	fillTelemetryDefaults(rel)
 }
 
 func fillCSIDefaults(
@@ -309,6 +304,35 @@ func fillPrometheusDefaults(
 	}
 	if rel.Components.AlertManager == "" {
 		rel.Components.AlertManager = defaultAlertManagerImage
+	}
+}
+
+func fillTelemetryDefaults(
+	rel *Version,
+) {
+	pxVersion, err := version.NewSemver(rel.PortworxVersion)
+	if err != nil || !pxutil.IsCCMGoSupported(pxVersion) {
+		// Old CCM Java telemetry
+		if rel.Components.Telemetry == "" {
+			rel.Components.Telemetry = defaultCCMJavaImage
+		}
+		if rel.Components.MetricsCollector == "" {
+			rel.Components.MetricsCollector = defaultCollectorImage
+		}
+		if rel.Components.MetricsCollectorProxy == "" {
+			rel.Components.MetricsCollectorProxy = defaultCollectorProxyImage
+		}
+	} else {
+		// New CCM Go telemetry
+		if rel.Components.Telemetry == "" {
+			rel.Components.Telemetry = defaultCCMGoImage
+		}
+		if rel.Components.LogUploader == "" {
+			rel.Components.LogUploader = defaultLogUploaderImage
+		}
+		if rel.Components.TelemetryProxy == "" {
+			rel.Components.TelemetryProxy = defaultCCMGoProxyImage
+		}
 	}
 }
 

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -251,9 +251,9 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			PrometheusConfigMapReload: "image/configmap-reload:2.6.0",
 			PrometheusConfigReloader:  "image/prometheus-config-reloader:2.6.0",
 			AlertManager:              "image/alertmanager:2.6.0",
-			Telemetry:                 "image/ccm-service:3.2.11",
-			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
-			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
+			Telemetry:                 "image/ccm-go:1.0.0",
+			TelemetryProxy:            "envoyproxy/envoy:v1.22.2",
+			LogUploader:               "purestorage/log-upload:1.0.0",
 			PxRepo:                    "portworx/px-repo:1.1.0",
 		},
 	}
@@ -767,6 +767,21 @@ func TestManifestFillTelemetryDefaults(t *testing.T) {
 	// TestCase: default CCM Go images
 	expected = &Version{
 		PortworxVersion: "2.12.0",
+	}
+	cluster.Spec.Image = "px/image:" + expected.PortworxVersion
+	body, _ = yaml.Marshal(expected)
+	versionsConfigMap.Data[VersionConfigMapKey] = string(body)
+	k8sClient.Update(context.TODO(), versionsConfigMap)
+	rel = m.GetVersions(cluster, true)
+	require.Equal(t, defaultCCMGoImage, rel.Components.Telemetry)
+	require.Equal(t, defaultCCMGoProxyImage, rel.Components.TelemetryProxy)
+	require.Equal(t, defaultLogUploaderImage, rel.Components.LogUploader)
+	require.Empty(t, rel.Components.MetricsCollector)
+	require.Empty(t, rel.Components.MetricsCollectorProxy)
+
+	// TestCase: default non-SemVerCCM use run CCM Go images
+	expected = &Version{
+		PortworxVersion: "abc_abc",
 	}
 	cluster.Spec.Image = "px/image:" + expected.PortworxVersion
 	body, _ = yaml.Marshal(expected)

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -362,7 +362,7 @@ func TestManifestWithoutPortworxVersion(t *testing.T) {
 
 func TestManifestWithPartialComponents(t *testing.T) {
 	expected := &Version{
-		PortworxVersion: "3.0.0",
+		PortworxVersion: "2.11.0",
 	}
 
 	k8sVersion, _ := version.NewSemver("1.16.8")
@@ -409,7 +409,7 @@ func TestManifestWithPartialComponents(t *testing.T) {
 	require.Equal(t, defaultPrometheusConfigMapReloadImage, rel.Components.PrometheusConfigMapReload)
 	require.Equal(t, defaultPrometheusConfigReloaderImage, rel.Components.PrometheusConfigReloader)
 	require.Equal(t, defaultAlertManagerImage, rel.Components.AlertManager)
-	require.Equal(t, defaultTelemetryImage, rel.Components.Telemetry)
+	require.Equal(t, defaultCCMJavaImage, rel.Components.Telemetry)
 	require.Equal(t, "image/csiprovisioner:3.0.0", rel.Components.CSIProvisioner)
 	require.Empty(t, rel.Components.CSIAttacher)
 
@@ -730,6 +730,54 @@ func TestManifestOnCacheExpiryAndOlderVersion(t *testing.T) {
 	os.Setenv(envKeyReleaseManifestRefreshInterval, "0")
 	rel = m.GetVersions(cluster, false)
 	require.Equal(t, "image/stork:2.5.1", rel.Components.Stork)
+}
+
+func TestManifestFillTelemetryDefaults(t *testing.T) {
+	k8sVersion, _ := version.NewSemver("1.20.0")
+	expected := &Version{
+		PortworxVersion: "2.9.0",
+	}
+	cluster := &corev1.StorageCluster{
+		Spec: corev1.StorageClusterSpec{
+			Image: "px/image:" + expected.PortworxVersion,
+		},
+	}
+	body, _ := yaml.Marshal(expected)
+	versionsConfigMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DefaultConfigMapName,
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string]string{
+			VersionConfigMapKey: string(body),
+		},
+	}
+	k8sClient := testutil.FakeK8sClient(versionsConfigMap)
+
+	// TestCase: default CCM Java images
+	m := Instance()
+	m.Init(k8sClient, nil, k8sVersion)
+	rel := m.GetVersions(cluster, true)
+	require.Equal(t, defaultCCMJavaImage, rel.Components.Telemetry)
+	require.Equal(t, defaultCollectorProxyImage, rel.Components.MetricsCollectorProxy)
+	require.Equal(t, defaultCollectorImage, rel.Components.MetricsCollector)
+	require.Empty(t, rel.Components.LogUploader)
+	require.Empty(t, rel.Components.TelemetryProxy)
+
+	// TestCase: default CCM Go images
+	expected = &Version{
+		PortworxVersion: "2.12.0",
+	}
+	cluster.Spec.Image = "px/image:" + expected.PortworxVersion
+	body, _ = yaml.Marshal(expected)
+	versionsConfigMap.Data[VersionConfigMapKey] = string(body)
+	k8sClient.Update(context.TODO(), versionsConfigMap)
+	rel = m.GetVersions(cluster, true)
+	require.Equal(t, defaultCCMGoImage, rel.Components.Telemetry)
+	require.Equal(t, defaultCCMGoProxyImage, rel.Components.TelemetryProxy)
+	require.Equal(t, defaultLogUploaderImage, rel.Components.LogUploader)
+	require.Empty(t, rel.Components.MetricsCollector)
+	require.Empty(t, rel.Components.MetricsCollectorProxy)
 }
 
 func TestMain(m *testing.M) {

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -181,13 +181,6 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			*toUpdate.Spec.AutoUpdateComponents == corev1.OnceAutoUpdate)
 		release := manifest.Instance().GetVersions(toUpdate, force)
 
-		logrus.Infof("JLIAO: versions in set px default: %s", release.Components)
-		logrus.Infof("JLIAO: has component changed %v", p.hasComponentChanged(toUpdate))
-		logrus.Infof("JLIAO: telemetry , auto update: %v, has changed: %v", autoUpdateTelemetry(toUpdate), hasTelemetryChanged(toUpdate))
-		logrus.Infof("JLIAO: telemetry proxy, auto update: %v, has changed: %v", autoUpdateTelemetryProxy(toUpdate), hasTelemetryProxyChanged(toUpdate))
-		logrus.Infof("JLIAO: metrics, auto update: %v, has changed: %v", autoUpdateMetricsCollector(toUpdate), hasMetricsCollectorChanged(toUpdate))
-		logrus.Infof("JLIAO: log uploader, auto update: %v, has changed: %v", autoUpdateLogUploader(toUpdate), hasLogUploaderChanged(toUpdate))
-
 		if toUpdate.Spec.Version == "" && pxEnabled {
 			if toUpdate.Spec.Image == "" {
 				toUpdate.Spec.Image = defaultPortworxImage
@@ -223,29 +216,15 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			(toUpdate.Status.DesiredImages.Telemetry == "" ||
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
-			logrus.Infof("JLIAO: set telemetry desired image: %s", release.Components.Telemetry)
 			toUpdate.Status.DesiredImages.Telemetry = release.Components.Telemetry
 		}
 
-		// Set desired telemetry proxy to determine whether to reconcile ccm java or go
-		// if desired telemetry proxy is empty, then run ccm java, otherwise ccm go
 		if autoUpdateTelemetryProxy(toUpdate) &&
 			(toUpdate.Status.DesiredImages.TelemetryProxy == "" ||
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
-			// Check if old ccm image is specified, if yes ccm upgrade should be blocked
-			// TODO: do we have a better way instead of checking the image?
-			blockTelemetryUpgrade := toUpdate.Spec.Monitoring.Telemetry.Image != "" &&
-				!strings.Contains(toUpdate.Spec.Monitoring.Telemetry.Image, "ccm-go")
-			if blockTelemetryUpgrade {
-				logrus.Infof("ccm upgrade is blocked as the telemetry image is specified, will continue running old telemetry ")
-			} else {
-				logrus.Infof("JLIAO: set telemetry proxy desired image: %s", release.Components.Telemetry)
-				toUpdate.Status.DesiredImages.TelemetryProxy = release.Components.TelemetryProxy
-			}
+			toUpdate.Status.DesiredImages.TelemetryProxy = release.Components.TelemetryProxy
 		}
-		logrus.Infof("JLIAO: px version: %s", pxutil.GetPortworxVersion(toUpdate))
-		logrus.Infof("JLIAO: ccm-go supported: %v", pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(toUpdate)))
 
 		if autoUpdateMetricsCollector(toUpdate) &&
 			(toUpdate.Status.DesiredImages.MetricsCollector == "" ||
@@ -260,7 +239,6 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			(toUpdate.Status.DesiredImages.LogUploader == "" ||
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
-			logrus.Infof("JLIAO: set loguploader desired image: %s", release.Components.LogUploader)
 			toUpdate.Status.DesiredImages.LogUploader = release.Components.LogUploader
 		}
 
@@ -1068,8 +1046,17 @@ func autoUpdateAutopilot(cluster *corev1.StorageCluster) bool {
 }
 
 func autoUpdateTelemetry(cluster *corev1.StorageCluster) bool {
-	return pxutil.IsTelemetryEnabled(cluster.Spec) &&
-		cluster.Spec.Monitoring.Telemetry.Image == ""
+	if pxutil.IsTelemetryEnabled(cluster.Spec) {
+		if cluster.Spec.Monitoring.Telemetry.Image == "" {
+			return true
+		} else if pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster)) &&
+			!strings.Contains(cluster.Spec.Monitoring.Telemetry.Image, "ccm-go") {
+			// reset telemetry image when new ccm is supported but old ccm image is set explicitly
+			cluster.Spec.Monitoring.Telemetry.Image = ""
+			return true
+		}
+	}
+	return false
 }
 
 func autoUpdateTelemetryProxy(cluster *corev1.StorageCluster) bool {
@@ -1079,14 +1066,13 @@ func autoUpdateTelemetryProxy(cluster *corev1.StorageCluster) bool {
 
 func autoUpdateMetricsCollector(cluster *corev1.StorageCluster) bool {
 	return pxutil.IsTelemetryEnabled(cluster.Spec) &&
-		!pxutil.RunCCMGo(cluster)
+		!pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster))
 }
 
 func autoUpdateLogUploader(cluster *corev1.StorageCluster) bool {
 	return pxutil.IsTelemetryEnabled(cluster.Spec) &&
 		pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster)) &&
-		pxutil.RunCCMGo(cluster) &&
-		cluster.Spec.Monitoring.Telemetry.ImageLogUpload == ""
+		cluster.Spec.Monitoring.Telemetry.LogUploaderImage == ""
 }
 
 func autoUpdatePxRepo(cluster *corev1.StorageCluster) bool {

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -181,6 +181,13 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			*toUpdate.Spec.AutoUpdateComponents == corev1.OnceAutoUpdate)
 		release := manifest.Instance().GetVersions(toUpdate, force)
 
+		logrus.Infof("JLIAO: versions in set px default: %s", release.Components)
+		logrus.Infof("JLIAO: has component changed %v", p.hasComponentChanged(toUpdate))
+		logrus.Infof("JLIAO: telemetry , auto update: %v, has changed: %v", autoUpdateTelemetry(toUpdate), hasTelemetryChanged(toUpdate))
+		logrus.Infof("JLIAO: telemetry proxy, auto update: %v, has changed: %v", autoUpdateTelemetryProxy(toUpdate), hasTelemetryProxyChanged(toUpdate))
+		logrus.Infof("JLIAO: metrics, auto update: %v, has changed: %v", autoUpdateMetricsCollector(toUpdate), hasMetricsCollectorChanged(toUpdate))
+		logrus.Infof("JLIAO: log uploader, auto update: %v, has changed: %v", autoUpdateLogUploader(toUpdate), hasLogUploaderChanged(toUpdate))
+
 		if toUpdate.Spec.Version == "" && pxEnabled {
 			if toUpdate.Spec.Image == "" {
 				toUpdate.Spec.Image = defaultPortworxImage
@@ -188,6 +195,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			toUpdate.Spec.Image = toUpdate.Spec.Image + ":" + release.PortworxVersion
 			toUpdate.Spec.Version = release.PortworxVersion
 		}
+
 		toUpdate.Status.Version = toUpdate.Spec.Version
 
 		if autoUpdateStork(toUpdate) &&
@@ -215,8 +223,29 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			(toUpdate.Status.DesiredImages.Telemetry == "" ||
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
+			logrus.Infof("JLIAO: set telemetry desired image: %s", release.Components.Telemetry)
 			toUpdate.Status.DesiredImages.Telemetry = release.Components.Telemetry
 		}
+
+		// Set desired telemetry proxy to determine whether to reconcile ccm java or go
+		// if desired telemetry proxy is empty, then run ccm java, otherwise ccm go
+		if autoUpdateTelemetryProxy(toUpdate) &&
+			(toUpdate.Status.DesiredImages.TelemetryProxy == "" ||
+				pxVersionChanged ||
+				autoUpdateComponents(toUpdate)) {
+			// Check if old ccm image is specified, if yes ccm upgrade should be blocked
+			// TODO: do we have a better way instead of checking the image?
+			blockTelemetryUpgrade := toUpdate.Spec.Monitoring.Telemetry.Image != "" &&
+				!strings.Contains(toUpdate.Spec.Monitoring.Telemetry.Image, "ccm-go")
+			if blockTelemetryUpgrade {
+				logrus.Infof("ccm upgrade is blocked as the telemetry image is specified, will continue running old telemetry ")
+			} else {
+				logrus.Infof("JLIAO: set telemetry proxy desired image: %s", release.Components.Telemetry)
+				toUpdate.Status.DesiredImages.TelemetryProxy = release.Components.TelemetryProxy
+			}
+		}
+		logrus.Infof("JLIAO: px version: %s", pxutil.GetPortworxVersion(toUpdate))
+		logrus.Infof("JLIAO: ccm-go supported: %v", pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(toUpdate)))
 
 		if autoUpdateMetricsCollector(toUpdate) &&
 			(toUpdate.Status.DesiredImages.MetricsCollector == "" ||
@@ -225,6 +254,14 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 				autoUpdateComponents(toUpdate)) {
 			toUpdate.Status.DesiredImages.MetricsCollector = release.Components.MetricsCollector
 			toUpdate.Status.DesiredImages.MetricsCollectorProxy = release.Components.MetricsCollectorProxy
+		}
+
+		if autoUpdateLogUploader(toUpdate) &&
+			(toUpdate.Status.DesiredImages.LogUploader == "" ||
+				pxVersionChanged ||
+				autoUpdateComponents(toUpdate)) {
+			logrus.Infof("JLIAO: set loguploader desired image: %s", release.Components.LogUploader)
+			toUpdate.Status.DesiredImages.LogUploader = release.Components.LogUploader
 		}
 
 		if autoUpdatePxRepo(toUpdate) &&
@@ -294,9 +331,17 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 		toUpdate.Status.DesiredImages.Telemetry = ""
 	}
 
+	if !autoUpdateTelemetryProxy(toUpdate) {
+		toUpdate.Status.DesiredImages.TelemetryProxy = ""
+	}
+
 	if !autoUpdateMetricsCollector(toUpdate) {
 		toUpdate.Status.DesiredImages.MetricsCollector = ""
 		toUpdate.Status.DesiredImages.MetricsCollectorProxy = ""
+	}
+
+	if !autoUpdateLogUploader(toUpdate) {
+		toUpdate.Status.DesiredImages.LogUploader = ""
 	}
 
 	if !autoUpdatePxRepo(toUpdate) {
@@ -640,8 +685,7 @@ func SetPortworxDefaults(toUpdate *corev1.StorageCluster, k8sVersion *version.Ve
 		}
 	}
 
-	pxVer2_8, _ := version.NewVersion("2.8")
-	if pxutil.IsTelemetryEnabled(toUpdate.Spec) && t.pxVersion.LessThan(pxVer2_8) {
+	if pxutil.IsTelemetryEnabled(toUpdate.Spec) && t.pxVersion.LessThan(pxutil.MinimumPxVersionCCM) {
 		toUpdate.Spec.Monitoring.Telemetry.Enabled = false // telemetry not supported for < 2.8
 		toUpdate.Spec.Monitoring.Telemetry.Image = ""
 	}
@@ -930,7 +974,9 @@ func (p *portworx) hasComponentChanged(cluster *corev1.StorageCluster) bool {
 		hasLighthouseChanged(cluster) ||
 		hasCSIChanged(cluster) ||
 		hasTelemetryChanged(cluster) ||
+		hasTelemetryProxyChanged(cluster) ||
 		hasMetricsCollectorChanged(cluster) ||
+		hasLogUploaderChanged(cluster) ||
 		hasPrometheusChanged(cluster) ||
 		hasAlertManagerChanged(cluster) ||
 		p.hasPrometheusVersionChanged(cluster) ||
@@ -968,10 +1014,20 @@ func hasTelemetryChanged(cluster *corev1.StorageCluster) bool {
 		cluster.Status.DesiredImages.Telemetry == ""
 }
 
+func hasTelemetryProxyChanged(cluster *corev1.StorageCluster) bool {
+	return autoUpdateTelemetryProxy(cluster) &&
+		cluster.Status.DesiredImages.TelemetryProxy == ""
+}
+
 func hasMetricsCollectorChanged(cluster *corev1.StorageCluster) bool {
 	return autoUpdateMetricsCollector(cluster) &&
 		(cluster.Status.DesiredImages.MetricsCollector == "" ||
 			cluster.Status.DesiredImages.MetricsCollectorProxy == "")
+}
+
+func hasLogUploaderChanged(cluster *corev1.StorageCluster) bool {
+	return autoUpdateLogUploader(cluster) &&
+		cluster.Status.DesiredImages.LogUploader == ""
 }
 
 func hasPxRepoChanged(cluster *corev1.StorageCluster) bool {
@@ -1016,8 +1072,21 @@ func autoUpdateTelemetry(cluster *corev1.StorageCluster) bool {
 		cluster.Spec.Monitoring.Telemetry.Image == ""
 }
 
+func autoUpdateTelemetryProxy(cluster *corev1.StorageCluster) bool {
+	return pxutil.IsTelemetryEnabled(cluster.Spec) &&
+		pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster))
+}
+
 func autoUpdateMetricsCollector(cluster *corev1.StorageCluster) bool {
-	return pxutil.IsTelemetryEnabled(cluster.Spec)
+	return pxutil.IsTelemetryEnabled(cluster.Spec) &&
+		!pxutil.RunCCMGo(cluster)
+}
+
+func autoUpdateLogUploader(cluster *corev1.StorageCluster) bool {
+	return pxutil.IsTelemetryEnabled(cluster.Spec) &&
+		pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster)) &&
+		pxutil.RunCCMGo(cluster) &&
+		cluster.Spec.Monitoring.Telemetry.ImageLogUpload == ""
 }
 
 func autoUpdatePxRepo(cluster *corev1.StorageCluster) bool {

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -254,9 +254,9 @@ func TestSetDefaultsOnStorageCluster(t *testing.T) {
 	driver.SetDefaultsOnStorageCluster(cluster)
 
 	// Use default image from release manifest when spec.image is not set
-	require.Equal(t, defaultPortworxImage+":3.0.0", cluster.Spec.Image)
-	require.Equal(t, "3.0.0", cluster.Spec.Version)
-	require.Equal(t, "3.0.0", cluster.Status.Version)
+	require.Equal(t, defaultPortworxImage+":2.10.0", cluster.Spec.Image)
+	require.Equal(t, "2.10.0", cluster.Spec.Version)
+	require.Equal(t, "2.10.0", cluster.Status.Version)
 	require.True(t, cluster.Spec.Kvdb.Internal)
 	require.Equal(t, defaultSecretsProvider, *cluster.Spec.SecretsProvider)
 	require.Equal(t, uint32(pxutil.DefaultStartPort), *cluster.Spec.StartPort)
@@ -267,9 +267,9 @@ func TestSetDefaultsOnStorageCluster(t *testing.T) {
 	cluster.Spec.Image = "  "
 	cluster.Spec.Version = "  "
 	driver.SetDefaultsOnStorageCluster(cluster)
-	require.Equal(t, defaultPortworxImage+":3.0.0", cluster.Spec.Image)
-	require.Equal(t, "3.0.0", cluster.Spec.Version)
-	require.Equal(t, "3.0.0", cluster.Status.Version)
+	require.Equal(t, defaultPortworxImage+":2.10.0", cluster.Spec.Image)
+	require.Equal(t, "2.10.0", cluster.Spec.Version)
+	require.Equal(t, "2.10.0", cluster.Status.Version)
 
 	// Don't use default image when spec.image has a value
 	cluster.Spec.Image = "foo/image:1.0.0"
@@ -282,9 +282,9 @@ func TestSetDefaultsOnStorageCluster(t *testing.T) {
 	cluster.Spec.Image = "test/image"
 	cluster.Spec.Version = ""
 	driver.SetDefaultsOnStorageCluster(cluster)
-	require.Equal(t, "test/image:3.0.0", cluster.Spec.Image)
-	require.Equal(t, "3.0.0", cluster.Spec.Version)
-	require.Equal(t, "3.0.0", cluster.Status.Version)
+	require.Equal(t, "test/image:2.10.0", cluster.Spec.Image)
+	require.Equal(t, "2.10.0", cluster.Spec.Version)
+	require.Equal(t, "2.10.0", cluster.Status.Version)
 
 	// Empty kvdb spec should still set internal kvdb as default
 	cluster.Spec.Kvdb = &corev1.KvdbSpec{}
@@ -7525,7 +7525,7 @@ func (m *fakeManifest) GetVersions(
 		compVersion = newCompVersion()
 	}
 	version := &manifest.Version{
-		PortworxVersion: "3.0.0",
+		PortworxVersion: "2.10.0",
 		Components: manifest.Release{
 			Stork:                      "openstorage/stork:" + compVersion,
 			Autopilot:                  "portworx/autopilot:" + compVersion,
@@ -7547,6 +7547,8 @@ func (m *fakeManifest) GetVersions(
 			AlertManager:               "quay.io/prometheus/alertmanager:v1.2.3",
 			MetricsCollector:           "purestorage/realtime-metrics:latest",
 			MetricsCollectorProxy:      "envoyproxy/envoy:v1.19.1",
+			LogUploader:                "purestorage/log-upload:1.2.3",
+			TelemetryProxy:             "purestorage/envoy:1.2.3",
 			PxRepo:                     "portworx/px-repo:" + compVersion,
 		},
 	}
@@ -7556,7 +7558,6 @@ func (m *fakeManifest) GetVersions(
 		version.Components.PrometheusConfigMapReload = ""
 		version.Components.PrometheusConfigReloader = "quay.io/prometheus-operator/prometheus-config-reloader:v0.50.0"
 		version.Components.AlertManager = "quay.io/prometheus/alertmanager:v0.22.2"
-
 	}
 	return version
 }

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -230,6 +230,11 @@ var (
 	// SpecsBaseDir functions returns the base directory for specs. This is extracted as
 	// variable for testing. DO NOT change the value of the function unless for testing.
 	SpecsBaseDir = getSpecsBaseDir
+
+	// MinimumPxVersionCCM minimum PX version to install ccm
+	MinimumPxVersionCCM, _ = version.NewVersion("2.8")
+	// MinimumPxVersionCCMGO minimum PX version to install ccm-go
+	MinimumPxVersionCCMGO, _ = version.NewVersion("2.12")
 )
 
 // IsPortworxEnabled returns true if portworx is not explicitly disabled using the annotation
@@ -960,6 +965,16 @@ func IsTelemetryEnabled(spec corev1.StorageClusterSpec) bool {
 	return spec.Monitoring != nil &&
 		spec.Monitoring.Telemetry != nil &&
 		spec.Monitoring.Telemetry.Enabled
+}
+
+// IsCCMGoSupported returns true if px version is higher than 2.12
+func IsCCMGoSupported(pxVersion *version.Version) bool {
+	return pxVersion.GreaterThanOrEqual(MinimumPxVersionCCMGO)
+}
+
+// RunCCMGo returns whether to run new ccm go or old ccm java based on if the telemetry proxy image is set
+func RunCCMGo(cluster *corev1.StorageCluster) bool {
+	return cluster.Status.DesiredImages.TelemetryProxy != ""
 }
 
 // IsPxRepoEnabled returns true is pxRepo is enabled

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -545,6 +545,8 @@ type TelemetrySpec struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Image is docker image of the telemetry container
 	Image string `json:"image,omitempty"`
+	// ImageLogUpload is docker image of the log-upload-service container.
+	ImageLogUpload string `json:"imageLogUpload,omitempty"`
 }
 
 // PrometheusSpec contains configuration of Prometheus stack
@@ -607,7 +609,9 @@ type ComponentImages struct {
 	AlertManager               string `json:"alertManager,omitempty"`
 	Telemetry                  string `json:"telemetry,omitempty"`
 	MetricsCollector           string `json:"metricsCollector,omitempty"`
-	MetricsCollectorProxy      string `json:"metricsCollectorProxy,omitempty"`
+	MetricsCollectorProxy      string `json:"metricsCollectorProxy,omitempty"` // TODO: use TelemetryProxy only
+	LogUploader                string `json:"logUploader,omitempty"`
+	TelemetryProxy             string `json:"telemetryProxy,omitempty"`
 	PxRepo                     string `json:"pxRepo,omitempty"`
 }
 

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -545,8 +545,8 @@ type TelemetrySpec struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Image is docker image of the telemetry container
 	Image string `json:"image,omitempty"`
-	// ImageLogUpload is docker image of the log-upload-service container.
-	ImageLogUpload string `json:"imageLogUpload,omitempty"`
+	// LogUploaderImage is docker image of the log-upload-service container.
+	LogUploaderImage string `json:"logUploaderImage,omitempty"`
 }
 
 // PrometheusSpec contains configuration of Prometheus stack

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -8127,6 +8127,7 @@ func TestDoesTelemetryMatch(t *testing.T) {
 		cluster := createStorageCluster()
 		// use monitoring spec from TC
 		cluster.Spec.Monitoring = tc.old.Monitoring
+		cluster.Spec.Image = "portworx:2.10.1"
 		k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
 		driver := testutil.MockDriver(mockCtrl)
 		storageLabels := map[string]string{

--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -707,7 +707,8 @@ func matchSelectedFields(
 		return false, nil
 	} else if !elementsMatch(oldSpec.Volumes, currentSpec.Volumes) {
 		return false, nil
-	} else if !doesTelemetryMatch(oldSpec, currentSpec) {
+	} else if !doesTelemetryMatch(oldSpec, currentSpec) && !util.IsCCMGoSupported(util.GetPortworxVersion(cluster)) {
+		// only check for old px version, ccm upgrade should be triggered by px upgrade
 		return false, nil
 	} else if isBounceRequired(oldSpec, currentSpec) {
 		return false, nil

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -906,6 +906,29 @@ func DeleteService(
 	return k8sClient.Update(context.TODO(), service)
 }
 
+// GetDeployment get deployment
+func GetDeployment(
+	k8sClient client.Client,
+	deployment *appsv1.Deployment,
+) (*appsv1.Deployment, error) {
+	existingDeployment := &appsv1.Deployment{}
+	err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      deployment.Name,
+			Namespace: deployment.Namespace,
+		},
+		existingDeployment,
+	)
+	if errors.IsNotFound(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return existingDeployment, nil
+}
+
 // CreateOrUpdateDeployment creates a deployment if not present, else updates it
 func CreateOrUpdateDeployment(
 	k8sClient client.Client,

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1837,6 +1837,57 @@ func GetV1beta1CRDFromFile(
 	return crd, nil
 }
 
+// GetRoleFromFile parses a Role object from a file
+func GetRoleFromFile(
+	filename string,
+	baseDir string,
+) (*rbacv1.Role, error) {
+	filepath := path.Join(baseDir, filename)
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	role := &rbacv1.Role{}
+	if err := ParseObjectFromFile(filepath, scheme, role); err != nil {
+		return nil, err
+	}
+	return role, nil
+}
+
+// GetRoleBindingFromFile parses a RoleBinding object from a file
+func GetRoleBindingFromFile(
+	filename string,
+	baseDir string,
+) (*rbacv1.RoleBinding, error) {
+	filepath := path.Join(baseDir, filename)
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	roleBinding := &rbacv1.RoleBinding{}
+	if err := ParseObjectFromFile(filepath, scheme, roleBinding); err != nil {
+		return nil, err
+	}
+	return roleBinding, nil
+}
+
+// GetDeploymentFromFile parses a Deployment object from a file
+func GetDeploymentFromFile(
+	filename string,
+	baseDir string,
+) (*appsv1.Deployment, error) {
+	filepath := path.Join(baseDir, filename)
+	scheme := runtime.NewScheme()
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	deployment := &appsv1.Deployment{}
+	if err := ParseObjectFromFile(filepath, scheme, deployment); err != nil {
+		return nil, err
+	}
+	return deployment, nil
+}
+
 // GetAllObjects gets all objects from k8s
 func GetAllObjects(k8sClient client.Client, namespace string) ([]client.Object, error) {
 	var objs []client.Object

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -222,6 +222,10 @@ func DeepEqualObjects(
 func DeepEqualDeployment(d1 *appsv1.Deployment, d2 *appsv1.Deployment) (bool, error) {
 	// DeepDerivative will return true if first argument is nil, hence check the length of volumes.
 	// The reason we don't use deepEqual for volumes is k8s API server may add defaultMode to it.
+	if (d1 == nil && d2 != nil) || (d1 != nil && d2 == nil) {
+		return false, fmt.Errorf("one deployment is nil, first: %v, second: %v", d1 == nil, d2 == nil)
+	}
+
 	if !equality.Semantic.DeepDerivative(d1.Spec.Template.Spec.Containers, d2.Spec.Template.Spec.Containers) {
 		return false, fmt.Errorf("containers not equal, first: %+v, second: %+v", d1.Spec.Template.Spec.Containers, d2.Spec.Template.Spec.Containers)
 	}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: telemetry ccm-go integration
Notes:
* ccm go is supported on PX 2.12+ only, older version will install ccm java
* when px upgrade to 2.12, if old ccm java is enabled, operator will upgrade to ccm go automatically , so telemetryProxy image must be available from manifest, otherwise should continue running old ccm java
* when px upgrade to 2.12, if old ccm java is enabled, but image is set explicitly, operator will reset the image and upgrade ccm
* during ccm upgrade, once old ccm components are deleted, operator will start creating new components. However it doesn't wait for all telemetry containers teardown in px pods.
* when disable telemetry, it will try to do a cleanup for both ccm java and ccm go

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

