### PR TITLE
PWX-17988 - Add TLS port to portworx service

### DIFF
--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -102,9 +102,11 @@ func (c *portworxAPI) createService(
 	startPort := pxutil.StartPort(cluster)
 	sdkTargetPort := 9020
 	restGatewayTargetPort := 9021
+	pxAPITLSPort := 9023
 	if startPort != pxutil.DefaultStartPort {
 		sdkTargetPort = startPort + 16
 		restGatewayTargetPort = startPort + 17
+		pxAPITLSPort = startPort + 19
 	}
 
 	newService := &v1.Service{
@@ -135,6 +137,12 @@ func (c *portworxAPI) createService(
 					Protocol:   v1.ProtocolTCP,
 					Port:       int32(9021),
 					TargetPort: intstr.FromInt(restGatewayTargetPort),
+				},
+				{
+					Name:       pxutil.PortworxRESTTLSPortName,
+					Protocol:   v1.ProtocolTCP,
+					Port:       int32(9023),
+					TargetPort: intstr.FromInt(pxAPITLSPort),
 				},
 			},
 		},

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -465,14 +465,20 @@ func getPortworxServiceSpec(
 					Port:       int32(9021),
 					TargetPort: intstr.FromInt(restGatewayTargetPort),
 				},
-				{
-					Name:       pxutil.PortworxRESTTLSPortName,
-					Protocol:   v1.ProtocolTCP,
-					Port:       int32(9023),
-					TargetPort: intstr.FromInt(pxAPITLSPort),
-				},
 			},
 		},
+	}
+
+	// TLS secured port 9023 added in PX 2.9.0, only add it is 2.9.0 or later
+	pxAPITLSVersion, _ := version.NewVersion("2.9.0")
+	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxAPITLSVersion) {
+		newService.Spec.Ports = append(newService.Spec.Ports,
+			v1.ServicePort{
+				Name:       pxutil.PortworxRESTTLSPortName,
+				Protocol:   v1.ProtocolTCP,
+				Port:       int32(9023),
+				TargetPort: intstr.FromInt(pxAPITLSPort),
+			})
 	}
 
 	if ownerRef != nil {

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -435,7 +435,7 @@ func getPortworxServiceSpec(
 ) *v1.Service {
 	labels := pxutil.SelectorLabels()
 	startPort := pxutil.StartPort(cluster)
-	_, sdkTargetPort, restGatewayTargetPort := getTargetPorts(startPort)
+	_, sdkTargetPort, restGatewayTargetPort, pxAPITLSPort := getTargetPorts(startPort)
 
 	newService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -464,6 +464,12 @@ func getPortworxServiceSpec(
 					Protocol:   v1.ProtocolTCP,
 					Port:       int32(9021),
 					TargetPort: intstr.FromInt(restGatewayTargetPort),
+				},
+				{
+					Name:       pxutil.PortworxRESTTLSPortName,
+					Protocol:   v1.ProtocolTCP,
+					Port:       int32(9023),
+					TargetPort: intstr.FromInt(pxAPITLSPort),
 				},
 			},
 		},
@@ -497,7 +503,7 @@ func getPortworxKVDBServiceSpec(
 ) *v1.Service {
 	labels := pxutil.SelectorLabels()
 	startPort := pxutil.StartPort(cluster)
-	kvdbTargetPort, _, _ := getTargetPorts(startPort)
+	kvdbTargetPort, _, _, _ := getTargetPorts(startPort)
 
 	newService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -535,16 +541,18 @@ func getPortworxKVDBServiceSpec(
 	return newService
 }
 
-func getTargetPorts(startPort int) (int, int, int) {
+func getTargetPorts(startPort int) (int, int, int, int) {
 	kvdbTargetPort := 9019
 	sdkTargetPort := 9020
 	restGatewayTargetPort := 9021
+	pxAPITLSPort := 9023
 	if startPort != pxutil.DefaultStartPort {
 		kvdbTargetPort = startPort + 15
 		sdkTargetPort = startPort + 16
 		restGatewayTargetPort = startPort + 17
+		pxAPITLSPort = startPort + 19
 	}
-	return kvdbTargetPort, sdkTargetPort, restGatewayTargetPort
+	return kvdbTargetPort, sdkTargetPort, restGatewayTargetPort, pxAPITLSPort
 }
 
 func getSecretsNamespace(cluster *corev1.StorageCluster) string {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -102,7 +102,97 @@ func TestOrderOfComponents(t *testing.T) {
 	}
 }
 
+// TestBasicComponentsInstallWithPreTLSPx validates that for px versions before 2.9,
+//   the TLS secured port 9023 is not exposed
+func TestBasicComponentsInstallWithPreTLSPx(t *testing.T) {
+	logrus.SetLevel(logrus.TraceLevel)
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	startPort := uint32(10001)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "false",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			StartPort: &startPort,
+			Placement: &corev1.PlacementSpec{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "px/enabled",
+										Operator: v1.NodeSelectorOpNotIn,
+										Values:   []string{"false"},
+									},
+									{
+										Key:      "node-role.kubernetes.io/master",
+										Operator: v1.NodeSelectorOpDoesNotExist,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	driver.SetDefaultsOnStorageCluster(cluster)
+	legacyImage := "portworx/oci-monitor:2.8.0"
+	cluster.Spec.Image = legacyImage
+
+	err := driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Portworx Service with legacy px (pre 2.9) should not expose 9023 TSL secured port
+	// s, _ := json.MarshalIndent(cluster.Spec, "", "\t")
+	// t.Logf("cluster spec under validation for legacy portworxService.yaml: %+v", string(s))
+	expectedPXService := testutil.GetExpectedService(t, "portworxService_pre_29.yaml")
+	pxService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxService, pxutil.PortworxServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedPXService.Name, pxService.Name)
+	require.Equal(t, expectedPXService.Namespace, pxService.Namespace)
+	require.Len(t, pxService.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, pxService.OwnerReferences[0].Name)
+	require.Equal(t, expectedPXService.Labels, pxService.Labels)
+	require.Equal(t, expectedPXService.Spec, pxService.Spec)
+
+	// Portworx API Service with legacy px (pre 2.9) should not expose 9023 TSL secured port
+	expectedPxAPIService := testutil.GetExpectedService(t, "portworxAPIService_pre_29.yaml")
+	pxAPIService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxAPIService, component.PxAPIServiceName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedPxAPIService.Name, pxAPIService.Name)
+	require.Equal(t, expectedPxAPIService.Namespace, pxAPIService.Namespace)
+	require.Len(t, pxAPIService.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, pxAPIService.OwnerReferences[0].Name)
+	require.Equal(t, expectedPxAPIService.Labels, pxAPIService.Labels)
+	require.Equal(t, expectedPxAPIService.Spec, pxAPIService.Spec)
+
+	// Portworx Proxy Service
+	expectedPxProxyService := testutil.GetExpectedService(t, "pxProxyService_pre_29.yaml")
+	pxProxyService := &v1.Service{}
+	err = testutil.Get(k8sClient, pxProxyService, pxutil.PortworxServiceName, api.NamespaceSystem)
+	require.NoError(t, err)
+	require.Equal(t, expectedPxProxyService.Name, pxProxyService.Name)
+	require.Equal(t, expectedPxProxyService.Namespace, pxProxyService.Namespace)
+	require.Empty(t, pxProxyService.OwnerReferences)
+	require.Equal(t, expectedPxProxyService.Labels, pxProxyService.Labels)
+	require.Equal(t, expectedPxProxyService.Spec, pxProxyService.Spec)
+}
+
 func TestBasicComponentsInstall(t *testing.T) {
+	logrus.SetLevel(logrus.TraceLevel)
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()
 	k8sClient := testutil.FakeK8sClient()
@@ -196,6 +286,9 @@ func TestBasicComponentsInstall(t *testing.T) {
 	require.Equal(t, cluster.Name, actualRB.OwnerReferences[0].Name)
 	require.ElementsMatch(t, expectedRB.Subjects, actualRB.Subjects)
 	require.Equal(t, expectedRB.RoleRef, actualRB.RoleRef)
+
+	s, _ := json.MarshalIndent(cluster.Spec, "", "\t")
+	t.Logf("cluster spec under validation for portworxService.yaml: %+v", string(s))
 
 	// Portworx Service
 	expectedPXService := testutil.GetExpectedService(t, "portworxService.yaml")

--- a/drivers/storage/portworx/testspec/portworxAPIService.yaml
+++ b/drivers/storage/portworx/testspec/portworxAPIService.yaml
@@ -22,3 +22,7 @@ spec:
       protocol: TCP
       port: 9021
       targetPort: 10018
+    - name: px-api-tls
+      protocol: TCP
+      port: 9023
+      targetPort: 10020

--- a/drivers/storage/portworx/testspec/portworxAPIService_pre_29.yaml
+++ b/drivers/storage/portworx/testspec/portworxAPIService_pre_29.yaml
@@ -1,0 +1,24 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-api
+  namespace: kube-test
+  labels:
+    name: portworx-api
+spec:
+  selector:
+    name: portworx-api
+  type: ClusterIP
+  ports:
+    - name: px-api
+      protocol: TCP
+      port: 9001
+      targetPort: 10001
+    - name: px-sdk
+      protocol: TCP
+      port: 9020
+      targetPort: 10017
+    - name: px-rest-gateway
+      protocol: TCP
+      port: 9021
+      targetPort: 10018

--- a/drivers/storage/portworx/testspec/portworxService.yaml
+++ b/drivers/storage/portworx/testspec/portworxService.yaml
@@ -22,3 +22,7 @@ spec:
       protocol: TCP
       port: 9021
       targetPort: 10018
+    - name: px-api-tls
+      protocol: TCP
+      port: 9023
+      targetPort: 10020

--- a/drivers/storage/portworx/testspec/portworxService_pre_29.yaml
+++ b/drivers/storage/portworx/testspec/portworxService_pre_29.yaml
@@ -1,0 +1,28 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-service
+  namespace: kube-test
+  labels:
+    name: portworx
+spec:
+  selector:
+    name: portworx
+  type: ClusterIP
+  ports:
+    - name: px-api
+      protocol: TCP
+      port: 9001
+      targetPort: 10001
+    - name: px-kvdb
+      protocol: TCP
+      port: 9019
+      targetPort: 10016
+    - name: px-sdk
+      protocol: TCP
+      port: 9020
+      targetPort: 10017
+    - name: px-rest-gateway
+      protocol: TCP
+      port: 9021
+      targetPort: 10018

--- a/drivers/storage/portworx/testspec/portworxService_pre_29.yaml
+++ b/drivers/storage/portworx/testspec/portworxService_pre_29.yaml
@@ -14,10 +14,6 @@ spec:
       protocol: TCP
       port: 9001
       targetPort: 10001
-    - name: px-kvdb
-      protocol: TCP
-      port: 9019
-      targetPort: 10016
     - name: px-sdk
       protocol: TCP
       port: 9020

--- a/drivers/storage/portworx/testspec/pxProxyService.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyService.yaml
@@ -22,3 +22,7 @@ spec:
       protocol: TCP
       port: 9021
       targetPort: 10018
+    - name: px-api-tls
+      protocol: TCP
+      port: 9023
+      targetPort: 10020

--- a/drivers/storage/portworx/testspec/pxProxyService_pre_29.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyService_pre_29.yaml
@@ -14,10 +14,6 @@ spec:
       protocol: TCP
       port: 9001
       targetPort: 10001
-    - name: px-kvdb
-      protocol: TCP
-      port: 9019
-      targetPort: 10016
     - name: px-sdk
       protocol: TCP
       port: 9020

--- a/drivers/storage/portworx/testspec/pxProxyService_pre_29.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyService_pre_29.yaml
@@ -1,0 +1,28 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-service
+  namespace: kube-system
+  labels:
+    name: portworx-proxy
+spec:
+  selector:
+    name: portworx-proxy
+  type: ClusterIP
+  ports:
+    - name: px-api
+      protocol: TCP
+      port: 9001
+      targetPort: 10001
+    - name: px-kvdb
+      protocol: TCP
+      port: 9019
+      targetPort: 10016
+    - name: px-sdk
+      protocol: TCP
+      port: 9020
+      targetPort: 10017
+    - name: px-rest-gateway
+      protocol: TCP
+      port: 9021
+      targetPort: 10018

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -54,6 +54,8 @@ const (
 	TelemetryContainerName = "telemetry"
 	// PortworxRESTPortName name of the Portworx API port
 	PortworxRESTPortName = "px-api"
+	// PortworxRESTTLSPortName name of the Portworx API port that is secured through TLS
+	PortworxRESTTLSPortName = "px-api-tls"
 	// PortworxSDKPortName name of the Portworx SDK port
 	PortworxSDKPortName = "px-sdk"
 	// PortworxKVDBPortName name of the Portworx internal KVDB port

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -710,7 +710,7 @@ func AppendTLSEnv(clusterSpec *corev1.StorageClusterSpec, envMap map[string]*v1.
 			// if the user specified a CA cert though k8s secret in spec.tls.rootCA.secretRef, use that
 			if !IsEmptyOrNilSecretReference(clusterSpec.Security.TLS.RootCA.SecretRef) {
 				rootCASecret := clusterSpec.Security.TLS.RootCA.SecretRef
-				logrus.Infof("Secret name containing CA cert: %v", DefaultCASecretName)
+				logrus.Infof("Reference secret name containing CA cert: %v", rootCASecret.SecretName)
 				envMap[EnvKeyCASecretName] = &v1.EnvVar{
 					Name:  EnvKeyCASecretName,
 					Value: rootCASecret.SecretName,
@@ -721,7 +721,7 @@ func AppendTLSEnv(clusterSpec *corev1.StorageClusterSpec, envMap map[string]*v1.
 				}
 			} else {
 				// The user installed a CA cert on the host file system. We assume that user has also uploaded it to the default k8s secret with the default key
-				logrus.Infof("Secret name containing CA cert: %v", DefaultCASecretName)
+				logrus.Infof("Default secret name containing CA cert: %v", DefaultCASecretName)
 				envMap[EnvKeyCASecretName] = &v1.EnvVar{
 					Name:  EnvKeyCASecretName,
 					Value: DefaultCASecretName,


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Add TLS ports (default to 9023) to portworx-service and portworx-api to modern px versions

**Which issue(s) this PR fixes** (optional)
Closes #PWX-17988

**Special notes for your reviewer**:

