### PR TITLE
PWX-24825: Check for a specific secure port in pvc controller for AKS.

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -1716,16 +1716,16 @@ func validatePvcControllerPorts(cluster *corev1.StorageCluster, pvcControllerDep
 					if len(container.Command) > 0 {
 						for _, containerCommand := range container.Command {
 							if strings.Contains(containerCommand, "--secure-port") {
-								if isAKS(cluster) {
-									if strings.Split(containerCommand, "=")[1] != AksPVCControllerSecurePort {
-										return nil, true, fmt.Errorf("failed to validate secure-port, secure-port is missing in the PVC Controler pod %s", pod.Name)
-									}
-								} else {
-									if len(pvcSecurePort) == 0 {
+								if len(pvcSecurePort) == 0 {
+									if isAKS(cluster) {
+										if strings.Split(containerCommand, "=")[1] != AksPVCControllerSecurePort {
+											return nil, true, fmt.Errorf("failed to validate secure-port, secure-port is missing in the PVC Controler pod %s", pod.Name)
+										}
+									} else {
 										return nil, true, fmt.Errorf("failed to validate secure-port, secure-port is missing from annotations in the StorageCluster, but is found in the PVC Controler pod %s", pod.Name)
-									} else if pvcSecurePort != strings.Split(containerCommand, "=")[1] {
-										return nil, true, fmt.Errorf("failed to validate secure-port, wrong --secure-port value in the command in PVC Controller pod [%s]: expected: %s, got: %s", pod.Name, pvcSecurePort, strings.Split(containerCommand, "=")[1])
 									}
+								} else if pvcSecurePort != strings.Split(containerCommand, "=")[1] {
+									return nil, true, fmt.Errorf("failed to validate secure-port, wrong --secure-port value in the command in PVC Controller pod [%s]: expected: %s, got: %s", pod.Name, pvcSecurePort, strings.Split(containerCommand, "=")[1])
 								}
 								logrus.Debugf("Value for secure-port inside PVC Controller pod [%s]: expected %s, got %s", pod.Name, pvcSecurePort, strings.Split(containerCommand, "=")[1])
 								securePortExist = true

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -53,7 +53,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	pvccontroller "github.com/libopenstorage/operator/drivers/storage/portworx/component"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/mock"
 	"github.com/libopenstorage/operator/pkg/util"
@@ -90,6 +89,9 @@ const (
 
 	// PxMasterVersion is a tag for Portworx master version
 	PxMasterVersion = "3.0.0.0"
+
+	// AksPVCControllerSecurePort is the PVC controller secure port.
+	AksPVCControllerSecurePort = "10261"
 )
 
 // TestSpecPath is the path for all test specs. Due to currently functional test and
@@ -1715,7 +1717,7 @@ func validatePvcControllerPorts(cluster *corev1.StorageCluster, pvcControllerDep
 						for _, containerCommand := range container.Command {
 							if strings.Contains(containerCommand, "--secure-port") {
 								if isAKS(cluster) {
-									if strings.Split(containerCommand, "=")[1] != pvccontroller.AksPVCControllerSecurePort {
+									if strings.Split(containerCommand, "=")[1] != AksPVCControllerSecurePort {
 										return nil, true, fmt.Errorf("failed to validate secure-port, secure-port is missing in the PVC Controler pod %s", pod.Name)
 									}
 								} else {


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

**What this PR does / why we need it**:
Operator integration tests were failing on AKS in the function validatePvcControllerPorts with error `14:33:08 2022/08/02 21:28:27 failed to validate secure-port, secure-port is missing from annotations in the StorageCluster, but is found in the PVC Controler pod portworx-pvc-controller-99f55f488-5q79p Next retry in: 20s`
Azure --secure-port get updated to value  AksPVCControllerSecurePort = "10261" in pvc controller irrespective of the StorageCluster annotation.  Updating this function to compare  secure-port against this value in case of AKS.
