### PR TITLE
[PWX-26146][PWX-26177] Add ccm-go missing scc configuration and metrics collector

### DIFF
--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -75,8 +74,10 @@ func (t *telemetry) reconcileCCMJava(
 	if err := t.reconcileCCMJavaProxyConfigMap(cluster, ownerRef); err != nil {
 		return err
 	}
-	if err := t.deployMetricsCollector(cluster, ownerRef); err != nil {
-		return err
+	if pxutil.IsMetricsCollectorSupported(pxutil.GetPortworxVersion(cluster)) {
+		if err := t.deployMetricsCollectorV1(cluster, ownerRef); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -85,18 +86,21 @@ func (t *telemetry) deleteCCMJava(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, TelemetryConfigMapName, cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
 	if err := k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
 
-	if err := t.deleteMetricsCollector(cluster.Namespace, ownerRef); err != nil {
+	if err := t.deleteMetricsCollectorV1(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (t *telemetry) deleteMetricsCollector(namespace string, ownerRef *metav1.OwnerReference) error {
+func (t *telemetry) deleteMetricsCollectorV1(namespace string, ownerRef *metav1.OwnerReference) error {
 	if err := k8sutil.DeleteServiceAccount(t.k8sClient, CollectorServiceAccountName, namespace, *ownerRef); err != nil {
 		return err
 	}
@@ -133,31 +137,19 @@ func (t *telemetry) deleteMetricsCollector(namespace string, ownerRef *metav1.Ow
 	return nil
 }
 
-func (t *telemetry) deployMetricsCollector(
+func (t *telemetry) deployMetricsCollectorV1(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	pxVer2_9_1, _ := version.NewVersion("2.9.1")
-	pxVersion := pxutil.GetPortworxVersion(cluster)
-	if pxVersion.LessThan(pxVer2_9_1) {
-		// Run metrics collector only for portworx version 2.9.1+
-		return nil
-	}
-
-	if len(cluster.Status.ClusterUID) == 0 {
-		logrus.Warn("clusterUID is empty, wait for it to fill collector proxy config")
-		return nil
-	}
-
 	if err := t.createCollectorServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
 
-	if err := t.createCollectorProxyConfigMap(cluster, ownerRef); err != nil {
+	if err := t.createCollectorClusterRole(); err != nil {
 		return err
 	}
 
-	if err := t.createCollectorConfigMap(cluster, ownerRef); err != nil {
+	if err := t.createCollectorClusterRoleBinding(cluster.Namespace); err != nil {
 		return err
 	}
 
@@ -169,11 +161,11 @@ func (t *telemetry) deployMetricsCollector(
 		return err
 	}
 
-	if err := t.createCollectorClusterRole(); err != nil {
+	if err := t.createCollectorProxyConfigMap(cluster, ownerRef); err != nil {
 		return err
 	}
 
-	if err := t.createCollectorClusterRoleBinding(cluster.Namespace); err != nil {
+	if err := t.createCollectorConfigMap(cluster, ownerRef); err != nil {
 		return err
 	}
 
@@ -315,6 +307,10 @@ func (t *telemetry) getCollectorDeployment(
 	if err != nil {
 		return nil, err
 	}
+	serviceAccountName := CollectorServiceAccountName
+	if t.isCCMGoSupported {
+		serviceAccountName = ServiceAccountNamePxTelemetry
+	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            CollectorDeploymentName,
@@ -327,7 +323,7 @@ func (t *telemetry) getCollectorDeployment(
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: v1.PodSpec{
-					ServiceAccountName: CollectorServiceAccountName,
+					ServiceAccountName: serviceAccountName,
 					Containers: []v1.Container{
 						{
 							Name:  "collector",
@@ -459,6 +455,10 @@ func (t *telemetry) createCollectorRoleBinding(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	serviceAccountName := CollectorServiceAccountName
+	if t.isCCMGoSupported {
+		serviceAccountName = ServiceAccountNamePxTelemetry
+	}
 	return k8sutil.CreateOrUpdateRoleBinding(
 		t.k8sClient,
 		&rbacv1.RoleBinding{
@@ -470,7 +470,7 @@ func (t *telemetry) createCollectorRoleBinding(
 			Subjects: []rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",
-					Name:      CollectorServiceAccountName,
+					Name:      serviceAccountName,
 					Namespace: cluster.Namespace,
 				},
 			},
@@ -516,6 +516,8 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           http_filters:
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           route_config:
             name: local_route
             virtual_hosts:

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -153,7 +153,7 @@ func (t *telemetry) deployMetricsCollector(
 		return err
 	}
 
-	if err := t.createCCMJavaProxyConfigMap(cluster, ownerRef); err != nil {
+	if err := t.createCollectorProxyConfigMap(cluster, ownerRef); err != nil {
 		return err
 	}
 
@@ -484,7 +484,7 @@ func (t *telemetry) createCollectorRoleBinding(
 	)
 }
 
-func (t *telemetry) createCCMJavaProxyConfigMap(
+func (t *telemetry) createCollectorProxyConfigMap(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -315,9 +315,6 @@ func fillTelemetryDefaults(
 		if rel.Components.Telemetry == "" {
 			rel.Components.Telemetry = defaultCCMJavaImage
 		}
-		if rel.Components.MetricsCollector == "" {
-			rel.Components.MetricsCollector = defaultCollectorImage
-		}
 		if rel.Components.MetricsCollectorProxy == "" {
 			rel.Components.MetricsCollectorProxy = defaultCollectorProxyImage
 		}
@@ -331,6 +328,9 @@ func fillTelemetryDefaults(
 		if rel.Components.TelemetryProxy == "" {
 			rel.Components.TelemetryProxy = defaultCCMGoProxyImage
 		}
+	}
+	if rel.Components.MetricsCollector == "" {
+		rel.Components.MetricsCollector = defaultCollectorImage
 	}
 }
 

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -254,6 +254,7 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			Telemetry:                 "image/ccm-go:1.0.0",
 			TelemetryProxy:            "envoyproxy/envoy:v1.22.2",
 			LogUploader:               "purestorage/log-upload:1.0.0",
+			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			PxRepo:                    "portworx/px-repo:1.1.0",
 		},
 	}
@@ -776,7 +777,7 @@ func TestManifestFillTelemetryDefaults(t *testing.T) {
 	require.Equal(t, defaultCCMGoImage, rel.Components.Telemetry)
 	require.Equal(t, defaultCCMGoProxyImage, rel.Components.TelemetryProxy)
 	require.Equal(t, defaultLogUploaderImage, rel.Components.LogUploader)
-	require.Empty(t, rel.Components.MetricsCollector)
+	require.Equal(t, defaultCollectorImage, rel.Components.MetricsCollector)
 	require.Empty(t, rel.Components.MetricsCollectorProxy)
 
 	// TestCase: default non-SemVerCCM use run CCM Go images
@@ -791,7 +792,7 @@ func TestManifestFillTelemetryDefaults(t *testing.T) {
 	require.Equal(t, defaultCCMGoImage, rel.Components.Telemetry)
 	require.Equal(t, defaultCCMGoProxyImage, rel.Components.TelemetryProxy)
 	require.Equal(t, defaultLogUploaderImage, rel.Components.LogUploader)
-	require.Empty(t, rel.Components.MetricsCollector)
+	require.Equal(t, defaultCollectorImage, rel.Components.MetricsCollector)
 	require.Empty(t, rel.Components.MetricsCollectorProxy)
 }
 

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -228,11 +228,18 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 
 		if autoUpdateMetricsCollector(toUpdate) &&
 			(toUpdate.Status.DesiredImages.MetricsCollector == "" ||
-				toUpdate.Status.DesiredImages.MetricsCollectorProxy == "" ||
+				(!pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(toUpdate)) &&
+					toUpdate.Status.DesiredImages.MetricsCollectorProxy == "") ||
+				(pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(toUpdate)) &&
+					toUpdate.Status.DesiredImages.TelemetryProxy == "") ||
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
 			toUpdate.Status.DesiredImages.MetricsCollector = release.Components.MetricsCollector
-			toUpdate.Status.DesiredImages.MetricsCollectorProxy = release.Components.MetricsCollectorProxy
+			if !pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(toUpdate)) {
+				toUpdate.Status.DesiredImages.MetricsCollectorProxy = release.Components.MetricsCollectorProxy
+			} else {
+				toUpdate.Status.DesiredImages.MetricsCollectorProxy = ""
+			}
 		}
 
 		if autoUpdateLogUploader(toUpdate) &&
@@ -1000,7 +1007,10 @@ func hasTelemetryProxyChanged(cluster *corev1.StorageCluster) bool {
 func hasMetricsCollectorChanged(cluster *corev1.StorageCluster) bool {
 	return autoUpdateMetricsCollector(cluster) &&
 		(cluster.Status.DesiredImages.MetricsCollector == "" ||
-			cluster.Status.DesiredImages.MetricsCollectorProxy == "")
+			(!pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster)) &&
+				cluster.Status.DesiredImages.MetricsCollectorProxy == "") ||
+			(pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster)) &&
+				cluster.Status.DesiredImages.TelemetryProxy == ""))
 }
 
 func hasLogUploaderChanged(cluster *corev1.StorageCluster) bool {
@@ -1065,8 +1075,7 @@ func autoUpdateTelemetryProxy(cluster *corev1.StorageCluster) bool {
 }
 
 func autoUpdateMetricsCollector(cluster *corev1.StorageCluster) bool {
-	return pxutil.IsTelemetryEnabled(cluster.Spec) &&
-		!pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster))
+	return pxutil.IsTelemetryEnabled(cluster.Spec)
 }
 
 func autoUpdateLogUploader(cluster *corev1.StorageCluster) bool {

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -7337,7 +7337,7 @@ func TestStorageClusterDefaultsForTelemetry(t *testing.T) {
 	driver.SetDefaultsOnStorageCluster(cluster)
 	require.Empty(t, cluster.Spec.Monitoring.Telemetry.Image)
 	require.Equal(t, "portworx/px-telemetry:"+newCompVersion(), cluster.Status.DesiredImages.Telemetry)
-	require.Empty(t, cluster.Status.DesiredImages.MetricsCollector)
+	require.Equal(t, "purestorage/realtime-metrics:latest", cluster.Status.DesiredImages.MetricsCollector)
 	require.Empty(t, cluster.Status.DesiredImages.MetricsCollectorProxy)
 	require.Equal(t, "purestorage/envoy:1.2.3", cluster.Status.DesiredImages.TelemetryProxy)
 	require.Equal(t, "purestorage/log-upload:1.2.3", cluster.Status.DesiredImages.LogUploader)

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -243,6 +243,8 @@ var (
 	MinimumPxVersionCCM, _ = version.NewVersion("2.8")
 	// MinimumPxVersionCCMGO minimum PX version to install ccm-go
 	MinimumPxVersionCCMGO, _ = version.NewVersion("2.12")
+	// MinimumPxVersionMetricsCollector minimum PX version to install metrics collector
+	MinimumPxVersionMetricsCollector, _ = version.NewVersion("2.9.1")
 )
 
 // IsPortworxEnabled returns true if portworx is not explicitly disabled using the annotation
@@ -1001,6 +1003,11 @@ func IsCCMGoSupported(pxVersion *version.Version) bool {
 func IsPxRepoEnabled(spec corev1.StorageClusterSpec) bool {
 	return spec.PxRepo != nil &&
 		spec.PxRepo.Enabled
+}
+
+// IsMetricsCollectorSupported returns true if px version is higher than 2.9.1
+func IsMetricsCollectorSupported(pxVersion *version.Version) bool {
+	return pxVersion.GreaterThanOrEqual(MinimumPxVersionMetricsCollector)
 }
 
 // ApplyStorageClusterSettings applies settings from StorageCluster to deployment of any component


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
1. Add missing scc configuration for ocp environment to allow pod creation in custom namespace.
* service account px-telemetry
* cluster role px-telemetry
* cluster role binding px-telemetry
2. Add metrics collector back to ccm-go components


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

