### PR TITLE
PWX-24024: Default value for max_storage_nodes_per_zone

### DIFF
--- a/deploy/olm-catalog/portworx/1.9.0/portworx-certified.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/1.9.0/portworx-certified.clusterserviceversion.yaml
@@ -7,9 +7,9 @@ metadata:
     capabilities: Auto Pilot
     categories: "Storage"
     description: Cloud native storage solution for production workloads
-    containerImage: portworx/px-operator:1.9.0-dev
+    containerImage: registry.connect.redhat.com/portworx/openstorage-operator@sha256:c1e25a64fd2fe5ca974182b316f6b4677b190ba292a1535af581cb286574703c
     repository: https://github.com/libopenstorage/operator
-    createdAt: 2022-04-21T08:00:00Z
+    createdAt: 2022-08-01T08:00:00Z
     support: Portworx, Inc
     certified: "true"
     operatorframework.io/initialization-resource: |-
@@ -52,7 +52,7 @@ spec:
   version: 1.9.0
   minKubeVersion: "1.12.0"
   maturity: stable
-  replaces: portworx-operator.v1.8.0
+  replaces: portworx-operator.v1.8.1
   maintainers:
   - name: Portworx
     email: support@portworx.com
@@ -215,7 +215,7 @@ spec:
                     topologyKey: kubernetes.io/hostname
               containers:
               - name: portworx-operator
-                image: portworx/px-operator:1.9.0-dev
+                image: registry.connect.redhat.com/portworx/openstorage-operator@sha256:c1e25a64fd2fe5ca974182b316f6b4677b190ba292a1535af581cb286574703c
                 imagePullPolicy: Always
                 command:
                 - /operator

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	failureDomainZoneKey   = "failure-domain.beta.kubernetes.io/zone"
-	failureDomainRegionKey = "failure-domain.beta.kubernetes.io/region"
+	failureDomainZoneKey   = v1.LabelTopologyZone
+	failureDomainRegionKey = v1.LabelTopologyRegion
 )
 
 var (

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -756,6 +756,7 @@ func TestCloudStorageLabelSelector(t *testing.T) {
 	require.NoError(t, err)
 
 	// Node pool label get set by default
+	driver.EXPECT().UpdateDriver(gomock.Any())
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	cluster.Spec.CloudStorage.NodePoolLabel = ""
 	err = controller.setStorageClusterDefaults(cluster)
@@ -785,6 +786,7 @@ func TestStorageClusterDefaults(t *testing.T) {
 	controller.log(cluster).Debugf("testing default cluster")
 
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
+	driver.EXPECT().UpdateDriver(gomock.Any()).AnyTimes()
 
 	// Use default revision history limit if not set
 	err := controller.setStorageClusterDefaults(cluster)
@@ -830,6 +832,7 @@ func TestStorageClusterDefaultsForUpdateStrategy(t *testing.T) {
 		Driver: driver,
 	}
 
+	driver.EXPECT().UpdateDriver(gomock.Any()).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 
 	// Use rolling update as default update strategy if nothing specified
@@ -899,6 +902,7 @@ func TestStorageClusterDefaultsForFinalizer(t *testing.T) {
 		Driver: driver,
 	}
 
+	driver.EXPECT().UpdateDriver(gomock.Any()).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 
 	// Add delete finalizer if no finalizers are present
@@ -922,6 +926,97 @@ func TestStorageClusterDefaultsForFinalizer(t *testing.T) {
 	require.Equal(t, expectedFinalizers, cluster.Finalizers)
 }
 
+func getk8sCLientWithNodesZones(
+	nodeCount uint32,
+	totalZones uint32,
+	cluster *corev1.StorageCluster,
+) client.Client {
+	k8sClient := testutil.FakeK8sClient(cluster)
+	zoneCount := uint32(0)
+	for node := uint32(0); node < nodeCount; node++ {
+		k8sNode := createK8sNode("k8s-node-"+strconv.Itoa(int(node)), 10)
+		zoneCount = zoneCount % totalZones
+		k8sNode.Labels[v1.LabelTopologyZone] = "Zone-" + strconv.Itoa(int(zoneCount))
+		k8sClient.Create(context.TODO(), k8sNode)
+		zoneCount++
+	}
+	return k8sClient
+}
+
+func TestStorageClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "kube-test",
+		},
+	}
+	driver := testutil.MockDriver(mockCtrl)
+	/* 1 zone */
+	k8sClient := getk8sCLientWithNodesZones(6, 1, cluster)
+
+	controller := Controller{
+		client: k8sClient,
+		Driver: driver,
+	}
+	driver.EXPECT().UpdateDriver(gomock.Any()).MinTimes(1)
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).MinTimes(1)
+
+	err := controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.Equal(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
+	require.Equal(t, "", cluster.Status.Phase)
+
+	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
+	require.Equal(t, uint32(3), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
+	require.Equal(t, uint32(3), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+
+	/* 2 zones */
+	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+	controller.client = getk8sCLientWithNodesZones(8, 2, cluster)
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
+	require.Equal(t, uint32(2), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+
+	/* 3 zones */
+	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+	controller.client = getk8sCLientWithNodesZones(9, 3, cluster)
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
+	require.Equal(t, uint32(1), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+
+	/* 4 zones */
+	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+	controller.client = getk8sCLientWithNodesZones(8, 4, cluster)
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
+	require.Equal(t, uint32(1), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+
+	/* Value specified */
+	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{
+		MaxStorageNodesPerZone: new(uint32),
+	}
+	*cluster.Spec.CloudStorage.MaxStorageNodesPerZone = 7
+	controller.client = getk8sCLientWithNodesZones(30, 3, cluster)
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
+	require.Equal(t, uint32(7), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+}
+
 func TestStorageClusterDefaultsWithDriverOverrides(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -941,6 +1036,7 @@ func TestStorageClusterDefaultsWithDriverOverrides(t *testing.T) {
 		Driver: driver,
 	}
 
+	driver.EXPECT().UpdateDriver(gomock.Any()).AnyTimes()
 	driver.EXPECT().
 		SetDefaultsOnStorageCluster(gomock.Any()).
 		Do(func(cluster *corev1.StorageCluster) {
@@ -1120,6 +1216,7 @@ func TestFailureDuringDriverPreInstall(t *testing.T) {
 
 	driver.EXPECT().Validate().Return(nil).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(fmt.Errorf("preinstall error"))
+	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -1177,6 +1274,7 @@ func TestStoragePodsShouldNotBeScheduledIfDisabled(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
@@ -1304,6 +1402,7 @@ func TestStoragePodGetsScheduled(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).
 		Do(func(c *corev1.StorageCluster) {
 			hash := computeHash(&c.Spec, nil)
@@ -1379,9 +1478,9 @@ func TestStorageNodeGetsCreated(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(storageLabels).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
-	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
@@ -2634,6 +2733,7 @@ func TestFailedPreInstallFromDriver(t *testing.T) {
 	}
 
 	driver.EXPECT().Validate().Return(nil).AnyTimes()
+	driver.EXPECT().UpdateDriver(gomock.Any()).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
@@ -2684,22 +2784,23 @@ func TestUpdateDriverWithInstanceInformation(t *testing.T) {
 		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
 	}
 
-	driver.EXPECT().Validate().Return(nil).AnyTimes()
-	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
-	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
-	driver.EXPECT().String().Return(driverName).AnyTimes()
-	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
-	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
-	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	expectedDriverInfo := &storage.UpdateDriverInfo{
 		ZoneToInstancesMap: map[string]uint64{
 			"z1": 2,
 			"z2": 1,
 		},
 	}
+
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
+	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return(driverName).AnyTimes()
+	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().UpdateDriver(expectedDriverInfo).Return(nil)
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
+	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1123,9 +1123,9 @@ func (c *Controller) CreatePodTemplate(
 	return newTemplate, nil
 }
 
-// GetDefaultMaxStorageNodesPerZone aims to return a good value for MaxStorageNodesPerZone with the
+// getDefaultMaxStorageNodesPerZone aims to return a good value for MaxStorageNodesPerZone with the
 // intention of having at least 3 nodes in the cluster.
-func (c *Controller) GetDefaultMaxStorageNodesPerZone(zoneMap map[string]uint64) uint32 {
+func getDefaultMaxStorageNodesPerZone(zoneMap map[string]uint64) uint32 {
 	numZones := len(zoneMap)
 	switch numZones {
 	case 0, 1:
@@ -1235,7 +1235,7 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		toUpdate.Spec.CloudStorage.MaxStorageNodes == nil {
 		// Let's do this only when it's a fresh install of px
 		toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = new(uint32)
-		*toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = c.GetDefaultMaxStorageNodesPerZone(zoneMap)
+		*toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = getDefaultMaxStorageNodesPerZone(zoneMap)
 	}
 	c.Driver.SetDefaultsOnStorageCluster(toUpdate)
 


### PR DESCRIPTION
  A default value for max_storage_nodes_per_zone will be set when
  the cluster is created afresh. This change does not effect existing installs
  or upgrades.

  The value will be determined as follows
________________________________
  Zones | Default value | total nodes
______________________________
    1   |      3        |   3
    2   |      2        |   4
    3   |      1        |   3
    4   |      1        |   4

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Testing: Created a new cluster on vSphere, GCE and AWS and verified that it works for 1, 2, 3 & 4 zones

**GCE:
2 zones:
    "max_storage_nodes_per_zone": 2,**
root@gke-nrevanna-cluster-2-z-default-pool-0cf395ca-wp2l:/# pxctl status | grep gke-nrevanna| wc -l
4
root@gke-nrevanna-cluster-2-z-default-pool-0cf395ca-wp2l:/# pxctl status | grep gke-nrevanna| grep 'No Storage' |wc -l
0

**4 zones:
     "max_storage_nodes_per_zone": 1,**
root@gke-nrevanna-cluster-4-z-default-pool-65c80102-ntbg:/# pxctl status | grep gke-nrevanna| wc -l
8
root@gke-nrevanna-cluster-4-z-default-pool-65c80102-ntbg:/# pxctl status | grep gke-nrevanna| grep 'No Storage' |wc -l
4
root@gke-nrevanna-cluster-4-z-default-pool-65c80102-ntbg:/#


**EKS
3 zones:
    "max_storage_nodes_per_zone": 1**
[root@ip-192-168-47-179 /]# pxctl status | grep ip-192| wc -l
3


**2 zones
    "max_storage_nodes_per_zone": 2,**
[root@ip-192-168-6-129 /]# pxctl status| grep  ip-192-168 | wc -l
6
[root@ip-192-168-6-129 /]# pxctl status| grep  ip-192-168 | grep 'No Storage'| wc -l
2

**vSphere
1 zone
    "max_storage_nodes_per_zone": 3,**