### PR TITLE
[PWX-26222] Update to use custom envoy image for ccm-go

### DIFF
--- a/deploy/ccm/phonehome-cluster.yaml
+++ b/deploy/ccm/phonehome-cluster.yaml
@@ -46,7 +46,7 @@ spec:
               protocol: TCP
           imagePullPolicy: Always
         - name: envoy
-          image: envoyproxy/envoy:v1.22.2
+          image: purestorage/telemetry-envoy:1.0.0
           securityContext:
             runAsUser: 1111
           volumeMounts:
@@ -70,8 +70,15 @@ spec:
               protocol: TCP
       initContainers:
         - name: init-cont
-          image: bitnami/kubectl:1.24.3
-          command: ['/bin/bash', '-c', "cert=$(kubectl get secrets -n kube-system --field-selector=metadata.name=pure-telemetry-certs -ojson |jq .items[0].data.cert); until [[ ${#cert} -gt 4 ]]; do echo waiting for cert generation; sleep 4; cert=$(kubectl get secrets -n kube-system --field-selector=metadata.name=pure-telemetry-certs -ojson |jq .items[0].data.cert); done;"]
+          image: purestorage/telemetry-envoy:1.0.0
+          env:
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          args:
+            - "cert_checker"
+          imagePullPolicy: Always
       volumes:
         - name: etcpwx
           hostPath:

--- a/deploy/ccm/registration-service.yaml
+++ b/deploy/ccm/registration-service.yaml
@@ -29,7 +29,7 @@ spec:
               protocol: TCP
           imagePullPolicy: Always
         - name: envoy
-          image: envoyproxy/envoy:v1.22.2
+          image: purestorage/telemetry-envoy:1.0.0
           securityContext:
             runAsUser: 1111
           volumeMounts:

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12799,6 +12799,8 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		deployment := &appsv1.Deployment{}
 		err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
 		require.NoError(t, err)
+		require.Len(t, deployment.Spec.Template.Spec.InitContainers, 0)
+		require.Equal(t, component.CollectorServiceAccountName, deployment.Spec.Template.Spec.ServiceAccountName)
 		// validate ccm go components don't exist
 		err = testutil.Get(k8sClient, serviceAccount, component.ServiceAccountNamePxTelemetry, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
@@ -12898,15 +12900,17 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		require.NoError(t, err)
 		roleBinding = &rbacv1.RoleBinding{}
 		err = testutil.Get(k8sClient, roleBinding, component.CollectorRoleBindingName, cluster.Namespace)
-		deployment = &appsv1.Deployment{}
-		err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
-		require.NoError(t, err)
 		configMap = &v1.ConfigMap{}
 		err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
 		require.NoError(t, err)
 		configMap = &v1.ConfigMap{}
 		err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
 		require.NoError(t, err)
+		deployment = &appsv1.Deployment{}
+		err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
+		require.NoError(t, err)
+		require.Len(t, deployment.Spec.Template.Spec.InitContainers, 1)
+		require.Equal(t, component.ServiceAccountNamePxTelemetry, deployment.Spec.Template.Spec.ServiceAccountName)
 	}
 	validateCCMGoComponents()
 }

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -34,7 +34,7 @@ const (
 	defaultCollectorImage      = "purestorage/realtime-metrics:1.0.1"
 	defaultCCMGoImage          = "purestorage/ccm-go:1.0.0"
 	defaultLogUploaderImage    = "purestorage/log-upload:1.0.0"
-	defaultCCMGoProxyImage     = "envoyproxy/envoy:v1.22.2"
+	defaultCCMGoProxyImage     = "purestorage/telemetry-envoy:1.0.0"
 	defaultPxRepoImage         = "portworx/px-repo:1.1.0"
 
 	// DefaultPrometheusOperatorImage is the default Prometheus operator image for k8s 1.21 and below

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -252,7 +252,7 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			PrometheusConfigReloader:  "image/prometheus-config-reloader:2.6.0",
 			AlertManager:              "image/alertmanager:2.6.0",
 			Telemetry:                 "image/ccm-go:1.0.0",
-			TelemetryProxy:            "envoyproxy/envoy:v1.22.2",
+			TelemetryProxy:            "purestorage/telemetry-envoy:1.0.0",
 			LogUploader:               "purestorage/log-upload:1.0.0",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			PxRepo:                    "portworx/px-repo:1.1.0",

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1017,8 +1017,14 @@ func IsMetricsCollectorSupported(pxVersion *version.Version) bool {
 //   affinity
 //   toleration
 func ApplyStorageClusterSettingsToPodSpec(cluster *corev1.StorageCluster, podSpec *v1.PodSpec) {
+	var containers []*v1.Container
 	for i := 0; i < len(podSpec.Containers); i++ {
-		container := &podSpec.Containers[i]
+		containers = append(containers, &podSpec.Containers[i])
+	}
+	for i := 0; i < len(podSpec.InitContainers); i++ {
+		containers = append(containers, &podSpec.InitContainers[i])
+	}
+	for _, container := range containers {
 		// Change image to custom repository if it has not been done
 		if !strings.HasPrefix(container.Image, strings.TrimSuffix(cluster.Spec.CustomImageRegistry, "/")) {
 			container.Image = util.GetImageURN(cluster, container.Image)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: 
* use custom envoy image to avoid using `kubectl` image for init containers of metrics collector and log uploader
* based on previous PR, please look at the top commit only if get chance, main logic is ready for review
* TODO: change hardcoded images

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

