### PR TITLE
[PWX-26142][PWX-26222]Use new envoy image in init containers and update all ccm-go component names

### DIFF
--- a/deploy/ccm/phonehome-cluster.yaml
+++ b/deploy/ccm/phonehome-cluster.yaml
@@ -46,7 +46,7 @@ spec:
               protocol: TCP
           imagePullPolicy: Always
         - name: envoy
-          image: envoyproxy/envoy:v1.22.2
+          image: purestorage/telemetry-envoy:1.0.0
           securityContext:
             runAsUser: 1111
           volumeMounts:
@@ -70,8 +70,15 @@ spec:
               protocol: TCP
       initContainers:
         - name: init-cont
-          image: bitnami/kubectl:1.24.3
-          command: ['/bin/bash', '-c', "cert=$(kubectl get secrets -n kube-system --field-selector=metadata.name=pure-telemetry-certs -ojson |jq .items[0].data.cert); until [[ ${#cert} -gt 4 ]]; do echo waiting for cert generation; sleep 4; cert=$(kubectl get secrets -n kube-system --field-selector=metadata.name=pure-telemetry-certs -ojson |jq .items[0].data.cert); done;"]
+          image: purestorage/telemetry-envoy:1.0.0
+          env:
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          args:
+            - "cert_checker"
+          imagePullPolicy: Always
       volumes:
         - name: etcpwx
           hostPath:

--- a/deploy/ccm/phonehome-cluster.yaml
+++ b/deploy/ccm/phonehome-cluster.yaml
@@ -98,14 +98,14 @@ spec:
                 path: ccm.properties
               - key: location
                 path: location
-            name: px-telemetry-config
+            name: px-telemetry-phonehome
           name: ccm-config
         - name: proxy-config
           configMap:
-            name: proxy-config-rest
+            name: px-telemetry-phonehome-proxy
         - name: tls-certificate
           configMap:
-            name: tls-certificate
+            name: px-telemetry-tls-certificate
         - name: pure-telemetry-certs
           secret:
             secretName: pure-telemetry-certs

--- a/deploy/ccm/px-telemetry-role-binding.yaml
+++ b/deploy/ccm/px-telemetry-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: px-telemetry
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: px-telemetry
+subjects:
+- kind: ServiceAccount
+  name: px-telemetry
+  apiGroup: ""
+  namespace: kube-system

--- a/deploy/ccm/px-telemetry-role.yaml
+++ b/deploy/ccm/px-telemetry-role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: px-telemetry
+rules:
+- apiGroups: ["core.libopenstorage.org"]
+  resources: ["storageclusters"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "create", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]

--- a/deploy/ccm/registration-service.yaml
+++ b/deploy/ccm/registration-service.yaml
@@ -29,7 +29,7 @@ spec:
               protocol: TCP
           imagePullPolicy: Always
         - name: envoy
-          image: envoyproxy/envoy:v1.22.2
+          image: purestorage/telemetry-envoy:1.0.0
           securityContext:
             runAsUser: 1111
           volumeMounts:

--- a/deploy/ccm/registration-service.yaml
+++ b/deploy/ccm/registration-service.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: registration-service
+  name: px-telemetry-registration
 spec:
   replicas: 1
   selector:
     matchLabels:
-      role: registration-service
+      role: px-telemetry-registration
   template:
     metadata:
       labels:
-        role: registration-service
+        role: px-telemetry-registration
     spec:
       hostNetwork: true
       containers:
@@ -43,7 +43,7 @@ spec:
       volumes:
         - name: registration-config
           configMap:
-            name: registration-config
+            name: px-telemetry-register
         - name: proxy-config
           configMap:
-            name: proxy-config-register
+            name: px-telemetry-register-proxy

--- a/deploy/ccm/secret-manager-role-binding.yaml
+++ b/deploy/ccm/secret-manager-role-binding.yaml
@@ -2,13 +2,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: kube-system
-  name: registerrolebinding
+  name: px-telemetry-secret-manager
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: secret-manager
+  name: px-telemetry-secret-manager
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: px-telemetry
   apiGroup: ""
   namespace: kube-system

--- a/deploy/ccm/secret-manager-role.yaml
+++ b/deploy/ccm/secret-manager-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: kube-system
-  name: secret-manager
+  name: px-telemetry-secret-manager
 rules:
 - apiGroups: [""]
   resources: ["secrets"]

--- a/deploy/ccm/stc-reader-role-binding.yaml
+++ b/deploy/ccm/stc-reader-role-binding.yaml
@@ -2,13 +2,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   namespace: kube-system
-  name: stcrolebinding
+  name: px-telemetry-stc-reader
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: stc-reader
+  name: px-telemetry-stc-reader
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: px-telemetry
   apiGroup: ""
   namespace: kube-system

--- a/deploy/ccm/stc-reader-role.yaml
+++ b/deploy/ccm/stc-reader-role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: kube-system
-  name: stc-reader
+  name: px-telemetry-stc-reader
 rules:
 - apiGroups: ["core.libopenstorage.org"]
   resources: ["storageclusters"]

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -29,60 +29,70 @@ import (
 
 // TODO: change all names to be px specific
 const (
-	// RoleNameSecretManager is name of role secret-manager
-	RoleNameSecretManager = "secret-manager"
-	// RoleBindingNameSecretManager is name of role binding registerrolebinding
-	RoleBindingNameSecretManager = "registerrolebinding"
-	// RoleNameSTCReader is name of role stc-reader
-	RoleNameSTCReader = "stc-reader"
-	// RoleBindingNameSTCReader is name of role binding stcrolebinding
-	RoleBindingNameSTCReader = "stcrolebinding"
-	// ConfigMapNameRegistrationConfig is name of config map registration-config
-	ConfigMapNameRegistrationConfig = "registration-config"
-	// ConfigMapNameProxyConfigRegister is name of config map proxy-config-register
-	ConfigMapNameProxyConfigRegister = "proxy-config-register"
-	// ConfigMapNameProxyConfigRest is name of config map proxy-config-rest
-	ConfigMapNameProxyConfigRest = "proxy-config-rest"
-	// ConfigMapNameTLSCertificate is name of config map tls-certificate
-	ConfigMapNameTLSCertificate = "tls-certificate"
-	// ConfigMapNamePxTelemetryConfig is name of config map px-telemetry-config
-	ConfigMapNamePxTelemetryConfig = TelemetryConfigMapName
-	// DeploymentNameRegistrationService is name of deployment registration-servicea
-	DeploymentNameRegistrationService = "registration-service"
-	// DaemonSetNameTelemetryPhonehome is name of deployment phonehome-cluster
+	// ServiceAccountNameTelemetry is name of telemetry service account
+	ServiceAccountNameTelemetry = "px-telemetry"
+	// ClusterRoleNameTelemetry is name of telemetry cluster role
+	ClusterRoleNameTelemetry = "px-telemetry"
+	// ClusterRoleBindingNameTelemetry is name of telemetry cluster role binding
+	ClusterRoleBindingNameTelemetry = "px-telemetry"
+	// RoleNameSecretManager is name of secret manager role
+	RoleNameSecretManager = "px-telemetry-secret-manager"
+	// RoleBindingNameSecretManager is name of secret manager role binding
+	RoleBindingNameSecretManager = "px-telemetry-secret-manager"
+	// RoleNameSTCReader is name of stc reader role
+	RoleNameSTCReader = "px-telemetry-stc-reader"
+	// RoleBindingNameSTCReader is name of stc reader role binding
+	RoleBindingNameSTCReader = "px-telemetry-stc-reader"
+	// RoleNameTelemetryCollectorV2 is name of role for metrics collector V2
+	RoleNameTelemetryCollectorV2 = "px-telemetry-collector"
+	// RoleBindingNameTelemetryCollectorV2 is name of role binding for metrics collector V2
+	RoleBindingNameTelemetryCollectorV2 = "px-telemetry-collector"
+	// ConfigMapNameTelemetryRegister is name of config map for registration
+	ConfigMapNameTelemetryRegister = "px-telemetry-register"
+	// ConfigMapNameTelemetryRegisterProxy is name of config map for registration proxy
+	ConfigMapNameTelemetryRegisterProxy = "px-telemetry-register-proxy"
+	// ConfigMapNameTelemetryPhonehome is name of config map for phonehome
+	ConfigMapNameTelemetryPhonehome = "px-telemetry-phonehome"
+	// ConfigMapNameTelemetryPhonehomeProxy is name of config map for phonehome proxy
+	ConfigMapNameTelemetryPhonehomeProxy = "px-telemetry-phonehome-proxy"
+	// ConfigMapNameTelemetryTLSCertificate is name of config map tls-certificate
+	ConfigMapNameTelemetryTLSCertificate = "px-telemetry-tls-certificate"
+	// ConfigMapNameTelemetryCollectorV2 is name of config map for metrics collector
+	ConfigMapNameTelemetryCollectorV2 = "px-telemetry-collector"
+	// ConfigMapNameTelemetryCollectorProxyV2 is name of config map for metrics collector proxy
+	ConfigMapNameTelemetryCollectorProxyV2 = "px-telemetry-collector-proxy"
+	// DeploymentNameTelemetryRegistration is name of telemetry registration deployment
+	DeploymentNameTelemetryRegistration = "px-telemetry-registration"
+	// DaemonSetNameTelemetryPhonehome is name of phonehome daemonset
 	DaemonSetNameTelemetryPhonehome = "px-telemetry-phonehome"
-	// ServiceAccountNamePxTelemetry is name of service account px-telemetry
-	ServiceAccountNamePxTelemetry = "px-telemetry"
-	// ClusterRoleNamePxTelemetry is name of cluster role px-telemetry
-	ClusterRoleNamePxTelemetry = "px-telemetry"
-	// ClusterRoleBindingNamePxTelemetry is name of cluster role binding px-telemetry
-	ClusterRoleBindingNamePxTelemetry = "px-telemetry"
+	// DeploymentNameTelemetryCollectorV2 is name of telemetry metrics collector
+	DeploymentNameTelemetryCollectorV2 = "px-telemetry-metrics-collector"
 
-	roleFileNameSecretManager             = "secret-manager-role.yaml"
-	roleBindingFileNameSecretManager      = "secret-manager-role-binding.yaml"
-	roleFileNameSTCReader                 = "stc-reader-role.yaml"
-	roleBindingFileNameSTCReader          = "stc-reader-role-binding.yaml"
-	deploymentFileNameRegistrationService = "registration-service.yaml"
-	daemonsetFileNameTelemetryPhonehome   = "phonehome-cluster.yaml"
-	containerNameRegistrationService      = "registration"
-	containerNameLogUploader              = "log-upload-service"
-	containerNameTelemetryProxy           = "envoy"
-	portNameLogUploaderContainer          = "loguploader"
+	roleFileNameSecretManager                    = "secret-manager-role.yaml"
+	roleBindingFileNameSecretManager             = "secret-manager-role-binding.yaml"
+	roleFileNameSTCReader                        = "stc-reader-role.yaml"
+	roleBindingFileNameSTCReader                 = "stc-reader-role-binding.yaml"
+	configFileNameTelemetryRegister              = "config_properties_px.yaml"
+	configFileNameTelemetryRegisterProxy         = "envoy-config-register.yaml"
+	configFileNameTelemetryRegisterCustomerProxy = "envoy-config-register-customer-proxy.yaml"
+	configFileNameTelemetryPhonehome             = "ccm.properties"
+	configFileNameTelemetryPhonehomeProxy        = "envoy-config-rest.yaml"
+	configFileNameTelemetryTLSCertificate        = "tls_certificate_sds_secret.yaml"
+	deploymentFileNameTelemetryRegistration      = "registration-service.yaml"
+	daemonsetFileNameTelemetryPhonehome          = "phonehome-cluster.yaml"
 
-	configFileNameRegistrationConfig               = "config_properties_px.yaml"
-	configFileNameProxyConfigRegister              = "envoy-config-register.yaml"
-	configFileNameProxyConfigRegisterCustomerProxy = "envoy-config-register-customer-proxy.yaml"
-	configFileNameProxyConfigRest                  = "envoy-config-rest.yaml"
-	configFileNameTLSCertificate                   = "tls_certificate_sds_secret.yaml"
-	configFileNamePXTelemetryConfig                = TelemetryPropertiesFilename
-	configParameterApplianceID                     = "APPLIANCE_ID"
-	configParameterComponentSN                     = "COMPONENT_SN"
-	configParameterProductVersion                  = "PRODUCT_VERSION"
-	configParameterRegisterProxyURL                = "REGISTER_PROXY_URL"
-	configParameterRestProxyURL                    = "REST_PROXY_URL"
-	configParameterCertSecretNamespace             = "CERT_SECRET_NAMESPACE"
-	configParameterCustomProxyPort                 = "CUSTOM_PROXY_PORT"
-	configParameterPortworxPort                    = "PORTWORX_PORT"
+	configParameterApplianceID         = "APPLIANCE_ID"
+	configParameterComponentSN         = "COMPONENT_SN"
+	configParameterProductVersion      = "PRODUCT_VERSION"
+	configParameterRegisterProxyURL    = "REGISTER_PROXY_URL"
+	configParameterRestProxyURL        = "REST_PROXY_URL"
+	configParameterCertSecretNamespace = "CERT_SECRET_NAMESPACE"
+	configParameterCustomProxyPort     = "CUSTOM_PROXY_PORT"
+	configParameterPortworxPort        = "PORTWORX_PORT"
+	containerNameTelemetryRegistration = "registration"
+	containerNameLogUploader           = "log-upload-service"
+	containerNameTelemetryProxy        = "envoy"
+	portNameLogUploaderContainer       = "loguploader"
 
 	productionArcusLocation         = "external"
 	productionArcusRestProxyURL     = "rest.cloud-support.purestorage.com"
@@ -210,7 +220,7 @@ func (t *telemetry) deleteCCMGo(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	if err := k8sutil.DeleteServiceAccount(t.k8sClient, ServiceAccountNamePxTelemetry, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteServiceAccount(t.k8sClient, ServiceAccountNameTelemetry, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
 	if err := t.deleteCCMGoClusterRoleAndClusterRoleBinding(); err != nil {
@@ -239,10 +249,6 @@ func (t *telemetry) reconcileCCMGoServiceAccount(
 	if err := t.createServiceAccountPxTelemetry(cluster, ownerRef); err != nil {
 		return err
 	}
-	// Delete service account used by metrics collector v1
-	if err := k8sutil.DeleteServiceAccount(t.k8sClient, CollectorServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -256,21 +262,14 @@ func (t *telemetry) reconcileCCMGoClusterRolesAndClusterRoleBindings(
 	if err := t.createClusterRoleBindingPxTelemetry(cluster.Namespace); err != nil {
 		return err
 	}
-	// Delete cluster role and cluster role binding used by metrics collector v1
-	if err := k8sutil.DeleteClusterRole(t.k8sClient, CollectorClusterRoleName); err != nil {
-		return err
-	}
-	if err := k8sutil.DeleteClusterRoleBinding(t.k8sClient, CollectorClusterRoleBindingName); err != nil {
-		return err
-	}
 	return nil
 }
 
 func (t *telemetry) deleteCCMGoClusterRoleAndClusterRoleBinding() error {
-	if err := k8sutil.DeleteClusterRole(t.k8sClient, ClusterRoleNamePxTelemetry); err != nil {
+	if err := k8sutil.DeleteClusterRole(t.k8sClient, ClusterRoleNameTelemetry); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteClusterRoleBinding(t.k8sClient, ClusterRoleBindingNamePxTelemetry); err != nil {
+	if err := k8sutil.DeleteClusterRoleBinding(t.k8sClient, ClusterRoleBindingNameTelemetry); err != nil {
 		return err
 	}
 	return nil
@@ -326,10 +325,10 @@ func (t *telemetry) deleteCCMGoRolesAndRoleBindings(
 	if err := k8sutil.DeleteRole(t.k8sClient, RoleNameSTCReader, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteRole(t.k8sClient, CollectorRoleName, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteRole(t.k8sClient, RoleNameTelemetryCollectorV2, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteRoleBinding(t.k8sClient, CollectorRoleBindingName, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteRoleBinding(t.k8sClient, RoleBindingNameTelemetryCollectorV2, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
 	return nil
@@ -339,10 +338,6 @@ func (t *telemetry) reconcileCCMGoRegistrationService(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	// Delete unused old components from ccm java
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef); err != nil {
-		return err
-	}
 	// Create cm registration-config from config_properties_px.yaml
 	if err := t.createCCMGoConfigMapRegistrationConfig(cluster, ownerRef); err != nil {
 		logrus.WithError(err).Error("failed to create cm registration-config from config_properties_px.yaml ")
@@ -355,7 +350,7 @@ func (t *telemetry) reconcileCCMGoRegistrationService(
 	}
 	// Create deployment registration-service
 	if err := t.createDeploymentRegistrationService(cluster, ownerRef); err != nil {
-		logrus.WithError(err).Errorf("failed to create deployment %s/%s", cluster.Namespace, DeploymentNameRegistrationService)
+		logrus.WithError(err).Errorf("failed to create deployment %s/%s", cluster.Namespace, DeploymentNameTelemetryRegistration)
 		return err
 	}
 	return nil
@@ -365,13 +360,13 @@ func (t *telemetry) deleteCCMGoRegistrationService(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameRegistrationConfig, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameTelemetryRegister, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameProxyConfigRegister, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameTelemetryRegisterProxy, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteDeployment(t.k8sClient, DeploymentNameRegistrationService, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteDeployment(t.k8sClient, DeploymentNameTelemetryRegistration, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
 	t.isDeploymentRegistrationServiceCreated = false
@@ -382,6 +377,13 @@ func (t *telemetry) reconcileCCMGoTelemetryPhonehome(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	// Delete unused old components from ccm java
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, TelemetryConfigMapName, cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef); err != nil {
+		return err
+	}
 	// Reconcile config maps for log uploader
 	// Creat cm proxy-config-rest from envoy-config-rest.yaml
 	if err := t.createCCMGoConfigMapProxyConfigRest(cluster, ownerRef); err != nil {
@@ -411,13 +413,13 @@ func (t *telemetry) deleteCCMGoPhonehomeCluster(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameProxyConfigRest, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameTelemetryPhonehomeProxy, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameTLSCertificate, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameTelemetryTLSCertificate, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNamePxTelemetryConfig, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameTelemetryPhonehome, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
 	if err := k8sutil.DeleteDaemonSet(t.k8sClient, DaemonSetNameTelemetryPhonehome, cluster.Namespace, *ownerRef); err != nil {
@@ -430,6 +432,11 @@ func (t *telemetry) reconcileCCMGoMetricsCollectorV2(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	// Delete metrics collector V1 if exists
+	if err := t.deleteMetricsCollectorV1(cluster.Namespace, ownerRef); err != nil {
+		return err
+	}
+	// Deploy metrics collector V2 with all new object names
 	if err := t.createCollectorProxyConfigMap(cluster, ownerRef); err != nil {
 		return err
 	}
@@ -446,13 +453,13 @@ func (t *telemetry) deleteCCMGoMetricsCollectorV2(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, CollectorProxyConfigMapName, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameTelemetryCollectorV2, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteConfigMap(t.k8sClient, CollectorConfigMapName, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteConfigMap(t.k8sClient, ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteDeployment(t.k8sClient, CollectorDeploymentName, cluster.Namespace, *ownerRef); err != nil {
+	if err := k8sutil.DeleteDeployment(t.k8sClient, DeploymentNameTelemetryCollectorV2, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
 	t.isCollectorDeploymentCreated = false
@@ -502,7 +509,7 @@ func (t *telemetry) createServiceAccountPxTelemetry(
 		t.k8sClient,
 		&v1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            ServiceAccountNamePxTelemetry,
+				Name:            ServiceAccountNameTelemetry,
 				Namespace:       cluster.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
@@ -516,7 +523,7 @@ func (t *telemetry) createClusterRolePxTelemetry() error {
 		t.k8sClient,
 		&rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: ClusterRoleNamePxTelemetry,
+				Name: ClusterRoleNameTelemetry,
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
@@ -541,18 +548,18 @@ func (t *telemetry) createClusterRoleBindingPxTelemetry(clusterNamespace string)
 		t.k8sClient,
 		&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: ClusterRoleBindingNamePxTelemetry,
+				Name: ClusterRoleBindingNameTelemetry,
 			},
 			Subjects: []rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",
-					Name:      ServiceAccountNamePxTelemetry,
+					Name:      ServiceAccountNameTelemetry,
 					Namespace: clusterNamespace,
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
 				Kind:     "ClusterRole",
-				Name:     ClusterRoleNamePxTelemetry,
+				Name:     ClusterRoleNameTelemetry,
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},
@@ -564,7 +571,7 @@ func (t *telemetry) createCCMGoConfigMapRegistrationConfig(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	config, err := readConfigMapDataFromFile(configFileNameRegistrationConfig, map[string]string{
+	config, err := readConfigMapDataFromFile(configFileNameTelemetryRegister, map[string]string{
 		configParameterCertSecretNamespace: cluster.Namespace,
 	})
 	if err != nil {
@@ -574,12 +581,12 @@ func (t *telemetry) createCCMGoConfigMapRegistrationConfig(
 		t.k8sClient,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            ConfigMapNameRegistrationConfig,
+				Name:            ConfigMapNameTelemetryRegister,
 				Namespace:       cluster.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Data: map[string]string{
-				configFileNameRegistrationConfig: config,
+				configFileNameTelemetryRegister: config,
 			},
 		},
 		ownerRef,
@@ -591,7 +598,7 @@ func (t *telemetry) createCCMGoConfigMapProxyConfigRegister(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	configFileName := configFileNameProxyConfigRegister
+	configFileName := configFileNameTelemetryRegisterProxy
 	replaceMap := map[string]string{
 		configParameterApplianceID:    cluster.Status.ClusterUID,
 		configParameterComponentSN:    cluster.Name,
@@ -613,12 +620,12 @@ func (t *telemetry) createCCMGoConfigMapProxyConfigRegister(
 		t.k8sClient,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            ConfigMapNameProxyConfigRegister,
+				Name:            ConfigMapNameTelemetryRegisterProxy,
 				Namespace:       cluster.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Data: map[string]string{
-				configFileNameProxyConfigRegister: config,
+				configFileNameTelemetryRegisterProxy: config,
 			},
 		},
 		ownerRef,
@@ -630,7 +637,7 @@ func (t *telemetry) createCCMGoConfigMapProxyConfigRest(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	configFileName := configFileNameProxyConfigRest
+	configFileName := configFileNameTelemetryPhonehomeProxy
 	replaceMap := map[string]string{
 		configParameterApplianceID:    cluster.Status.ClusterUID,
 		configParameterProductVersion: pxutil.GetPortworxVersion(cluster).String(),
@@ -651,12 +658,12 @@ func (t *telemetry) createCCMGoConfigMapProxyConfigRest(
 		t.k8sClient,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            ConfigMapNameProxyConfigRest,
+				Name:            ConfigMapNameTelemetryPhonehomeProxy,
 				Namespace:       cluster.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Data: map[string]string{
-				configFileNameProxyConfigRest: config,
+				configFileNameTelemetryPhonehomeProxy: config,
 			},
 		},
 		ownerRef,
@@ -668,7 +675,7 @@ func (t *telemetry) createCCMGoConfigMapTLSCertificate(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	config, err := readConfigMapDataFromFile(configFileNameTLSCertificate, nil)
+	config, err := readConfigMapDataFromFile(configFileNameTelemetryTLSCertificate, nil)
 	if err != nil {
 		return err
 	}
@@ -676,12 +683,12 @@ func (t *telemetry) createCCMGoConfigMapTLSCertificate(
 		t.k8sClient,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            ConfigMapNameTLSCertificate,
+				Name:            ConfigMapNameTelemetryTLSCertificate,
 				Namespace:       cluster.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Data: map[string]string{
-				configFileNameTLSCertificate: config,
+				configFileNameTelemetryTLSCertificate: config,
 			},
 		},
 		ownerRef,
@@ -693,7 +700,7 @@ func (t *telemetry) createCCMGoConfigMapPXTelemetryConfig(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	config, err := readConfigMapDataFromFile(configFileNamePXTelemetryConfig, map[string]string{
+	config, err := readConfigMapDataFromFile(configFileNameTelemetryPhonehome, map[string]string{
 		configParameterPortworxPort: fmt.Sprintf(`"%v"`, logUploaderPort),
 	})
 	if err != nil {
@@ -703,13 +710,13 @@ func (t *telemetry) createCCMGoConfigMapPXTelemetryConfig(
 		t.k8sClient,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            ConfigMapNamePxTelemetryConfig,
+				Name:            ConfigMapNameTelemetryPhonehome,
 				Namespace:       cluster.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Data: map[string]string{
-				configFileNamePXTelemetryConfig: config,
-				TelemetryArcusLocationFilename:  getArcusTelemetryLocation(cluster),
+				configFileNameTelemetryPhonehome: config,
+				TelemetryArcusLocationFilename:   getArcusTelemetryLocation(cluster),
 			},
 		},
 		ownerRef,
@@ -720,7 +727,7 @@ func (t *telemetry) createDeploymentRegistrationService(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	deployment, err := k8sutil.GetDeploymentFromFile(deploymentFileNameRegistrationService, pxutil.SpecsBaseDir())
+	deployment, err := k8sutil.GetDeploymentFromFile(deploymentFileNameTelemetryRegistration, pxutil.SpecsBaseDir())
 	if err != nil {
 		return err
 	}
@@ -734,16 +741,16 @@ func (t *telemetry) createDeploymentRegistrationService(
 	}
 	for i := 0; i < len(deployment.Spec.Template.Spec.Containers); i++ {
 		container := &deployment.Spec.Template.Spec.Containers[i]
-		if container.Name == containerNameRegistrationService {
+		if container.Name == containerNameTelemetryRegistration {
 			container.Image = telemetryImage
 		} else if container.Name == containerNameTelemetryProxy {
 			container.Image = proxyImage
 		}
 	}
-	deployment.Name = DeploymentNameRegistrationService
+	deployment.Name = DeploymentNameTelemetryRegistration
 	deployment.Namespace = cluster.Namespace
 	deployment.OwnerReferences = []metav1.OwnerReference{*ownerRef}
-	deployment.Spec.Template.Spec.ServiceAccountName = ServiceAccountNamePxTelemetry
+	deployment.Spec.Template.Spec.ServiceAccountName = ServiceAccountNameTelemetry
 	pxutil.ApplyStorageClusterSettingsToPodSpec(cluster, &deployment.Spec.Template.Spec)
 
 	existingDeployment := &appsv1.Deployment{}
@@ -807,7 +814,7 @@ func (t *telemetry) createDaemonSetPXTelemetryPhonehome(
 	daemonset.Name = DaemonSetNameTelemetryPhonehome
 	daemonset.Namespace = cluster.Namespace
 	daemonset.OwnerReferences = []metav1.OwnerReference{*ownerRef}
-	daemonset.Spec.Template.Spec.ServiceAccountName = ServiceAccountNamePxTelemetry
+	daemonset.Spec.Template.Spec.ServiceAccountName = ServiceAccountNameTelemetry
 	pxutil.ApplyStorageClusterSettingsToPodSpec(cluster, &daemonset.Spec.Template.Spec)
 
 	existingDaemonSet := &appsv1.DaemonSet{}
@@ -934,7 +941,7 @@ func createRoleBindingFromFile(
 	roleBinding.Subjects = []rbacv1.Subject{
 		{
 			Kind:      "ServiceAccount",
-			Name:      ServiceAccountNamePxTelemetry,
+			Name:      ServiceAccountNameTelemetry,
 			APIGroup:  "",
 			Namespace: cluster.Namespace,
 		},

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -439,15 +439,11 @@ func (t *telemetry) createCollectorRole(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	roleName := CollectorRoleName
-	if t.isCCMGoSupported {
-		roleName = RoleNameTelemetryCollectorV2
-	}
 	return k8sutil.CreateOrUpdateRole(
 		t.k8sClient,
 		&rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            roleName,
+				Name:            CollectorRoleName,
 				Namespace:       cluster.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
@@ -467,32 +463,24 @@ func (t *telemetry) createCollectorRoleBinding(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	roleName := CollectorRoleName
-	roleBindingName := CollectorRoleBindingName
-	serviceAccountName := CollectorServiceAccountName
-	if t.isCCMGoSupported {
-		roleName = RoleNameTelemetryCollectorV2
-		roleBindingName = RoleBindingNameTelemetryCollectorV2
-		serviceAccountName = ServiceAccountNameTelemetry
-	}
 	return k8sutil.CreateOrUpdateRoleBinding(
 		t.k8sClient,
 		&rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            roleBindingName,
+				Name:            CollectorRoleBindingName,
 				Namespace:       cluster.Namespace,
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Subjects: []rbacv1.Subject{
 				{
 					Kind:      "ServiceAccount",
-					Name:      serviceAccountName,
+					Name:      CollectorServiceAccountName,
 					Namespace: cluster.Namespace,
 				},
 			},
 			RoleRef: rbacv1.RoleRef{
 				Kind:     "Role",
-				Name:     roleName,
+				Name:     CollectorRoleName,
 				APIGroup: "rbac.authorization.k8s.io",
 			},
 		},

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12569,37 +12569,15 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 	err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNameTelemetry, "")
 	require.NoError(t, err)
 
-	// Validate ccm-go role and role bindings
+	// Validate ccm-go role and role binding
 	role := &rbacv1.Role{}
-	err = testutil.Get(k8sClient, role, component.RoleNameSecretManager, cluster.Namespace)
+	err = testutil.Get(k8sClient, role, component.RoleNameTelemetry, cluster.Namespace)
 	require.NoError(t, err)
 	require.Len(t, role.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, role.OwnerReferences[0].Name)
 
 	roleBinding := &rbacv1.RoleBinding{}
-	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSecretManager, cluster.Namespace)
-	require.NoError(t, err)
-	require.Len(t, roleBinding.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, roleBinding.OwnerReferences[0].Name)
-
-	role = &rbacv1.Role{}
-	err = testutil.Get(k8sClient, role, component.RoleNameSTCReader, cluster.Namespace)
-	require.NoError(t, err)
-	require.Len(t, role.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, role.OwnerReferences[0].Name)
-	roleBinding = &rbacv1.RoleBinding{}
-	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSTCReader, cluster.Namespace)
-	require.NoError(t, err)
-	require.Len(t, roleBinding.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, roleBinding.OwnerReferences[0].Name)
-
-	role = &rbacv1.Role{}
-	err = testutil.Get(k8sClient, role, component.RoleNameTelemetryCollectorV2, cluster.Namespace)
-	require.NoError(t, err)
-	require.Len(t, role.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, role.OwnerReferences[0].Name)
-	roleBinding = &rbacv1.RoleBinding{}
-	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetryCollectorV2, cluster.Namespace)
+	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetry, cluster.Namespace)
 	require.NoError(t, err)
 	require.Len(t, roleBinding.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, roleBinding.OwnerReferences[0].Name)
@@ -12705,17 +12683,9 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, role, component.RoleNameSecretManager, cluster.Namespace)
+	err = testutil.Get(k8sClient, role, component.RoleNameTelemetry, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSecretManager, cluster.Namespace)
-	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, role, component.RoleNameSTCReader, cluster.Namespace)
-	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSTCReader, cluster.Namespace)
-	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, role, component.RoleNameTelemetryCollectorV2, cluster.Namespace)
-	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetryCollectorV2, cluster.Namespace)
+	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetry, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
 	err = testutil.Get(k8sClient, clusterRole, component.ClusterRoleNameTelemetry, "")
 	require.True(t, errors.IsNotFound(err))
@@ -12830,17 +12800,9 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNameTelemetry, "")
 		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, role, component.RoleNameSecretManager, cluster.Namespace)
+		err = testutil.Get(k8sClient, role, component.RoleNameTelemetry, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSecretManager, cluster.Namespace)
-		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, role, component.RoleNameTelemetryCollectorV2, cluster.Namespace)
-		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetryCollectorV2, cluster.Namespace)
-		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, role, component.RoleNameSTCReader, cluster.Namespace)
-		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSTCReader, cluster.Namespace)
+		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetry, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegister, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
@@ -12889,22 +12851,10 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNameTelemetry, "")
 		require.NoError(t, err)
 		role := &rbacv1.Role{}
-		err = testutil.Get(k8sClient, role, component.RoleNameSecretManager, cluster.Namespace)
+		err = testutil.Get(k8sClient, role, component.RoleNameTelemetry, cluster.Namespace)
 		require.NoError(t, err)
 		roleBinding := &rbacv1.RoleBinding{}
-		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSecretManager, cluster.Namespace)
-		require.NoError(t, err)
-		role = &rbacv1.Role{}
-		err = testutil.Get(k8sClient, role, component.RoleNameSTCReader, cluster.Namespace)
-		require.NoError(t, err)
-		roleBinding = &rbacv1.RoleBinding{}
-		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSTCReader, cluster.Namespace)
-		require.NoError(t, err)
-		role = &rbacv1.Role{}
-		err = testutil.Get(k8sClient, role, component.RoleNameTelemetryCollectorV2, cluster.Namespace)
-		require.NoError(t, err)
-		roleBinding = &rbacv1.RoleBinding{}
-		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetryCollectorV2, cluster.Namespace)
+		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetry, cluster.Namespace)
 		require.NoError(t, err)
 		configMap := &v1.ConfigMap{}
 		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegister, cluster.Namespace)

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12557,16 +12557,16 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 
 	// Validate ccm-go service account, cluster role and cluster role binding
 	serviceAccount := &v1.ServiceAccount{}
-	err = testutil.Get(k8sClient, serviceAccount, component.ServiceAccountNamePxTelemetry, cluster.Namespace)
+	err = testutil.Get(k8sClient, serviceAccount, component.ServiceAccountNameTelemetry, cluster.Namespace)
 	require.NoError(t, err)
 	require.Len(t, serviceAccount.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, serviceAccount.OwnerReferences[0].Name)
 
 	clusterRole := &rbacv1.ClusterRole{}
-	err = testutil.Get(k8sClient, clusterRole, component.ClusterRoleNamePxTelemetry, "")
+	err = testutil.Get(k8sClient, clusterRole, component.ClusterRoleNameTelemetry, "")
 	require.NoError(t, err)
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-	err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNamePxTelemetry, "")
+	err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNameTelemetry, "")
 	require.NoError(t, err)
 
 	// Validate ccm-go role and role bindings
@@ -12593,34 +12593,57 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 	require.Len(t, roleBinding.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, roleBinding.OwnerReferences[0].Name)
 
+	role = &rbacv1.Role{}
+	err = testutil.Get(k8sClient, role, component.RoleNameTelemetryCollectorV2, cluster.Namespace)
+	require.NoError(t, err)
+	require.Len(t, role.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, role.OwnerReferences[0].Name)
+	roleBinding = &rbacv1.RoleBinding{}
+	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetryCollectorV2, cluster.Namespace)
+	require.NoError(t, err)
+	require.Len(t, roleBinding.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, roleBinding.OwnerReferences[0].Name)
+
 	// Validate config maps
 	// TODO: validate config map content
 	configMap := &v1.ConfigMap{}
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameRegistrationConfig, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegister, cluster.Namespace)
 	require.NoError(t, err)
 	require.Len(t, configMap.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, configMap.OwnerReferences[0].Name)
 
 	configMap = &v1.ConfigMap{}
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameProxyConfigRegister, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegisterProxy, cluster.Namespace)
 	require.NoError(t, err)
 	require.Len(t, configMap.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, configMap.OwnerReferences[0].Name)
 
 	configMap = &v1.ConfigMap{}
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameProxyConfigRest, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryPhonehomeProxy, cluster.Namespace)
 	require.NoError(t, err)
 	require.Len(t, configMap.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, configMap.OwnerReferences[0].Name)
 
 	configMap = &v1.ConfigMap{}
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTLSCertificate, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryTLSCertificate, cluster.Namespace)
 	require.NoError(t, err)
 	require.Len(t, configMap.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, configMap.OwnerReferences[0].Name)
 
 	configMap = &v1.ConfigMap{}
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNamePxTelemetryConfig, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryPhonehome, cluster.Namespace)
+	require.NoError(t, err)
+	require.Len(t, configMap.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, configMap.OwnerReferences[0].Name)
+
+	configMap = &v1.ConfigMap{}
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorV2, cluster.Namespace)
+	require.NoError(t, err)
+	require.Len(t, configMap.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, configMap.OwnerReferences[0].Name)
+
+	configMap = &v1.ConfigMap{}
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
 	require.NoError(t, err)
 	require.Len(t, configMap.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, configMap.OwnerReferences[0].Name)
@@ -12628,7 +12651,7 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 	// Validate deployments
 	// TODO: validate deployment specs
 	deployment := &appsv1.Deployment{}
-	err = testutil.Get(k8sClient, deployment, component.DeploymentNameRegistrationService, cluster.Namespace)
+	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 	require.NoError(t, err)
 	require.Len(t, deployment.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, deployment.OwnerReferences[0].Name)
@@ -12639,27 +12662,16 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 	require.Len(t, deployment.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, daemonset.OwnerReferences[0].Name)
 
+	deployment = &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryCollectorV2, cluster.Namespace)
+	require.NoError(t, err)
+	require.Len(t, deployment.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, deployment.OwnerReferences[0].Name)
+
 	secret := v1.Secret{}
 	err = testutil.Get(k8sClient, &secret, component.TelemetryCertName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t, secret.OwnerReferences[0].Name, cluster.Name)
-
-	// Validate metrics collector
-	configMap = &v1.ConfigMap{}
-	err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
-	require.NoError(t, err)
-	require.Equal(t, configMap.OwnerReferences[0].Name, cluster.Name)
-
-	configMap = &v1.ConfigMap{}
-	err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
-	require.NoError(t, err)
-	require.Equal(t, configMap.OwnerReferences[0].Name, cluster.Name)
-
-	deployment = &appsv1.Deployment{}
-	err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
-	require.NoError(t, err)
-	require.Len(t, deployment.OwnerReferences, 1)
-	require.Equal(t, cluster.Name, deployment.OwnerReferences[0].Name)
 
 	// Now disable telemetry
 	cluster.Spec.Monitoring.Telemetry.Enabled = false
@@ -12673,19 +12685,25 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 	require.Empty(t, cluster.Status.DesiredImages.TelemetryProxy)
 	require.Empty(t, cluster.Status.DesiredImages.LogUploader)
 
-	err = testutil.Get(k8sClient, deployment, component.DeploymentNameRegistrationService, cluster.Namespace)
+	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryCollectorV2, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
 	err = testutil.Get(k8sClient, daemonset, component.DaemonSetNameTelemetryPhonehome, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameRegistrationConfig, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegister, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameProxyConfigRegister, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegisterProxy, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameProxyConfigRest, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryPhonehomeProxy, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTLSCertificate, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryTLSCertificate, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, configMap, component.ConfigMapNamePxTelemetryConfig, cluster.Namespace)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryPhonehome, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorV2, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
 	err = testutil.Get(k8sClient, role, component.RoleNameSecretManager, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
@@ -12695,11 +12713,15 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSTCReader, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
+	err = testutil.Get(k8sClient, role, component.RoleNameTelemetryCollectorV2, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
+	err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetryCollectorV2, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
-	err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
+	err = testutil.Get(k8sClient, clusterRole, component.ClusterRoleNameTelemetry, "")
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNameTelemetry, "")
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, serviceAccount, component.ServiceAccountNameTelemetry, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
 
 	// Cert is not deleted after telemetry is disabled. it would be reused when it's re-enabled.
@@ -12802,29 +12824,41 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		require.Len(t, deployment.Spec.Template.Spec.InitContainers, 0)
 		require.Equal(t, component.CollectorServiceAccountName, deployment.Spec.Template.Spec.ServiceAccountName)
 		// validate ccm go components don't exist
-		err = testutil.Get(k8sClient, serviceAccount, component.ServiceAccountNamePxTelemetry, cluster.Namespace)
+		err = testutil.Get(k8sClient, serviceAccount, component.ServiceAccountNameTelemetry, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, clusterRole, component.ClusterRoleNamePxTelemetry, "")
+		err = testutil.Get(k8sClient, clusterRole, component.ClusterRoleNameTelemetry, "")
 		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNamePxTelemetry, "")
+		err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNameTelemetry, "")
 		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, role, component.RoleNameSecretManager, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSecretManager, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
+		err = testutil.Get(k8sClient, role, component.RoleNameTelemetryCollectorV2, cluster.Namespace)
+		require.True(t, errors.IsNotFound(err))
+		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetryCollectorV2, cluster.Namespace)
+		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, role, component.RoleNameSTCReader, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSTCReader, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameRegistrationConfig, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegister, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameProxyConfigRegister, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegisterProxy, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameProxyConfigRest, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryPhonehome, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTLSCertificate, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryPhonehomeProxy, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
-		err = testutil.Get(k8sClient, deployment, component.DeploymentNameRegistrationService, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorV2, cluster.Namespace)
+		require.True(t, errors.IsNotFound(err))
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
+		require.True(t, errors.IsNotFound(err))
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryTLSCertificate, cluster.Namespace)
+		require.True(t, errors.IsNotFound(err))
+		err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
+		require.True(t, errors.IsNotFound(err))
+		err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryCollectorV2, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
 		daemonset := &appsv1.DaemonSet{}
 		err = testutil.Get(k8sClient, daemonset, component.DaemonSetNameTelemetryPhonehome, cluster.Namespace)
@@ -12846,13 +12880,13 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 	validateCCMGoComponents := func() {
 		// validate ccm go components exist
 		serviceAccount := &v1.ServiceAccount{}
-		err = testutil.Get(k8sClient, serviceAccount, component.ServiceAccountNamePxTelemetry, cluster.Namespace)
+		err = testutil.Get(k8sClient, serviceAccount, component.ServiceAccountNameTelemetry, cluster.Namespace)
 		require.NoError(t, err)
 		clusterRole := &rbacv1.ClusterRole{}
-		err = testutil.Get(k8sClient, clusterRole, component.ClusterRoleNamePxTelemetry, "")
+		err = testutil.Get(k8sClient, clusterRole, component.ClusterRoleNameTelemetry, "")
 		require.NoError(t, err)
 		clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
-		err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNamePxTelemetry, "")
+		err = testutil.Get(k8sClient, clusterRoleBinding, component.ClusterRoleBindingNameTelemetry, "")
 		require.NoError(t, err)
 		role := &rbacv1.Role{}
 		err = testutil.Get(k8sClient, role, component.RoleNameSecretManager, cluster.Namespace)
@@ -12866,27 +12900,44 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		roleBinding = &rbacv1.RoleBinding{}
 		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameSTCReader, cluster.Namespace)
 		require.NoError(t, err)
+		role = &rbacv1.Role{}
+		err = testutil.Get(k8sClient, role, component.RoleNameTelemetryCollectorV2, cluster.Namespace)
+		require.NoError(t, err)
+		roleBinding = &rbacv1.RoleBinding{}
+		err = testutil.Get(k8sClient, roleBinding, component.RoleBindingNameTelemetryCollectorV2, cluster.Namespace)
+		require.NoError(t, err)
 		configMap := &v1.ConfigMap{}
-		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameRegistrationConfig, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegister, cluster.Namespace)
 		require.NoError(t, err)
 		configMap = &v1.ConfigMap{}
-		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameProxyConfigRegister, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryRegisterProxy, cluster.Namespace)
 		require.NoError(t, err)
 		configMap = &v1.ConfigMap{}
-		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameProxyConfigRest, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryPhonehomeProxy, cluster.Namespace)
 		require.NoError(t, err)
 		configMap = &v1.ConfigMap{}
-		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTLSCertificate, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryTLSCertificate, cluster.Namespace)
 		require.NoError(t, err)
 		configMap = &v1.ConfigMap{}
-		err = testutil.Get(k8sClient, configMap, component.ConfigMapNamePxTelemetryConfig, cluster.Namespace)
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryPhonehome, cluster.Namespace)
+		require.NoError(t, err)
+		configMap = &v1.ConfigMap{}
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorV2, cluster.Namespace)
+		require.NoError(t, err)
+		configMap = &v1.ConfigMap{}
+		err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
 		require.NoError(t, err)
 		deployment := &appsv1.Deployment{}
-		err = testutil.Get(k8sClient, deployment, component.DeploymentNameRegistrationService, cluster.Namespace)
+		err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 		require.NoError(t, err)
 		daemonset := &appsv1.DaemonSet{}
 		err = testutil.Get(k8sClient, daemonset, component.DaemonSetNameTelemetryPhonehome, cluster.Namespace)
 		require.NoError(t, err)
+		deployment = &appsv1.Deployment{}
+		err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryCollectorV2, cluster.Namespace)
+		require.NoError(t, err)
+		require.Len(t, deployment.Spec.Template.Spec.InitContainers, 1)
+		require.Equal(t, component.ServiceAccountNameTelemetry, deployment.Spec.Template.Spec.ServiceAccountName)
 		// validate ccm java components don't exist
 		err = testutil.Get(k8sClient, serviceAccount, component.CollectorServiceAccountName, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
@@ -12894,23 +12945,19 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, clusterRoleBinding, component.CollectorClusterRoleBindingName, "")
 		require.True(t, errors.IsNotFound(err))
-		// validate metrics collector components exist
 		role = &rbacv1.Role{}
 		err = testutil.Get(k8sClient, role, component.CollectorRoleName, cluster.Namespace)
-		require.NoError(t, err)
-		roleBinding = &rbacv1.RoleBinding{}
+		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, roleBinding, component.CollectorRoleBindingName, cluster.Namespace)
-		configMap = &v1.ConfigMap{}
+		require.True(t, errors.IsNotFound(err))
+		err = testutil.Get(k8sClient, configMap, component.TelemetryConfigMapName, cluster.Namespace)
+		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
-		require.NoError(t, err)
-		configMap = &v1.ConfigMap{}
+		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
-		require.NoError(t, err)
-		deployment = &appsv1.Deployment{}
+		require.True(t, errors.IsNotFound(err))
 		err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
-		require.NoError(t, err)
-		require.Len(t, deployment.Spec.Template.Spec.InitContainers, 1)
-		require.Equal(t, component.ServiceAccountNamePxTelemetry, deployment.Spec.Template.Spec.ServiceAccountName)
+		require.True(t, errors.IsNotFound(err))
 	}
 	validateCCMGoComponents()
 }

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12799,6 +12799,8 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		deployment := &appsv1.Deployment{}
 		err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
 		require.NoError(t, err)
+		require.Len(t, deployment.Spec.Template.Spec.InitContainers, 0)
+		require.Equal(t, component.CollectorServiceAccountName, deployment.Spec.Template.Spec.ServiceAccountName)
 		// validate ccm go components don't exist
 		err = testutil.Get(k8sClient, serviceAccount, component.ServiceAccountNamePxTelemetry, cluster.Namespace)
 		require.True(t, errors.IsNotFound(err))
@@ -12898,15 +12900,17 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		require.NoError(t, err)
 		roleBinding = &rbacv1.RoleBinding{}
 		err = testutil.Get(k8sClient, roleBinding, component.CollectorRoleBindingName, cluster.Namespace)
-		deployment = &appsv1.Deployment{}
-		err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
-		require.NoError(t, err)
 		configMap = &v1.ConfigMap{}
 		err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
 		require.NoError(t, err)
 		configMap = &v1.ConfigMap{}
 		err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
 		require.NoError(t, err)
+		deployment = &appsv1.Deployment{}
+		err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
+		require.NoError(t, err)
+		require.Len(t, deployment.Spec.Template.Spec.InitContainers, 1)
+		require.Equal(t, component.ServiceAccountNamePxTelemetry, deployment.Spec.Template.Spec.ServiceAccountName)
 	}
 	validateCCMGoComponents()
 }

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -34,7 +34,7 @@ const (
 	defaultCollectorImage      = "purestorage/realtime-metrics:1.0.1"
 	defaultCCMGoImage          = "purestorage/ccm-go:1.0.0"
 	defaultLogUploaderImage    = "purestorage/log-upload:1.0.0"
-	defaultCCMGoProxyImage     = "envoyproxy/envoy:v1.22.2"
+	defaultCCMGoProxyImage     = "purestorage/telemetry-envoy:1.0.0"
 	defaultPxRepoImage         = "portworx/px-repo:1.1.0"
 
 	// DefaultPrometheusOperatorImage is the default Prometheus operator image for k8s 1.21 and below

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -252,7 +252,7 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			PrometheusConfigReloader:  "image/prometheus-config-reloader:2.6.0",
 			AlertManager:              "image/alertmanager:2.6.0",
 			Telemetry:                 "image/ccm-go:1.0.0",
-			TelemetryProxy:            "envoyproxy/envoy:v1.22.2",
+			TelemetryProxy:            "purestorage/telemetry-envoy:1.0.0",
 			LogUploader:               "purestorage/log-upload:1.0.0",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			PxRepo:                    "portworx/px-repo:1.1.0",

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1017,8 +1017,14 @@ func IsMetricsCollectorSupported(pxVersion *version.Version) bool {
 //   affinity
 //   toleration
 func ApplyStorageClusterSettingsToPodSpec(cluster *corev1.StorageCluster, podSpec *v1.PodSpec) {
+	var containers []*v1.Container
 	for i := 0; i < len(podSpec.Containers); i++ {
-		container := &podSpec.Containers[i]
+		containers = append(containers, &podSpec.Containers[i])
+	}
+	for i := 0; i < len(podSpec.InitContainers); i++ {
+		containers = append(containers, &podSpec.InitContainers[i])
+	}
+	for _, container := range containers {
 		// Change image to custom repository if it has not been done
 		if !strings.HasPrefix(container.Image, strings.TrimSuffix(cluster.Spec.CustomImageRegistry, "/")) {
 			container.Image = util.GetImageURN(cluster, container.Image)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* use new custom envoy proxy image for telemetry components, which has cert check embedded
* update all telemetry component names to be px specific
* metrics collector upgrade: completely delete old components and deploy new components with new names
* add cert check init container to new metrics collector pod
* combine role/rolebinding used by registration, phonehome and collector into one.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
sample: all new telemetry components
```
$ kubectl get serviceaccount -n kube-system | grep px-telemetry
px-telemetry                         1         12m

$ kubectl get clusterrole | grep px-telemetry
px-telemetry                                                           2022-08-12T22:41:01Z

$ kubectl get clusterrolebinding | grep px-telemetry
px-telemetry                                           ClusterRole/px-telemetry                                                           13m

$ kubectl get role -n kube-system | grep px-telemetry
px-telemetry                                     2022-08-12T22:41:01Z

$ kubectl get rolebinding -n kube-system | grep px-telemetry
px-telemetry                                        Role/px-telemetry                                     13m

$ kubectl get pod -n kube-system | grep px-telemetry
px-telemetry-metrics-collector-5bf58c49c9-wdk8n       2/2     Running             1          8m47s
px-telemetry-phonehome-87wtq                          2/2     Running             0          8m39s
px-telemetry-phonehome-tzkd5                          2/2     Running             0          8m40s
px-telemetry-phonehome-w6n9l                          2/2     Running             0          8m39s
px-telemetry-phonehome-x6q26                          2/2     Running             0          8m38s
px-telemetry-registration-57cd877fc8-s9sw5            2/2     Running             0          8m47s

$ kubectl get deployment -n kube-system | grep px-telemetry
px-telemetry-metrics-collector   1/1     1            1           14m
px-telemetry-registration        1/1     1            1           14m

$ kubectl get ds -n kube-system | grep px-telemetry
px-telemetry-phonehome   4         4         4       4            4           <none>                   14m

$ kubectl get cm -n kube-system | grep px-telemetry
px-telemetry-collector               1      14m
px-telemetry-collector-proxy         1      14m
px-telemetry-phonehome               2      14m
px-telemetry-phonehome-proxy         1      14m
px-telemetry-register                1      14m
px-telemetry-register-proxy          1      14m
px-telemetry-tls-certificate         1      14m
```
