### PR TITLE
[PWX-26222] Fix security context in ccm-go init containers

### DIFF
--- a/deploy/ccm/phonehome-cluster.yaml
+++ b/deploy/ccm/phonehome-cluster.yaml
@@ -79,6 +79,8 @@ spec:
           args:
             - "cert_checker"
           imagePullPolicy: Always
+          securityContext:
+            runAsUser: 1111
       volumes:
         - name: etcpwx
           hostPath:

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -417,6 +417,9 @@ func (t *telemetry) getCollectorDeployment(
 				Value: cluster.Namespace,
 			}},
 			Args: []string{"cert_checker"},
+			SecurityContext: &v1.SecurityContext{
+				RunAsUser: &runAsUser,
+			},
 		}}
 		deployment.Spec.Template.Spec.ServiceAccountName = ServiceAccountNameTelemetry
 		for i := 0; i < len(deployment.Spec.Template.Spec.Volumes); i++ {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: security context is missing in init container when using ocp

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

