### PR TITLE
[PWX-26364] Don't block telemetry Java configmap creation when cluste…

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -139,10 +139,6 @@ func (t *telemetry) Reconcile(cluster *corev1.StorageCluster) error {
 	if err := t.setTelemetryCertOwnerRef(cluster, ownerRef); err != nil {
 		return err
 	}
-	if cluster.Status.ClusterUID == "" {
-		logrus.Warn("clusterUID is empty, wait for it to reconcile telemetry components")
-		return nil
-	}
 	t.isCCMGoSupported = pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster))
 	if t.isCCMGoSupported {
 		return t.reconcileCCMGo(cluster, ownerRef)
@@ -184,6 +180,10 @@ func (t *telemetry) reconcileCCMGo(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	if cluster.Status.ClusterUID == "" {
+		logrus.Warn("clusterUID is empty, wait for it to reconcile telemetry components")
+		return nil
+	}
 	if err := t.reconcileCCMGoServiceAccount(cluster, ownerRef); err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -72,6 +72,10 @@ func (t *telemetry) reconcileCCMJava(
 		return err
 	}
 	if pxutil.IsMetricsCollectorSupported(pxutil.GetPortworxVersion(cluster)) {
+		if cluster.Status.ClusterUID == "" {
+			logrus.Warn("clusterUID is empty, wait for it to fill collector proxy config")
+			return nil
+		}
 		if err := t.deployMetricsCollectorV1(cluster, ownerRef); err != nil {
 			return err
 		}


### PR DESCRIPTION
…r UID is not ready

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: When installing older px with telemetry enabled, the ccm configmap creation should not be blocked by cluster UID check.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

