### PR TITLE
PWX-24077: Add '/var/cores' to volume mounts for wiper.  Used for log…

### DIFF
--- a/drivers/storage/portworx/testspec/nodeWiper.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiper.yaml
@@ -52,6 +52,8 @@ spec:
           readOnly: true
         - name: sys
           mountPath: /sys
+        - name: varcores
+          mountPath: /var/cores
       restartPolicy: Always
       serviceAccountName: px-node-wiper
       volumes:
@@ -90,3 +92,6 @@ spec:
       - name: sys
         hostPath:
           path: /sys
+      - name: varcores
+        hostPath:
+          path: /var/cores

--- a/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
@@ -52,6 +52,8 @@ spec:
           readOnly: true
         - name: sys
           mountPath: /sys
+        - name: varcores
+          mountPath: /var/cores
       restartPolicy: Always
       serviceAccountName: px-node-wiper
       volumes:
@@ -90,3 +92,6 @@ spec:
       - name: sys
         hostPath:
           path: /sys
+      - name: varcores
+        hostPath:
+          path: /var/vcap/store/cores

--- a/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
@@ -53,6 +53,8 @@ spec:
           readOnly: true
         - name: sys
           mountPath: /sys
+        - name: varcores
+          mountPath: /var/cores
       restartPolicy: Always
       serviceAccountName: px-node-wiper
       volumes:
@@ -91,3 +93,6 @@ spec:
       - name: sys
         hostPath:
           path: /sys
+      - name: varcores
+        hostPath:
+          path: /var/cores


### PR DESCRIPTION
…… (#690)

* PWX-24077: Add '/var/cores' to volume mounts for wiper.  Used for logging.

Signed-off-by: Jose Rivera <jose@portworx.com>

* PWX-24077 - Update test specs and fix host mount location for PKS.

Signed-off-by: Jose Rivera <jose@portworx.com>

* PWX-24077: Fix host mount for PKS.

Signed-off-by: Jose Rivera <jose@portworx.com>

* PWX-24077: Remove string added by mistake.

Signed-off-by: Jose Rivera <jose@portworx.com>


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-24077

**Special notes for your reviewer**:

This is already merged into master.   Tried getting into 1.9.0 but it was closed.    Piyush already thinks the change is fine https://github.com/libopenstorage/operator/pull/713