### PR TITLE
[PWX-26670] Filter out px-csi-ext pods when scanning pre-installed snapshot controllers

### DIFF
--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -56,11 +56,13 @@ const (
 	csiCRDSuffixVolumeSnapshot        = "volumesnapshot.yaml"
 	csiCRDSuffixVolumeSnapshotContent = "volumesnapshotcontent.yaml"
 	csiCRDSuffixVolumeSnapshotClass   = "volumesnapshotclass.yaml"
+
+	csiDeploymentAppLabel = "app"
 )
 
 var (
 	csiDeploymentTemplateLabels = map[string]string{
-		"app": "px-csi-driver",
+		csiDeploymentAppLabel: "px-csi-driver",
 	}
 )
 
@@ -530,6 +532,11 @@ func (c *csi) findPreinstalledCSISnapshotController() error {
 		return err
 	}
 	for _, pod := range podList.Items {
+		// Ignore csi pods deployed by operator
+		appLabel, ok := pod.Labels[csiDeploymentAppLabel]
+		if ok && appLabel == csiDeploymentTemplateLabels[csiDeploymentAppLabel] {
+			continue
+		}
 		for _, container := range pod.Spec.Containers {
 			if strings.Contains(container.Image, "/snapshot-controller:") {
 				c.csiSnapshotControllerPreInstalled = boolPtr(true)


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: If `installSnapshotController` is true in stc spec, during operator upgrade it will treat the existing operator deployed snapshot controller as external one, then remove it from px-csi-ext deployment.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

