### PR TITLE
[1.9.1][PWX-26670] Filter out px-csi-ext pods when scanning pre-installed snapshot controllers

### DIFF
--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -56,11 +56,13 @@ const (
 	csiCRDSuffixVolumeSnapshot        = "volumesnapshot.yaml"
 	csiCRDSuffixVolumeSnapshotContent = "volumesnapshotcontent.yaml"
 	csiCRDSuffixVolumeSnapshotClass   = "volumesnapshotclass.yaml"
+
+	csiDeploymentAppLabel = "app"
 )
 
 var (
 	csiDeploymentTemplateLabels = map[string]string{
-		"app": "px-csi-driver",
+		csiDeploymentAppLabel: "px-csi-driver",
 	}
 )
 
@@ -530,6 +532,11 @@ func (c *csi) findPreinstalledCSISnapshotController() error {
 		return err
 	}
 	for _, pod := range podList.Items {
+		// Ignore csi pods deployed by operator
+		appLabel, ok := pod.Labels[csiDeploymentAppLabel]
+		if ok && appLabel == csiDeploymentTemplateLabels[csiDeploymentAppLabel] {
+			continue
+		}
 		for _, container := range pod.Spec.Containers {
 			if strings.Contains(container.Image, "/snapshot-controller:") {
 				c.csiSnapshotControllerPreInstalled = boolPtr(true)

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12605,6 +12605,37 @@ func TestCSISnapController(t *testing.T) {
 	err = testutil.Get(driver.k8sClient, deployment, component.CSIApplicationName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t, expectedDeployment.Spec, deployment.Spec)
+
+	// Restart operator with snapshot controller enabled, the container should not be deleted
+	expectedDeployment = testutil.GetExpectedDeployment(t, "csiDeployment_1.0_k8s120.yaml")
+	csiPod := &v1.Pod{}
+	csiPod.ObjectMeta = expectedDeployment.Spec.Template.ObjectMeta
+	csiPod.Spec = expectedDeployment.Spec.Template.Spec
+	dummyPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-other-random-pod",
+			Namespace: "kube-system",
+		},
+	}
+	k8sClient = testutil.FakeK8sClient(csiPod, dummyPod)
+	reregisterComponents()
+
+	driver = portworx{}
+	driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	driver.SetDefaultsOnStorageCluster(cluster)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	require.NotNil(t, cluster.Spec.CSI)
+	require.True(t, cluster.Spec.CSI.Enabled)
+	require.NotNil(t, cluster.Spec.CSI.InstallSnapshotController)
+	require.True(t, *cluster.Spec.CSI.InstallSnapshotController)
+	require.NotEmpty(t, cluster.Status.DesiredImages.CSISnapshotController)
+
+	deployment = &appsv1.Deployment{}
+	err = testutil.Get(driver.k8sClient, deployment, component.CSIApplicationName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedDeployment.Spec, deployment.Spec)
 }
 
 func contains(slice []string, val string) bool {


### PR DESCRIPTION
…

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

