### PR TITLE
[PWX-26381][PWX-26696][PWX-26768] Add custom proxy and port shifting support for metrics collector

### DIFF
--- a/deploy/ccm/ccm.properties
+++ b/deploy/ccm/ccm.properties
@@ -2,6 +2,7 @@
   "product_name": "portworx",
   "port": "PORTWORX_PORT",
   "node_name_key": "K8S_NODE_NAME",
+  "envoy_port": "REST_CLOUD_SUPPORT_PORT",
   "logupload": {
     "logfile_patterns": [
       "/var/cores/*diags*",

--- a/deploy/ccm/ccm.properties
+++ b/deploy/ccm/ccm.properties
@@ -1,44 +1,44 @@
 {
+  "product_name": "portworx",
+  "port": "PORTWORX_PORT",
+  "node_name_key": "K8S_NODE_NAME",
+  "logupload": {
+    "logfile_patterns": [
+      "/var/cores/*diags*",
+      "/var/cores/auto/*diags*",
+      "/var/cores/*px-cores*",
+      "/var/cores/*.heap",
+      "/var/cores/*.stack",
+      "/var/cores/.alerts/alerts*"
+    ],
+    "skip_patterns": [
+      "/var/cores/*skip*",
+      "/var/cores/auto/*skip*"
+    ],
+    "additional_files": [
+      "/etc/pwx/config.json",
+      "/var/cores/.alerts/alerts.log",
+      "/var/cores/px_etcd_watch.log",
+      "/var/cores/px_cache_mon.log",
+      "/var/cores/px_cache_mon_watch.log",
+      "/var/cores/px_healthmon_watch.log",
+      "/var/cores/px_event_watch.log"
+    ],
+    "phonehome_hour_range": 8760,
+    "phonehome_sent": "/var/logs/phonehome.sent",
+    "always_scan_range_days": 7,
+    "max_retry_per_hour": 5,
+    "phonehome_max_retry_upload_days": 10
+  },
+  "bookkeeping": {
+    "logupload_book_path": "/var/cache/ccm/log_upload.book",
+    "logupload_map_path": "/var/cache/ccm/log_upload.map"
+  },
+  "standalone": {
+    "version": "1.0.0",
+    "controller_sn": "SA-0",
+    "component_name":"SA-0",
     "product_name": "portworx",
-    "port": PORTWORX_PORT,
-    "node_name_key": "K8S_NODE_NAME",
-    "logupload": {
-      "logfile_patterns": [
-        "/var/cores/*diags*",
-        "/var/cores/auto/*diags*",
-        "/var/cores/*px-cores*",
-        "/var/cores/*.heap",
-        "/var/cores/*.stack",
-        "/var/cores/.alerts/alerts*"
-      ],
-      "skip_patterns": [
-        "/var/cores/*skip*",
-        "/var/cores/auto/*skip*"
-      ],
-      "additional_files": [
-        "/etc/pwx/config.json",
-        "/var/cores/.alerts/alerts.log",
-        "/var/cores/px_etcd_watch.log",
-        "/var/cores/px_cache_mon.log",
-        "/var/cores/px_cache_mon_watch.log",
-        "/var/cores/px_healthmon_watch.log",
-        "/var/cores/px_event_watch.log"
-      ],
-      "phonehome_hour_range": 8760,
-      "phonehome_sent": "/var/logs/phonehome.sent",
-      "always_scan_range_days": 7,
-      "max_retry_per_hour": 5,
-      "phonehome_max_retry_upload_days": 10
-    },
-    "bookkeeping": {
-        "logupload_book_path": "/var/cache/ccm/log_upload.book",
-        "logupload_map_path": "/var/cache/ccm/log_upload.map"
-    },
-    "standalone": {
-      "version": "1.0.0",
-      "controller_sn": "SA-0",
-      "component_name":"SA-0",
-      "product_name": "portworx",
-      "appliance_id_path": "/etc/pwx/cluster_uuid"
-    }
+    "appliance_id_path": "/etc/pwx/cluster_uuid"
   }
+}

--- a/deploy/ccm/config_properties_px.yaml
+++ b/deploy/ccm/config_properties_px.yaml
@@ -7,7 +7,7 @@ cert:
   keyAlgorithm: "RSA"
   noRelCertEnabled: true
   release:
-    staging: 
+    staging:
       private: "/opt/ccm/cert/rel_priv_staging.pem"
     production:
       private: "/opt/ccm/cert/rel_priv.pem"
@@ -20,9 +20,9 @@ standalone:
 envoy:
   protocol: "http"
   registrationHost: "localhost"
-  registrationPort: "12001"
+  registrationPort: "REGISTER_CLOUD_SUPPORT_PORT"
   renewalHost: "localhost"
-  renewalPort: "12002"
+  renewalPort: "REST_CLOUD_SUPPORT_PORT"
 cloud:
   auth:
     version: "1.0"

--- a/deploy/ccm/envoy-config-collector-custom-proxy.yaml
+++ b/deploy/ccm/envoy-config-collector-custom-proxy.yaml
@@ -12,7 +12,7 @@ static_resources:
     address:
       socket_address:
         address: 127.0.0.1
-        port_value: CLOUD_SUPPORT_PORT
+        port_value: REST_CLOUD_SUPPORT_PORT
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/deploy/ccm/envoy-config-collector.yaml
+++ b/deploy/ccm/envoy-config-collector.yaml
@@ -11,7 +11,7 @@ static_resources:
   - name: listener_cloud_support
     address:
       socket_address:
-        address: 0.0.0.0
+        address: 127.0.0.1
         port_value: REST_CLOUD_SUPPORT_PORT
     filter_chains:
     - filters:
@@ -42,6 +42,9 @@ static_resources:
                 - header:
                     key: "appliance-id"
                     value: APPLIANCE_ID
+                - header:
+                    key: "component-sn"
+                    value: COMPONENT_SN
                 - header:
                     key: "product-version"
                     value: PRODUCT_VERSION

--- a/deploy/ccm/envoy-config-register-custom-proxy.yaml
+++ b/deploy/ccm/envoy-config-register-custom-proxy.yaml
@@ -12,7 +12,7 @@ static_resources:
     address:
       socket_address:
         address: 127.0.0.1
-        port_value: CLOUD_SUPPORT_PORT
+        port_value: REGISTER_CLOUD_SUPPORT_PORT
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/deploy/ccm/envoy-config-register.yaml
+++ b/deploy/ccm/envoy-config-register.yaml
@@ -9,7 +9,7 @@ static_resources:
     address:
       socket_address:
         address: 127.0.0.1
-        port_value: CLOUD_SUPPORT_PORT
+        port_value: REGISTER_CLOUD_SUPPORT_PORT
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/deploy/ccm/envoy-config-rest-custom-proxy.yaml
+++ b/deploy/ccm/envoy-config-rest-custom-proxy.yaml
@@ -12,7 +12,7 @@ static_resources:
     address:
       socket_address:
         address: 127.0.0.1
-        port_value: CLOUD_SUPPORT_PORT
+        port_value: REST_CLOUD_SUPPORT_PORT
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/deploy/ccm/metrics-collector-deployment.yaml
+++ b/deploy/ccm/metrics-collector-deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: px-telemetry-metrics-collector
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: realtime-metrics-collector
+  template:
+    metadata:
+      labels:
+        role: realtime-metrics-collector
+    spec:
+      containers:
+      - env:
+        - name: CONFIG
+          value: config/portworx.yaml
+        image: purestorage/realtime-metrics:1.0.2
+        imagePullPolicy: Always
+        name: collector
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 200m
+            memory: 64Mi
+        securityContext:
+          runAsUser: 1111
+        volumeMounts:
+        - mountPath: /config
+          name: px-collector-config
+          readOnly: true
+      - args:
+        - envoy
+        - --config-path
+        - /config/envoy-config.yaml
+        image: purestorage/telemetry-envoy:1.0.0
+        imagePullPolicy: Always
+        name: envoy
+        securityContext:
+          runAsUser: 1111
+        volumeMounts:
+        - mountPath: /config
+          name: px-collector-proxy-config
+          readOnly: true
+        - mountPath: /appliance-cert
+          name: pure-telemetry-certs
+          readOnly: true
+        - mountPath: /etc/envoy/
+          name: tls-certificate
+          readOnly: true
+      initContainers:
+      - name: init-cont
+        image: purestorage/telemetry-envoy:1.0.0
+        env:
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        args:
+        - "cert_checker"
+        imagePullPolicy: Always
+        securityContext:
+          runAsUser: 1111
+      volumes:
+      - configMap:
+          name: px-telemetry-collector
+        name: px-collector-config
+      - configMap:
+          name: px-telemetry-collector-proxy
+        name: px-collector-proxy-config
+      - name: pure-telemetry-certs
+        secret:
+          secretName: pure-telemetry-certs
+      - configMap:
+          name: px-telemetry-tls-certificate
+        name: tls-certificate

--- a/deploy/ccm/phonehome-cluster.yaml
+++ b/deploy/ccm/phonehome-cluster.yaml
@@ -8,11 +8,6 @@ spec:
   selector:
     matchLabels:
       name: px-telemetry-phonehome
-  minReadySeconds: 0
-  updateStrategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 100%
   template:
     metadata:
       labels:

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -766,8 +766,10 @@ func (t *telemetry) createCCMGoConfigMapTelemetryPhonehome(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	cloudSupportPort, _, _ := getCCMCloudSupportPorts(cluster, defaultPhonehomePort)
 	config, err := readConfigMapDataFromFile(configFileNameTelemetryPhonehome, map[string]string{
-		configParameterPortworxPort: fmt.Sprint(getCCMListeningPort(cluster)),
+		configParameterPortworxPort:         fmt.Sprint(getCCMListeningPort(cluster)),
+		configParameterRestCloudSupportPort: fmt.Sprint(cloudSupportPort),
 	})
 	if err != nil {
 		return err

--- a/drivers/storage/portworx/testspec/ccmGoCollectorConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorConfigMap.yaml
@@ -1,9 +1,13 @@
-# Note the portworx endpoint port for openshift is 17001, non-openshift is 9001
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: px-collector-config
+  name: px-telemetry-collector
   namespace: kube-test
+  ownerReferences:
+  - apiVersion: core.libopenstorage.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: StorageCluster
 data:
   portworx.yaml: |-
     scrapeConfig:
@@ -14,6 +18,6 @@ data:
             name: portworx
           namespace: kube-test
           endpoint: metrics
-          port: 9001
+          port: 10001
     forwardConfig:
-      url: http://localhost:10000/metrics/1.0/pure1-metrics-pb
+      url: http://localhost:11000/metrics/1.0/pure1-metrics-pb

--- a/drivers/storage/portworx/testspec/ccmGoCollectorDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorDeployment.yaml
@@ -1,0 +1,100 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: px-telemetry-metrics-collector
+  namespace: kube-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: realtime-metrics-collector
+  template:
+    metadata:
+      labels:
+        role: realtime-metrics-collector
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+      containers:
+      - env:
+        - name: CONFIG
+          value: config/portworx.yaml
+        image: docker.io/purestorage/realtime-metrics:latest
+        imagePullPolicy: Always
+        name: collector
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 200m
+            memory: 64Mi
+        securityContext:
+          runAsUser: 1111
+        volumeMounts:
+        - mountPath: /config
+          name: px-collector-config
+          readOnly: true
+      - args:
+        - envoy
+        - --config-path
+        - /config/envoy-config.yaml
+        image: docker.io/purestorage/envoy:1.2.3
+        imagePullPolicy: Always
+        name: envoy
+        securityContext:
+          runAsUser: 1111
+        volumeMounts:
+        - mountPath: /config
+          name: px-collector-proxy-config
+          readOnly: true
+        - mountPath: /appliance-cert
+          name: pure-telemetry-certs
+          readOnly: true
+        - mountPath: /etc/envoy/
+          name: tls-certificate
+          readOnly: true
+      initContainers:
+      - args:
+        - cert_checker
+        env:
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/purestorage/envoy:1.2.3
+        imagePullPolicy: Always
+        name: init-cont
+        securityContext:
+          runAsUser: 1111
+      serviceAccountName: px-telemetry
+      volumes:
+      - configMap:
+          name: px-telemetry-collector
+        name: px-collector-config
+      - configMap:
+          name: px-telemetry-collector-proxy
+        name: px-collector-proxy-config
+      - name: pure-telemetry-certs
+        secret:
+          secretName: pure-telemetry-certs
+      - configMap:
+          name: px-telemetry-tls-certificate
+        name: tls-certificate

--- a/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap.yaml
@@ -15,14 +15,16 @@ data:
         socket_address:
           address: 127.0.0.1
           port_value: 9901
-    
+    node:
+      id: "id_rest"
+      cluster: "cluster_rest"
     static_resources:
       listeners:
       - name: listener_cloud_support
         address:
           socket_address:
             address: 127.0.0.1
-            port_value: 10000
+            port_value: 11000
         filter_chains:
         - filters:
           - name: envoy.filters.network.http_connection_manager
@@ -51,13 +53,13 @@ data:
                         value: "portworx"
                     - header:
                         key: "appliance-id"
-                        value: "test-clusteruid"
+                        value: test-clusteruid
                     - header:
                         key: "component-sn"
-                        value: "portworx-metrics-node"
+                        value: portworx-metrics-node
                     - header:
                         key: "product-version"
-                        value: "2.12.0"
+                        value: 2.12.0
                     route:
                       host_rewrite_literal: rest.cloud-support.purestorage.com
                       cluster: cluster_cloud_support
@@ -80,8 +82,7 @@ data:
           typed_config:
             "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
             common_tls_context:
-              tls_certificates:
-              - certificate_chain:
-                  filename: /appliance-cert/cert
-                private_key:
-                  filename: /appliance-cert/private_key
+              tls_certificate_sds_secret_configs:
+                name: tls_sds
+                sds_config:
+                  path: /etc/envoy/tls_certificate_sds_secret.yaml

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
@@ -14,6 +14,7 @@ data:
       "product_name": "portworx",
       "port": "10090",
       "node_name_key": "K8S_NODE_NAME",
+      "envoy_port": "13002",
       "logupload": {
         "logfile_patterns": [
           "/var/cores/*diags*",

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: px-telemetry-phonehome
+  namespace: kube-test
+  ownerReferences:
+  - apiVersion: core.libopenstorage.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: StorageCluster
+data:
+  ccm.properties: |-
+    {
+      "product_name": "portworx",
+      "port": "10090",
+      "node_name_key": "K8S_NODE_NAME",
+      "logupload": {
+        "logfile_patterns": [
+          "/var/cores/*diags*",
+          "/var/cores/auto/*diags*",
+          "/var/cores/*px-cores*",
+          "/var/cores/*.heap",
+          "/var/cores/*.stack",
+          "/var/cores/.alerts/alerts*"
+        ],
+        "skip_patterns": [
+          "/var/cores/*skip*",
+          "/var/cores/auto/*skip*"
+        ],
+        "additional_files": [
+          "/etc/pwx/config.json",
+          "/var/cores/.alerts/alerts.log",
+          "/var/cores/px_etcd_watch.log",
+          "/var/cores/px_cache_mon.log",
+          "/var/cores/px_cache_mon_watch.log",
+          "/var/cores/px_healthmon_watch.log",
+          "/var/cores/px_event_watch.log"
+        ],
+        "phonehome_hour_range": 8760,
+        "phonehome_sent": "/var/logs/phonehome.sent",
+        "always_scan_range_days": 7,
+        "max_retry_per_hour": 5,
+        "phonehome_max_retry_upload_days": 10
+      },
+      "bookkeeping": {
+        "logupload_book_path": "/var/cache/ccm/log_upload.book",
+        "logupload_map_path": "/var/cache/ccm/log_upload.map"
+      },
+      "standalone": {
+        "version": "1.0.0",
+        "controller_sn": "SA-0",
+        "component_name":"SA-0",
+        "product_name": "portworx",
+        "appliance_id_path": "/etc/pwx/cluster_uuid"
+      }
+    }
+  location: external

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSet.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSet.yaml
@@ -1,0 +1,131 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    name: px-telemetry-phonehome
+  name: px-telemetry-phonehome
+  namespace: kube-test
+spec:
+  selector:
+    matchLabels:
+      name: px-telemetry-phonehome
+  template:
+    metadata:
+      labels:
+        name: px-telemetry-phonehome
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+      containers:
+      - env:
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: docker.io/purestorage/log-upload:1.2.3
+        imagePullPolicy: Always
+        name: log-upload-service
+        ports:
+        - containerPort: 10090
+          hostPort: 10090
+          name: loguploader
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /etc/pwx
+          name: etcpwx
+        - mountPath: /var/cache
+          name: varcache
+        - mountPath: /var/log
+          name: journalmount2
+          readOnly: true
+        - mountPath: /var/cores
+          name: varcores
+        - mountPath: /config
+          name: ccm-config
+          readOnly: true
+      - args:
+        - envoy
+        - --config-path
+        - /config/envoy-config-rest.yaml
+        image: docker.io/purestorage/envoy:1.2.3
+        imagePullPolicy: Always
+        name: envoy
+        ports:
+        - containerPort: 13002
+          hostPort: 13002
+          name: envoy
+          protocol: TCP
+        securityContext:
+          runAsUser: 1111
+        volumeMounts:
+        - mountPath: /config
+          name: proxy-config
+          readOnly: true
+        - mountPath: /etc/envoy/
+          name: tls-certificate
+          readOnly: true
+        - mountPath: /appliance-cert
+          name: pure-telemetry-certs
+          readOnly: true
+      initContainers:
+      - args:
+        - cert_checker
+        env:
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: docker.io/purestorage/envoy:1.2.3
+        imagePullPolicy: Always
+        name: init-cont
+        securityContext:
+          runAsUser: 1111
+      serviceAccountName: px-telemetry
+      volumes:
+      - hostPath:
+          path: /etc/pwx
+        name: etcpwx
+      - hostPath:
+          path: /var/cache
+        name: varcache
+      - hostPath:
+          path: /var/cores
+        name: varcores
+      - hostPath:
+          path: /var/log
+        name: journalmount2
+      - configMap:
+          items:
+          - key: ccm.properties
+            path: ccm.properties
+          - key: location
+            path: location
+          name: px-telemetry-phonehome
+        name: ccm-config
+      - configMap:
+          name: px-telemetry-phonehome-proxy
+        name: proxy-config
+      - configMap:
+          name: px-telemetry-tls-certificate
+        name: tls-certificate
+      - name: pure-telemetry-certs
+        secret:
+          secretName: pure-telemetry-certs

--- a/drivers/storage/portworx/testspec/ccmGoRegisterConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterConfigMap.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: px-telemetry-register
+  namespace: kube-test
+  ownerReferences:
+  - apiVersion: core.libopenstorage.org/v1
+    blockOwnerDeletion: true
+    controller: true
+    kind: StorageCluster
+data:
+  config_properties_px.yaml: |-
+    actKeyRequired: false
+    cert:
+      keySize: 2048
+      renewWindowInDays: 30
+      registrationEnabled: true
+      renewEnabled: true
+      keyAlgorithm: "RSA"
+      noRelCertEnabled: true
+      release:
+        staging:
+          private: "/opt/ccm/cert/rel_priv_staging.pem"
+        production:
+          private: "/opt/ccm/cert/rel_priv.pem"
+    subscription:
+      useApplianceId: true
+      accountType: "UNKNOWN"
+    standalone:
+      applianceIdPath: "/var/cache/appliance_id"
+      generateApplianceIdEnabled: false
+    envoy:
+      protocol: "http"
+      registrationHost: "localhost"
+      registrationPort: "13001"
+      renewalHost: "localhost"
+      renewalPort: "13002"
+    cloud:
+      auth:
+        version: "1.0"
+    productName: "portworx"
+    k8s:
+      certSecretName: "pure-telemetry-certs"
+      certSecretNamespace: kube-test

--- a/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: px-telemetry-registration
+  namespace: kube-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      role: px-telemetry-registration
+  template:
+    metadata:
+      labels:
+        role: px-telemetry-registration
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              - key: node-role.kubernetes.io/master
+                operator: Exists
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+      containers:
+      - env:
+        - name: CONFIG
+          value: config/config_properties_px.yaml
+        image: docker.io/portworx/px-telemetry:4.3.2
+        imagePullPolicy: Always
+        name: registration
+        volumeMounts:
+        - mountPath: /config
+          name: registration-config
+          readOnly: true
+      - args:
+        - envoy
+        - --config-path
+        - /config/envoy-config-register.yaml
+        image: docker.io/purestorage/envoy:1.2.3
+        imagePullPolicy: Always
+        name: envoy
+        securityContext:
+          runAsUser: 1111
+        volumeMounts:
+        - mountPath: /config
+          name: proxy-config
+          readOnly: true
+      hostNetwork: true
+      serviceAccountName: px-telemetry
+      volumes:
+      - configMap:
+          name: px-telemetry-register
+        name: registration-config
+      - configMap:
+          name: px-telemetry-register-proxy
+        name: proxy-config

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -590,7 +590,6 @@ func SplitPxProxyHostPort(proxy string) (string, string, error) {
 	proxy = strings.TrimPrefix(proxy, "https://")
 	address, port, err := net.SplitHostPort(proxy)
 	if err != nil {
-		logrus.Info(err)
 		return "", "", err
 	} else if address == "" || port == "" {
 		return "", "", fmt.Errorf("failed to split px proxy address %s", proxy)

--- a/pkg/migration/cleanup.go
+++ b/pkg/migration/cleanup.go
@@ -260,6 +260,7 @@ func (h *Handler) deleteMonitoringComponent(cluster *corev1.StorageCluster) erro
 	if err := h.deleteObject(prometheusOpAccountName, cluster.Namespace, &v1.ServiceAccount{}, cluster); err != nil {
 		return err
 	}
+	// If telemetry is disabled when approving migration, this configmap could lose owner, so let operator manage it
 	if err := h.deleteObject(component.TelemetryConfigMapName, cluster.Namespace, &v1.ConfigMap{}, cluster); err != nil {
 		return err
 	}

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -5099,7 +5099,7 @@ func TestTelemetryMigrationWithPX2_12(t *testing.T) {
 	err = testutil.Get(k8sClient, telemetrySecret, component.TelemetryCertName, cluster.Namespace)
 	require.NoError(t, err)
 	err = testutil.Get(k8sClient, telemetryConfig, component.TelemetryConfigMapName, cluster.Namespace)
-	require.Error(t, err)
+	require.True(t, errors.IsNotFound(err))
 
 	close(recorder.Events)
 	var msg string


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* rewrite metrics collector V2 code and don't reuse V1
* port shifting issue fixed
* configmap and deployment content validation added in unit tests
* metrics collector now use shifted ports based on px start port, and support custom proxy
* make phonehome envoy port configurable

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
passed automation https://jenkins.pwx.dev.purestorage.com/view/Newstack%20Dashboard/job/Operator/job/operator-integration-basic-dev/1/console
