### PR TITLE
PTX-12727 Hardcode maxStorageNodesPerZone for CloudStorage

### DIFF
--- a/test/integration_test/utils/storagecluster.go
+++ b/test/integration_test/utils/storagecluster.go
@@ -103,9 +103,13 @@ func ConstructStorageCluster(cluster *corev1.StorageCluster, specGenURL string, 
 			KvdbDeviceSpec: &PxKvdbSpec,
 		}
 		cloudProvider := &CloudProvider
+		// TODO Hardcoding maxStorageNodesPerZone to 5 as a workaround
+		// until we have better way to do this
+		maxStorageNodesPerZone := uint32(5)
 		cloudStorage := &corev1.CloudStorageSpec{
-			Provider:           cloudProvider,
-			CloudStorageCommon: cloudCommon,
+			Provider:               cloudProvider,
+			CloudStorageCommon:     cloudCommon,
+			MaxStorageNodesPerZone: &maxStorageNodesPerZone,
 		}
 
 		cluster.Spec.CloudStorage = cloudStorage


### PR DESCRIPTION
Hardcode maxStorageNodesPerZone to 5 for CloudStorage to pass DeepEquals validation until we have a better method to do this

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>