### PR TITLE
PWX-24025: Default value for max_storage_nodes_per_zone - upgrade sce…

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -1055,7 +1055,7 @@ func testStoragelessNodesUpgrade(t *testing.T, expectedValue uint32, storageless
 	}
 	driver := testutil.MockDriver(mockCtrl)
 
-	total_nodes := uint32(24)
+	totalNodes := uint32(24)
 	zones := uint32(len(storageless))
 	origVersion := "2.10.0"
 	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
@@ -1063,7 +1063,7 @@ func testStoragelessNodesUpgrade(t *testing.T, expectedValue uint32, storageless
 	cluster.Spec.Version = origVersion
 	cluster.Status.Version = "2.10.1"
 	cluster.Spec.CloudStorage.MaxStorageNodesPerZone = nil
-	k8sClient, expected := getK8sClientWithNodesZones(t, total_nodes, zones, cluster, storageless...)
+	k8sClient, expected := getK8sClientWithNodesZones(t, totalNodes, zones, cluster, storageless...)
 
 	controller := Controller{
 		client: k8sClient,

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -1004,6 +1004,20 @@ func TestStorageUpgradeClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
 	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
 	require.Nil(t, cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
 
+	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, errors.NewBadRequest("error")).AnyTimes()
+
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
+	require.Nil(t, cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+
+	cluster.Annotations = map[string]string{}
+	cluster.Annotations[constants.AnnotationDisableStorage] = strconv.FormatBool(true)
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
+	require.Nil(t, cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+
 	// storage only
 	testStoragelessNodesUpgrade(t, 24, 0)
 	testStoragelessNodesUpgrade(t, 12, 0, 0)

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -1004,23 +1004,13 @@ func TestStorageUpgradeClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
 	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
 	require.Nil(t, cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
 
-	for zones := 1; zones < 4; zones++ {
-		cluster.Spec.Image = "oci-monitor:" + origVersion
-		cluster.Spec.Version = origVersion
-		cluster.Status.Version = "2.10.1"
-		cluster.Spec.CloudStorage.MaxStorageNodesPerZone = nil
-		k8sClient, _ = getK8sClientWithNodesZones(t, totalNodes, uint32(zones), cluster)
+	// storage only
+	testStoragelessNodesUpgrade(t, 24, 0)
+	testStoragelessNodesUpgrade(t, 12, 0, 0)
+	testStoragelessNodesUpgrade(t, 8, 0, 0, 0)
+	testStoragelessNodesUpgrade(t, 6, 0, 0, 0, 0)
 
-		controller = Controller{
-			client: k8sClient,
-			Driver: driver,
-		}
-
-		err = controller.setStorageClusterDefaults(cluster)
-		require.NoError(t, err)
-		require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
-		require.Equal(t, totalNodes/uint32(zones), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
-	}
+	// storageless
 	testStoragelessNodesUpgrade(t, 14, 10)
 	testStoragelessNodesUpgrade(t, 23, 1)
 	testStoragelessNodesUpgrade(t, 7, 5, 5)

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -979,10 +979,10 @@ func TestStorageUpgradeClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
 			Phase: string(corev1.NodeInitStatus),
 		},
 	}
-	total_nodes := uint32(12)
+	totalNodes := uint32(12)
 	driver := testutil.MockDriver(mockCtrl)
 	/* 1 zone */
-	k8sClient, expected := getK8sClientWithNodesZones(t, total_nodes, 1, cluster)
+	k8sClient, expected := getK8sClientWithNodesZones(t, totalNodes, 1, cluster)
 
 	controller := Controller{
 		client: k8sClient,
@@ -1009,7 +1009,7 @@ func TestStorageUpgradeClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
 		cluster.Spec.Version = origVersion
 		cluster.Status.Version = "2.10.1"
 		cluster.Spec.CloudStorage.MaxStorageNodesPerZone = nil
-		k8sClient, _ = getK8sClientWithNodesZones(t, total_nodes, uint32(zones), cluster)
+		k8sClient, _ = getK8sClientWithNodesZones(t, totalNodes, uint32(zones), cluster)
 
 		controller = Controller{
 			client: k8sClient,
@@ -1019,7 +1019,7 @@ func TestStorageUpgradeClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
 		err = controller.setStorageClusterDefaults(cluster)
 		require.NoError(t, err)
 		require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
-		require.Equal(t, total_nodes/uint32(zones), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+		require.Equal(t, totalNodes/uint32(zones), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
 	}
 	testStoragelessNodesUpgrade(t, 14, 10)
 	testStoragelessNodesUpgrade(t, 23, 1)

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -935,7 +935,7 @@ func getK8sClientWithNodesZones(
 	if len(storagelessCount) != 0 {
 		require.Equal(t, uint32(len(storagelessCount)), totalZones)
 	} else {
-		storagelessCount = make([]uint32, totalZones, totalZones)
+		storagelessCount = make([]uint32, totalZones)
 	}
 	expected := []*storageapi.StorageNode{}
 	k8sClient := testutil.FakeK8sClient(cluster)

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1185,10 +1185,8 @@ func getDefaultMaxStorageNodesPerZone(zoneMap map[string]uint64) uint32 {
 }
 
 func (c *Controller) isPxImageBeingUpdated(toUpdate *corev1.StorageCluster) bool {
-	logrus.Infof("MYD %v", *toUpdate)
 	pxEnabled := storagePodsEnabled(toUpdate)
 	newVersion := pxutil.GetImageTag(strings.TrimSpace(toUpdate.Spec.Image))
-	logrus.Infof("MYD new:%v pxEnabled:%v", newVersion, pxEnabled)
 	return pxEnabled &&
 		(toUpdate.Spec.Version == "" || newVersion != toUpdate.Status.Version)
 }

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	storageapi "github.com/libopenstorage/openstorage/api"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	"github.com/libopenstorage/operator/pkg/cloudprovider"
 	"reflect"
 	"sort"
@@ -78,6 +80,8 @@ const (
 	deprecatedCRDBasePath               = "/crds/deprecated"
 	storageClusterCRDFile               = "core_v1_storagecluster_crd.yaml"
 	minSupportedK8sVersion              = "1.12.0"
+	nodeTypeLabelKey                    = "portworx.io/node-type"
+	storagelessLabelValue               = "storageless"
 )
 
 var _ reconcile.Reconciler = &Controller{}
@@ -1122,6 +1126,45 @@ func (c *Controller) CreatePodTemplate(
 	}
 	return newTemplate, nil
 }
+func (c *Controller) getCurrentMaxStorageNodesPerZone(
+	cluster *corev1.StorageCluster,
+	nodeList *v1.NodeList,
+	cloudProvider cloudprovider.Ops,
+) (uint32, error) {
+	storageNodeMap := make(map[string]*storageapi.StorageNode)
+
+	if storagePodsEnabled(cluster) {
+		storageNodeList, err := c.Driver.GetStorageNodes(cluster)
+		if err != nil {
+			logrus.Errorf("Couldn't get storage node list %v", err)
+			return 0, err
+		}
+		for _, storageNode := range storageNodeList {
+			if len(storageNode.SchedulerNodeName) != 0 && len(storageNode.Pools) > 0 {
+				storageNodeMap[storageNode.SchedulerNodeName] = storageNode
+			}
+		}
+		zoneMap := make(map[string]uint32)
+		for _, node := range nodeList.Items {
+			if _, ok := storageNodeMap[node.Name]; ok {
+				zone, err := cloudProvider.GetZone(&node)
+				if err != nil {
+					return 0, err
+				}
+				count := zoneMap[zone]
+				zoneMap[zone] = count + 1
+			}
+		}
+		maxValue := uint32(0)
+		for _, value := range zoneMap {
+			if value > maxValue {
+				maxValue = value
+			}
+		}
+		return maxValue, nil
+	}
+	return 0, fmt.Errorf("storage disabled")
+}
 
 // getDefaultMaxStorageNodesPerZone aims to return a good value for MaxStorageNodesPerZone with the
 // intention of having at least 3 nodes in the cluster.
@@ -1139,6 +1182,15 @@ func getDefaultMaxStorageNodesPerZone(zoneMap map[string]uint64) uint32 {
 		// In a cluster with 3 or more zones, let's have one node in each zone.
 		return 1
 	}
+}
+
+func (c *Controller) isPxImageBeingUpdated(toUpdate *corev1.StorageCluster) bool {
+	logrus.Infof("MYD %v", *toUpdate)
+	pxEnabled := storagePodsEnabled(toUpdate)
+	newVersion := pxutil.GetImageTag(strings.TrimSpace(toUpdate.Spec.Image))
+	logrus.Infof("MYD new:%v pxEnabled:%v", newVersion, pxEnabled)
+	return pxEnabled &&
+		(toUpdate.Spec.Version == "" || newVersion != toUpdate.Status.Version)
 }
 
 func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) error {
@@ -1229,14 +1281,33 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		logrus.Debugf("Failed to update driver: %v", err)
 	}
 
-	if toUpdate.Status.Phase == "" &&
-		toUpdate.Spec.CloudStorage != nil &&
+	// if no value is set for any of max_storage_nodes*, try to see if can set a default value
+	if toUpdate.Spec.CloudStorage != nil &&
+		toUpdate.Spec.CloudStorage.MaxStorageNodesPerZonePerNodeGroup == nil &&
 		toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone == nil &&
 		toUpdate.Spec.CloudStorage.MaxStorageNodes == nil {
-		// Let's do this only when it's a fresh install of px
-		toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = new(uint32)
-		*toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = getDefaultMaxStorageNodesPerZone(zoneMap)
+		maxStorageNodesPerZone := uint32(0)
+		err = nil
+		if toUpdate.Status.Phase == "" {
+			// Let's do this only when it's a fresh install of px
+			maxStorageNodesPerZone = getDefaultMaxStorageNodesPerZone(zoneMap)
+		} else {
+			// Upgrade scenario
+			if c.isPxImageBeingUpdated(toUpdate) {
+				// If PX image is not changing, we don't have to update the values. This is to prevent pod restarts
+				maxStorageNodesPerZone, err = c.getCurrentMaxStorageNodesPerZone(cluster, nodeList, cloudProvider)
+			}
+		}
+		if maxStorageNodesPerZone != 0 {
+			if err == nil {
+				toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = &maxStorageNodesPerZone
+				logrus.Infof("setting max_storage_nodes_per_zone=%v", maxStorageNodesPerZone)
+			} else {
+				logrus.Errorf("could not set a default value for max_storage_nodes_per_zone %v", err)
+			}
+		}
 	}
+
 	c.Driver.SetDefaultsOnStorageCluster(toUpdate)
 
 	// Update the cluster only if anything has changed

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -80,8 +80,6 @@ const (
 	deprecatedCRDBasePath               = "/crds/deprecated"
 	storageClusterCRDFile               = "core_v1_storagecluster_crd.yaml"
 	minSupportedK8sVersion              = "1.12.0"
-	nodeTypeLabelKey                    = "portworx.io/node-type"
-	storagelessLabelValue               = "storageless"
 )
 
 var _ reconcile.Reconciler = &Controller{}
@@ -1294,15 +1292,14 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 			if c.isPxImageBeingUpdated(toUpdate) {
 				// If PX image is not changing, we don't have to update the values. This is to prevent pod restarts
 				maxStorageNodesPerZone, err = c.getCurrentMaxStorageNodesPerZone(cluster, nodeList, cloudProvider)
+				if err != nil {
+					logrus.Errorf("could not set a default value for max_storage_nodes_per_zone %v", err)
+				}
 			}
 		}
-		if maxStorageNodesPerZone != 0 {
-			if err == nil {
-				toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = &maxStorageNodesPerZone
-				logrus.Infof("setting max_storage_nodes_per_zone=%v", maxStorageNodesPerZone)
-			} else {
-				logrus.Errorf("could not set a default value for max_storage_nodes_per_zone %v", err)
-			}
+		if err == nil && maxStorageNodesPerZone != 0 {
+			toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = &maxStorageNodesPerZone
+			logrus.Infof("setting spec.cloudStorage.maxStorageNodesPerZone %v", maxStorageNodesPerZone)
 		}
 	}
 


### PR DESCRIPTION
…nario

    We will calculate the total number of storage nodes in a cluster
    when the operator is upgraded. If there is not default value set for
    max_storage_nodes_per_zone, total storage nodes per zone will be
    calculated and added as a default value.

**What this PR does / why we need it**:
see above
**Which issue(s) this PR fixes** (optional)
Closes #PWX-24025

**Special notes for your reviewer**:
Testing:
-- Added a Unit test
```
> go test -v -run TestStorageUpgradeClusterDefaultsMaxStorageNodesPerZone
=== RUN   TestStorageUpgradeClusterDefaultsMaxStorageNodesPerZone
INFO[0000] setting max_storage_nodes_per_zone=24
INFO[0000] setting max_storage_nodes_per_zone=12
INFO[0000] setting max_storage_nodes_per_zone=8
INFO[0000] setting max_storage_nodes_per_zone=6
INFO[0000] setting max_storage_nodes_per_zone=14
INFO[0000] setting max_storage_nodes_per_zone=23
INFO[0000] setting max_storage_nodes_per_zone=7
INFO[0000] setting max_storage_nodes_per_zone=7
INFO[0000] setting max_storage_nodes_per_zone=12
INFO[0000] setting max_storage_nodes_per_zone=3
INFO[0000] setting max_storage_nodes_per_zone=3
INFO[0000] setting max_storage_nodes_per_zone=3
INFO[0000] setting max_storage_nodes_per_zone=1
INFO[0000] setting max_storage_nodes_per_zone=8
INFO[0000] setting max_storage_nodes_per_zone=8
INFO[0000] setting max_storage_nodes_per_zone=1
INFO[0000] setting max_storage_nodes_per_zone=5
INFO[0000] setting max_storage_nodes_per_zone=6
INFO[0000] setting max_storage_nodes_per_zone=6
--- PASS: TestStorageUpgradeClusterDefaultsMaxStorageNodesPerZone (0.02s)
PASS
ok      github.com/libopenstorage/operator/pkg/controller/storagecluster        0.043s
```
-- On a 9 node EKS cluster did the following
- Installed Operator 1.9 and px 2.10
- Verified that there is not value for max_storage_nodes_per_zone (both stc and config.json)
- Upgraded op-1.9 to op-my-fixes
- Verified that there is not value for max_storage_nodes_per_zone (both stc and config.json). And that no pods restarted.
- Edited stc to update the px version to 2.10.1
- Saw that in stc the max_.._zone value was updated to 3 `maxStorageNodesPerZone: 3`
- Saw that pods were rebooting. 
- On one of the rebooted pods verified that config.json had the updated value ` "max_storage_nodes_per_zone": 3`

- - Will work on Azure for a similar manual test