### PR TITLE
[PWX-26326] Delete telemetry secret only when delete strategy is Unin…

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -787,11 +787,13 @@ func ValidateUninstallStorageCluster(
 	}
 
 	// Verify telemetry secret is deleted on UninstallAndWipe
-	// Only do the validation when telemetry is enabled, since if it's disabled, there's a chance secret owner is not set yet
-	telemetryEnabled := cluster.Spec.Monitoring != nil && cluster.Spec.Monitoring.Telemetry != nil && cluster.Spec.Monitoring.Telemetry.Enabled
-	_, err := coreops.Instance().GetSecret("pure-telemetry-certs", cluster.Namespace)
-	if !errors.IsNotFound(err) && telemetryEnabled {
-		return fmt.Errorf("telemetry secret pure-telemetry-certs was found when shouldn't have been")
+	if cluster.Spec.DeleteStrategy != nil && cluster.Spec.DeleteStrategy.Type == corev1.UninstallAndWipeStorageClusterStrategyType {
+		// Only do the validation when telemetry is enabled, since if it's disabled, there's a chance secret owner is not set yet
+		telemetryEnabled := cluster.Spec.Monitoring != nil && cluster.Spec.Monitoring.Telemetry != nil && cluster.Spec.Monitoring.Telemetry.Enabled
+		_, err := coreops.Instance().GetSecret("pure-telemetry-certs", cluster.Namespace)
+		if !errors.IsNotFound(err) && telemetryEnabled {
+			return fmt.Errorf("telemetry secret pure-telemetry-certs was found when shouldn't have been")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
…stallAndWipe

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* Set telemetry secret owner reference when delete strategy is UninstallAndWipe
* Otherwise remove the owner reference from telemetry secret.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
passed automation: https://jenkins.pwx.dev.purestorage.com/view/Newstack%20Dashboard/job/Operator/job/operator-integration-basic-master-dev/1/
