### PR TITLE
PWX-24024: First Install: Default value for max_storage_nodes_per_zone (#711)

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	failureDomainZoneKey   = "failure-domain.beta.kubernetes.io/zone"
-	failureDomainRegionKey = "failure-domain.beta.kubernetes.io/region"
+	failureDomainZoneKey   = v1.LabelTopologyZone
+	failureDomainRegionKey = v1.LabelTopologyRegion
 )
 
 var (

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/libopenstorage/operator/pkg/cloudprovider"
 	"reflect"
 	"sort"
 	"strconv"
@@ -54,7 +55,6 @@ import (
 
 	"github.com/libopenstorage/operator/drivers/storage"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/cloudprovider"
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
 	"github.com/libopenstorage/operator/pkg/util/k8s"
@@ -73,7 +73,7 @@ const (
 	defaultStorageClusterUniqueLabelKey = apps.ControllerRevisionHashLabelKey
 	defaultRevisionHistoryLimit         = 10
 	defaultMaxUnavailablePods           = 1
-	failureDomainZoneKey                = "failure-domain.beta.kubernetes.io/zone"
+	failureDomainZoneKey                = v1.LabelZoneFailureDomainStable
 	crdBasePath                         = "/crds"
 	deprecatedCRDBasePath               = "/crds/deprecated"
 	storageClusterCRDFile               = "core_v1_storagecluster_crd.yaml"
@@ -736,49 +736,17 @@ func (c *Controller) manage(
 		return fmt.Errorf("couldn't get node to storage cluster pods mapping for storage cluster %v: %v",
 			cluster.Name, err)
 	}
+	var nodesNeedingStoragePods, podsToDelete []string
 
-	// For each node, if the node is running the storage pod but isn't supposed to, kill the storage pod.
-	// If the node is supposed to run the storage pod, but isn't, create the storage pod on the node.
 	nodeList := &v1.NodeList{}
 	err = c.client.List(context.TODO(), nodeList, &client.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("couldn't get list of nodes when syncing storage cluster %#v: %v",
 			cluster, err)
 	}
-	var (
-		nodesNeedingStoragePods, podsToDelete []string
-		cloudProviderName                     string
-	)
-	zoneMap := make(map[string]uint64)
 
-	for _, node := range nodeList.Items {
-		// Get the cloud provider
-		// From kubernetes node spec:  <ProviderName>://<ProviderSpecificNodeID>
-		if len(node.Spec.ProviderID) != 0 {
-			tokens := strings.Split(node.Spec.ProviderID, "://")
-			if len(tokens) == 2 {
-				cloudProviderName = tokens[0]
-				break
-			} // else provider id is invalid
-		}
-	}
-
-	cloudProvider := cloudprovider.New(cloudProviderName)
-
-	for _, node := range nodeList.Items {
-		if zone, err := cloudProvider.GetZone(&node); err == nil {
-			instancesCount := zoneMap[zone]
-			zoneMap[zone] = instancesCount + 1
-		}
-	}
-
-	if err := c.Driver.UpdateDriver(&storage.UpdateDriverInfo{
-		ZoneToInstancesMap: zoneMap,
-		CloudProvider:      cloudProviderName,
-	}); err != nil {
-		logrus.Debugf("Failed to update driver: %v", err)
-	}
-
+	// For each node, if the node is running the storage pod but isn't supposed to, kill the storage pod.
+	// If the node is supposed to run the storage pod, but isn't, create the storage pod on the node.
 	for _, node := range nodeList.Items {
 		nodesNeedingStoragePodsOnNode, podsToDeleteOnNode, err := c.podsShouldBeOnNode(&node, nodeToStoragePods, cluster)
 		if err != nil {
@@ -1153,6 +1121,24 @@ func (c *Controller) CreatePodTemplate(
 	return newTemplate, nil
 }
 
+// getDefaultMaxStorageNodesPerZone aims to return a good value for MaxStorageNodesPerZone with the
+// intention of having at least 3 nodes in the cluster.
+func getDefaultMaxStorageNodesPerZone(zoneMap map[string]uint64) uint32 {
+	numZones := len(zoneMap)
+	switch numZones {
+	case 0, 1:
+		// If there is a single Zone, have all 3 nodes in the same zone
+		return 3
+	case 2:
+		// If there are two zones, it'll be tricky since we'll always lose quorum when a zone
+		// goes down. Let's have 2 nodes in a zone so that we have a 4 node cluster.
+		return 2
+	default:
+		// In a cluster with 3 or more zones, let's have one node in each zone.
+		return 1
+	}
+}
+
 func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) error {
 	toUpdate := cluster.DeepCopy()
 
@@ -1204,6 +1190,51 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		toUpdate.Spec.CloudStorage.NodePoolLabel = key
 	}
 
+	nodeList := &v1.NodeList{}
+	err = c.client.List(context.TODO(), nodeList, &client.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("couldn't get list of nodes when syncing storage cluster %#v: %v",
+			toUpdate, err)
+	}
+	var cloudProviderName string
+	zoneMap := make(map[string]uint64)
+
+	for _, node := range nodeList.Items {
+		// Get the cloud provider
+		// From kubernetes node spec:  <ProviderName>://<ProviderSpecificNodeID>
+		if len(node.Spec.ProviderID) != 0 {
+			tokens := strings.Split(node.Spec.ProviderID, "://")
+			if len(tokens) == 2 {
+				cloudProviderName = tokens[0]
+				break
+			} // else provider id is invalid
+		}
+	}
+
+	cloudProvider := cloudprovider.New(cloudProviderName)
+
+	for _, node := range nodeList.Items {
+		if zone, err := cloudProvider.GetZone(&node); err == nil {
+			instancesCount := zoneMap[zone]
+			zoneMap[zone] = instancesCount + 1
+		}
+	}
+
+	if err := c.Driver.UpdateDriver(&storage.UpdateDriverInfo{
+		ZoneToInstancesMap: zoneMap,
+		CloudProvider:      cloudProviderName,
+	}); err != nil {
+		logrus.Debugf("Failed to update driver: %v", err)
+	}
+
+	if toUpdate.Status.Phase == "" &&
+		toUpdate.Spec.CloudStorage != nil &&
+		toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone == nil &&
+		toUpdate.Spec.CloudStorage.MaxStorageNodes == nil {
+		// Let's do this only when it's a fresh install of px
+		toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = new(uint32)
+		*toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = getDefaultMaxStorageNodesPerZone(zoneMap)
+	}
 	c.Driver.SetDefaultsOnStorageCluster(toUpdate)
 
 	// Update the cluster only if anything has changed


### PR DESCRIPTION
* PWX-24024: Default value for max_storage_nodes_per_zone

  A default value for max_storage_nodes_per_zone will be set when the cluster is created afresh. This change does not effect existing installs or upgrades.

  The value will be determined as follows Zones | Default value | total nodes ------------------------------------
    1   |      3        |   3
    2   |      2        |   4
    3   |      1        |   3
    >4   |      1        |  >4

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Cherry-picking from master.
