### PR TITLE
[PWX-27016] Fix ccm-go phonehome issue on ocp cluster

### DIFF
--- a/deploy/ccm/envoy-config-collector-custom-proxy.yaml
+++ b/deploy/ccm/envoy-config-collector-custom-proxy.yaml
@@ -2,7 +2,7 @@ admin:
   address:
     socket_address:
       address: 127.0.0.1
-      port_value: 9901
+      port_value: 9903
 node:
   id: "id_rest"
   cluster: "cluster_rest"

--- a/deploy/ccm/envoy-config-collector.yaml
+++ b/deploy/ccm/envoy-config-collector.yaml
@@ -2,7 +2,7 @@ admin:
   address:
     socket_address:
       address: 127.0.0.1
-      port_value: 9901
+      port_value: 9903
 node:
   id: "id_rest"
   cluster: "cluster_rest"

--- a/deploy/ccm/envoy-config-rest-custom-proxy.yaml
+++ b/deploy/ccm/envoy-config-rest-custom-proxy.yaml
@@ -2,7 +2,7 @@ admin:
   address:
     socket_address:
       address: 127.0.0.1
-      port_value: 9901
+      port_value: 9902
 node:
   id: "id_rest"
   cluster: "cluster_rest"

--- a/deploy/ccm/envoy-config-rest.yaml
+++ b/deploy/ccm/envoy-config-rest.yaml
@@ -2,7 +2,7 @@ admin:
   address:
     socket_address:
       address: 127.0.0.1
-      port_value: 9901
+      port_value: 9902
 node:
   id: "id_rest"
   cluster: "cluster_rest"

--- a/deploy/ccm/metrics-collector-deployment.yaml
+++ b/deploy/ccm/metrics-collector-deployment.yaml
@@ -34,6 +34,8 @@ spec:
           readOnly: true
       - args:
         - envoy
+        - "--base-id"
+        - "3"
         - --config-path
         - /config/envoy-config.yaml
         image: purestorage/telemetry-envoy:1.0.0

--- a/deploy/ccm/phonehome-cluster.yaml
+++ b/deploy/ccm/phonehome-cluster.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         name: px-telemetry-phonehome
     spec:
+      hostNetwork: true
       containers:
         - name: log-upload-service
           image: purestorage/log-upload:1.0.0
@@ -34,11 +35,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-          ports:
-            - name: loguploader
-              containerPort: 9090
-              hostPort: 9090
-              protocol: TCP
           imagePullPolicy: Always
         - name: envoy
           image: purestorage/telemetry-envoy:1.0.0
@@ -56,13 +52,10 @@ spec:
             name: pure-telemetry-certs
           args:
           - "envoy"
+          - "--base-id"
+          - "2"
           - "--config-path"
           - "/config/envoy-config-rest.yaml"
-          ports:
-            - name: envoy
-              containerPort: 12002
-              hostPort: 12002
-              protocol: TCP
       initContainers:
         - name: init-cont
           image: purestorage/telemetry-envoy:1.0.0

--- a/deploy/ccm/registration-service.yaml
+++ b/deploy/ccm/registration-service.yaml
@@ -34,6 +34,8 @@ spec:
             name: proxy-config
           args:
           - "envoy"
+          - "--base-id"
+          - "1"
           - "--config-path"
           - "/config/envoy-config-register.yaml"
       volumes:

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -861,23 +861,8 @@ func (t *telemetry) createDaemonSetTelemetryPhonehome(
 		container := &daemonset.Spec.Template.Spec.Containers[i]
 		if container.Name == containerNameLogUploader {
 			container.Image = logUploaderImage
-			for j := 0; j < len(container.Ports); j++ {
-				port := &container.Ports[j]
-				if port.Name == portNameLogUploaderContainer {
-					port.HostPort = int32(getCCMListeningPort(cluster))
-					port.ContainerPort = int32(getCCMListeningPort(cluster))
-				}
-			}
 		} else if container.Name == containerNameTelemetryProxy {
 			container.Image = proxyImage
-			for j := 0; j < len(container.Ports); j++ {
-				port := &container.Ports[j]
-				cloudSupportPort, _, _ := getCCMCloudSupportPorts(cluster, defaultPhonehomePort)
-				if port.Name == portNameEnvoy {
-					port.HostPort = int32(cloudSupportPort)
-					port.ContainerPort = int32(cloudSupportPort)
-				}
-			}
 		}
 	}
 	for i := 0; i < len(daemonset.Spec.Template.Spec.InitContainers); i++ {

--- a/drivers/storage/portworx/testspec/ccmGoCollectorDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorDeployment.yaml
@@ -54,6 +54,8 @@ spec:
           readOnly: true
       - args:
         - envoy
+        - --base-id
+        - "3"
         - --config-path
         - /config/envoy-config.yaml
         image: docker.io/purestorage/envoy:1.2.3

--- a/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap.yaml
@@ -14,7 +14,7 @@ data:
       address:
         socket_address:
           address: 127.0.0.1
-          port_value: 9901
+          port_value: 9903
     node:
       id: "id_rest"
       cluster: "cluster_rest"

--- a/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap_proxy.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap_proxy.yaml
@@ -14,7 +14,7 @@ data:
       address:
         socket_address:
           address: 127.0.0.1
-          port_value: 9901
+          port_value: 9903
     node:
       id: "id_rest"
       cluster: "cluster_rest"

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSet.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSet.yaml
@@ -34,6 +34,7 @@ spec:
                 operator: Exists
               - key: node-role.kubernetes.io/worker
                 operator: Exists
+      hostNetwork: true
       containers:
       - env:
         - name: K8S_NODE_NAME
@@ -43,11 +44,6 @@ spec:
         image: docker.io/purestorage/log-upload:1.2.3
         imagePullPolicy: Always
         name: log-upload-service
-        ports:
-        - containerPort: 10090
-          hostPort: 10090
-          name: loguploader
-          protocol: TCP
         volumeMounts:
         - mountPath: /etc/pwx
           name: etcpwx
@@ -63,16 +59,13 @@ spec:
           readOnly: true
       - args:
         - envoy
+        - --base-id
+        - "2"
         - --config-path
         - /config/envoy-config-rest.yaml
         image: docker.io/purestorage/envoy:1.2.3
         imagePullPolicy: Always
         name: envoy
-        ports:
-        - containerPort: 13002
-          hostPort: 13002
-          name: envoy
-          protocol: TCP
         securityContext:
           runAsUser: 1111
         volumeMounts:

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeProxyConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeProxyConfigMap.yaml
@@ -14,7 +14,7 @@ data:
       address:
         socket_address:
           address: 127.0.0.1
-          port_value: 9901
+          port_value: 9902
     node:
       id: "id_rest"
       cluster: "cluster_rest"

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeProxyConfigMap_proxy.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeProxyConfigMap_proxy.yaml
@@ -14,7 +14,7 @@ data:
       address:
         socket_address:
           address: 127.0.0.1
-          port_value: 9901
+          port_value: 9902
     node:
       id: "id_rest"
       cluster: "cluster_rest"

--- a/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
@@ -46,6 +46,8 @@ spec:
           readOnly: true
       - args:
         - envoy
+        - --base-id
+        - "1"
         - --config-path
         - /config/envoy-config-register.yaml
         image: docker.io/purestorage/envoy:1.2.3


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* use host network for phonehome
* resolve envoy admin port conflict
* resolve envoy base-id conflict

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

