### PR TITLE
improve functional test performance

### DIFF
--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -472,8 +472,7 @@ func BasicTelemetryRegression(tc *types.TestCase) func(*testing.T) {
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
 
-		cluster, err = operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
-		require.Nil(t, err)
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
 
 		// Validate Telemetry is not enabled by default
 		logrus.Info("Validate Telemetry is not enabled by default")
@@ -522,8 +521,7 @@ func BasicCsiRegression(tc *types.TestCase) func(*testing.T) {
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
 
-		cluster, err = operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
-		require.Nil(t, err)
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
 
 		// Validate CSI is enabled by default
 		require.Equal(t, cluster.Spec.CSI.Enabled, true)
@@ -608,9 +606,7 @@ func BasicStorkRegression(tc *types.TestCase) func(*testing.T) {
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
 
-		var err error
-		cluster, err = operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
-		require.Nil(t, err)
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
 
 		// Validate Stork is enabled by default
 		require.True(t, cluster.Spec.Stork.Enabled, "failed to validate Stork is enabled by default, it should be enabled, but it is set to %v", cluster.Spec.Stork.Enabled)
@@ -699,9 +695,7 @@ func BasicAutopilotRegression(tc *types.TestCase) func(*testing.T) {
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
 
-		var err error
-		cluster, err = operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
-		require.Nil(t, err)
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
 
 		// Validate Autopilot block is nil
 		require.Nil(t, cluster.Spec.Autopilot, "failed to validate Autopilot block, it should be nil by default, but it seems there is something set in there %+v", cluster.Spec.Autopilot)
@@ -756,9 +750,7 @@ func BasicPvcControllerRegression(tc *types.TestCase) func(*testing.T) {
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
 
-		var err error
-		cluster, err = operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
-		require.Nil(t, err)
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
 
 		require.Empty(t, cluster.Annotations["portworx.io/pvc-controller"], "failed to validate portworx.io/pvc-controller annotation, it shouldn't exist by default, but it is and has value of %s", cluster.Annotations["portworx.io/pvc-controller"])
 
@@ -864,8 +856,7 @@ func BasicAlertManagerRegression(tc *types.TestCase) func(*testing.T) {
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
 
-		cluster, err = operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
-		require.Nil(t, err)
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
 
 		// Validate AlertManager is not enabled by default
 		logrus.Info("Validate ALertManager is not enabled by default")
@@ -949,8 +940,7 @@ func BasicSecurityRegression(tc *types.TestCase) func(*testing.T) {
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
 
-		cluster, err = operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
-		require.Nil(t, err)
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
 
 		// Validate Security is not enabled by default
 		logrus.Info("Validate Security is not enabled by default")
@@ -996,8 +986,7 @@ func BasicKvdbRegression(tc *types.TestCase) func(*testing.T) {
 		cluster, ok := testSpec.(*corev1.StorageCluster)
 		require.True(t, ok)
 
-		cluster, err = operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
-		require.Nil(t, err)
+		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
 
 		// Delete all KVDB pods and validate the get re-created
 		logrus.Info("Delete portworx KVDB pods and validate they get re-deployed")

--- a/test/integration_test/migration_test.go
+++ b/test/integration_test/migration_test.go
@@ -34,7 +34,7 @@ import (
 
 const (
 	operatorRestartTimeout       = 5 * time.Minute
-	operatorRestartRetryInterval = 10 * time.Second
+	operatorRestartRetryInterval = 5 * time.Second
 	clusterCreationTimeout       = 5 * time.Minute
 	clusterCreationRetryInterval = 5 * time.Second
 	labelKeyPXEnabled            = "px/enabled"

--- a/test/integration_test/utils/constants.go
+++ b/test/integration_test/utils/constants.go
@@ -61,19 +61,19 @@ const (
 	// DefaultValidateDeployTimeout is a default timeout for deployment validation
 	DefaultValidateDeployTimeout = 15 * time.Minute
 	// DefaultValidateDeployRetryInterval is a default retry interval for deployment validation
-	DefaultValidateDeployRetryInterval = 20 * time.Second
+	DefaultValidateDeployRetryInterval = 15 * time.Second
 	// DefaultValidateUpgradeTimeout is a default timeout for upgrade validation
 	DefaultValidateUpgradeTimeout = 30 * time.Minute
 	// DefaultValidateUpgradeRetryInterval is a default retry interval for upgrade validation
-	DefaultValidateUpgradeRetryInterval = 30 * time.Second
+	DefaultValidateUpgradeRetryInterval = 15 * time.Second
 	// DefaultValidateUpdateTimeout is a default timeout for update validation
 	DefaultValidateUpdateTimeout = 20 * time.Minute
 	// DefaultValidateUpdateRetryInterval is a default retry interval for update validation
-	DefaultValidateUpdateRetryInterval = 20 * time.Second
+	DefaultValidateUpdateRetryInterval = 15 * time.Second
 	// DefaultValidateUninstallTimeout is a default timeout for uninstall validation
 	DefaultValidateUninstallTimeout = 15 * time.Minute
 	// DefaultValidateUninstallRetryInterval is a default retry interval for uninstall validation
-	DefaultValidateUninstallRetryInterval = 20 * time.Second
+	DefaultValidateUninstallRetryInterval = 15 * time.Second
 
 	// DefaultValidateComponentTimeout is a default timeout for component validation
 	DefaultValidateComponentTimeout = 10 * time.Minute


### PR DESCRIPTION
Reduced test execution time by 50%

1. dedupe BasicInstallWithAllDefaults (tested with upgrade test cases)
2. avoid uninstall and reinstall px in very test function
3. reduce interval when waiting for desired status.