### PR TITLE
PWX-24830: Adding apt-get to support debian container test image.

### DIFF
--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -138,6 +138,9 @@ done
 apk update
 apk add jq
 
+apt-get -y update
+apt-get install -y jq
+
 # Copy test pod template to a new file
 cp $test_pod_template $test_pod_spec
 


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

**What this PR does / why we need it**:
When adding GKE support we are using google/cloud-sdk container which is a Debian image. Operator test container assumes this container image to be Alpine. 

**Which issue(s) this PR fixes** (optional)
Closes #PWX-24830

**Special notes for your reviewer**:
These changes were removed in the following commit https://github.com/libopenstorage/operator/pull/234/files