### PR TITLE
[PWX-27219] Truncate clusterID during migration if longer than 63 chars

### DIFF
--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -1179,9 +1179,15 @@ func initRuntimeOptions(cluster *corev1.StorageCluster) {
 func getStorageClusterNameFromClusterID(clusterID string) string {
 	// Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
 	// If the cluster ID is a valid k8s object name, just set it as the storage cluster name
+	// Additionally, check whether the clusterID is longer than 63 chars, which will fail to construct controller revision
 	validNameRegex := regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
-	if validNameRegex.MatchString(clusterID) {
+	if validNameRegex.MatchString(clusterID) && len(clusterID) <= 63 {
 		return clusterID
+	}
+
+	// Truncate the cluster ID if it's longer than 63 chars
+	if len(clusterID) > 63 {
+		clusterID = clusterID[0:63]
 	}
 
 	// If the cluster ID is invalid as a k8s object name, replace '_' with '-' then remove all invalid characters

--- a/pkg/migration/migration_test.go
+++ b/pkg/migration/migration_test.go
@@ -5110,6 +5110,115 @@ func TestTelemetryMigrationWithPX2_12(t *testing.T) {
 	require.Contains(t, msg, "Migration completed successfully")
 }
 
+func TestStorageClusterCreatedWithLongClusterID(t *testing.T) {
+	clusterID := "this-is-a-super-loong-cluster-id-which-is-exactly-64-character-s"
+	stcName := "this-is-a-super-loong-cluster-id-which-is-exactly-64-character"
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "portworx",
+			Namespace: "kube-system",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "portworx",
+							Args: []string{
+								"-c", clusterID,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(ds)
+	mockController := gomock.NewController(t)
+	driver := testutil.MockDriver(mockController)
+	ctrl := &storagecluster.Controller{
+		Driver: driver,
+	}
+	ctrl.SetEventRecorder(record.NewFakeRecorder(10))
+	ctrl.SetKubernetesClient(k8sClient)
+	mockManifest := mock.NewMockManifest(mockController)
+	manifest.SetInstance(mockManifest)
+	mockManifest.EXPECT().CanAccessRemoteManifest(gomock.Any()).AnyTimes()
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(ds.Spec.Template.Spec, nil).AnyTimes()
+	driver.EXPECT().GetSelectorLabels().AnyTimes()
+	driver.EXPECT().String().AnyTimes()
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{
+		GitVersion: "v1.16.0",
+	}
+
+	migrator := New(ctrl)
+
+	go migrator.Start()
+	time.Sleep(2 * time.Second)
+
+	expectedCluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stcName,
+			Namespace: ds.Namespace,
+			Annotations: map[string]string{
+				constants.AnnotationMigrationApproved: "false",
+				pxutil.AnnotationClusterID:            clusterID,
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			CSI: &corev1.CSISpec{
+				Enabled: false,
+			},
+			Stork: &corev1.StorkSpec{
+				Enabled: false,
+			},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: false,
+			},
+			Monitoring: &corev1.MonitoringSpec{
+				Prometheus: &corev1.PrometheusSpec{
+					ExportMetrics: false,
+					Enabled:       false,
+					AlertManager: &corev1.AlertManagerSpec{
+						Enabled: false,
+					},
+				},
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: false,
+				},
+			},
+			CommonConfig: corev1.CommonConfig{
+				Env: []v1.EnvVar{
+					{
+						Name:  "PX_SECRETS_NAMESPACE",
+						Value: "portworx",
+					},
+				},
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			Phase:         constants.PhaseAwaitingApproval,
+			DesiredImages: &corev1.ComponentImages{},
+		},
+	}
+	cluster := &corev1.StorageCluster{}
+	err := testutil.Get(k8sClient, cluster, stcName, ds.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedCluster.Annotations, cluster.Annotations)
+	require.ElementsMatch(t, expectedCluster.Spec.Env, cluster.Spec.Env)
+	expectedCluster.Spec.Env = nil
+	cluster.Spec.Env = nil
+	require.Equal(t, expectedCluster.Spec, cluster.Spec)
+	require.Equal(t, expectedCluster.Status, cluster.Status)
+
+	// Stop the migration process by removing the daemonset
+	err = testutil.Delete(k8sClient, ds)
+	require.NoError(t, err)
+}
+
 func validateMigrationIsInProgress(
 	k8sClient client.Client,
 	cluster *corev1.StorageCluster,


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* truncate cluster id and store the original one in annotation

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

