### PR TITLE
[PWX-27353][PWX-27401] PVC controller fix and disabling metrics collector

### DIFF
--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -2,6 +2,7 @@ package component
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strconv"
 
@@ -246,6 +247,11 @@ func (c *pvcController) createClusterRole() error {
 					ResourceNames: []string{constants.PrivilegedPSPName},
 					Verbs:         []string{"use"},
 				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"*"},
+				},
 			},
 		},
 	)
@@ -311,6 +317,9 @@ func (c *pvcController) createDeployment(
 		} else {
 			command = append(command, "--leader-elect-resource-lock=configmaps")
 		}
+	} else {
+		command = append(command, "--leader-elect-resource-name=portworx-pvc-controller")
+		command = append(command, fmt.Sprintf("--leader-elect-resource-namespace=%s", cluster.Namespace))
 	}
 
 	if c.k8sVersion.LessThan(k8sutil.K8sVer1_22) {

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -142,6 +142,10 @@ func (t *telemetry) deployMetricsCollectorV1(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	if t.reconcileMetricsCollector == nil || !*t.reconcileMetricsCollector {
+		return nil
+	}
+
 	if err := t.createCollectorServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -1543,7 +1543,7 @@ func TestPVCControllerInstallWithK8s1_24(t *testing.T) {
 
 	expectedDeployment := testutil.GetExpectedDeployment(t, "pvcControllerDeployment_k8s_1.24.yaml")
 	expectedContainer := expectedDeployment.Spec.Template.Spec.Containers[0]
-	expectedContainer.Command = expectedContainer.Command[0:4]
+	expectedContainer.Command = expectedContainer.Command[0:6]
 	expectedContainer.Image = "k8s.gcr.io/kube-controller-manager-amd64:v1.24.0"
 	expectedContainer.LivenessProbe.HTTPGet.Port = intstr.FromInt(10257)
 	expectedContainer.LivenessProbe.HTTPGet.Scheme = v1.URISchemeHTTPS

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -7047,6 +7047,18 @@ func TestCompleteInstallWithCustomRegistryChange(t *testing.T) {
 		&client.CreateOptions{},
 	)
 
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
 	// Case: Custom registry should be added to the images
 	err := driver.PreInstall(cluster)
 	require.NoError(t, err)
@@ -7913,6 +7925,17 @@ func TestCompleteInstallWithCustomRepoRegistryChange(t *testing.T) {
 		&client.CreateOptions{},
 	)
 
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
 	// Case: Custom repo-registry should be added to the images
 	err := driver.PreInstall(cluster)
 	require.NoError(t, err)
@@ -8746,6 +8769,18 @@ func TestCompleteInstallWithCustomRepoRegistryChangeForK8s_1_12(t *testing.T) {
 	}
 	driver.SetDefaultsOnStorageCluster(cluster)
 
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
 	// Case: Custom repo-registry should be added to the images
 	err := driver.PreInstall(cluster)
 	require.NoError(t, err)
@@ -9012,6 +9047,18 @@ func TestCompleteInstallWithImagePullSecretChange(t *testing.T) {
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      component.AlertManagerConfigSecretName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
 				Namespace: cluster.Namespace,
 			},
 		},
@@ -9434,6 +9481,18 @@ func TestCompleteInstallWithTolerationsChange(t *testing.T) {
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      component.AlertManagerConfigSecretName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
 				Namespace: cluster.Namespace,
 			},
 		},
@@ -9955,6 +10014,18 @@ func TestCompleteInstallWithNodeAffinityChange(t *testing.T) {
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      component.AlertManagerConfigSecretName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
 				Namespace: cluster.Namespace,
 			},
 		},
@@ -12273,6 +12344,18 @@ func TestTelemetryEnableAndDisable(t *testing.T) {
 		},
 	}
 
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
 	driver.SetDefaultsOnStorageCluster(cluster)
 
 	err := driver.PreInstall(cluster)
@@ -12617,6 +12700,18 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 		&client.CreateOptions{},
 	)
 
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.DeploymentNameTelemetryCollectorV2,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
 	// Validate default ccm listening port
 	driver.SetDefaultsOnStorageCluster(cluster)
 	err := driver.PreInstall(cluster)
@@ -12875,6 +12970,18 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 		&client.CreateOptions{},
 	)
 
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
 	driver.SetDefaultsOnStorageCluster(cluster)
 	err := driver.PreInstall(cluster)
 	require.NoError(t, err)
@@ -13061,6 +13168,18 @@ func TestTelemetryCCMGoProxy(t *testing.T) {
 		},
 	}
 
+	// PWX-27401 reconcile collector to validate specs
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.DeploymentNameTelemetryCollectorV2,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
 	driver.SetDefaultsOnStorageCluster(cluster)
 
 	// TestCase: no px proxy specified
@@ -13190,6 +13309,167 @@ func TestTelemetryCCMGoProxy(t *testing.T) {
 	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryPhonehomeProxy, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
 	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+}
+
+// PWX-27401
+func TestTelemetryMetricsCollectorDisabledByDefault(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	// Deploy px with CCM Java enabled
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/oci-monitor:2.10.1",
+			Monitoring: &corev1.MonitoringSpec{
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: true,
+					Image:   "purestorage/telemetry:1.2.3",
+				},
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			ClusterUID: "test-clusteruid",
+		},
+	}
+	// This cert is created by ccm container outside of operator, let's simulate it.
+	k8sClient.Create(
+		context.TODO(),
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.TelemetryCertName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
+	// TestCase: enabling telemetry doesn't create metrics collector
+	driver.SetDefaultsOnStorageCluster(cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	serviceAccount := &v1.ServiceAccount{}
+	err = testutil.Get(k8sClient, serviceAccount, component.CollectorServiceAccountName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	clusterRole := &rbacv1.ClusterRole{}
+	err = testutil.Get(k8sClient, clusterRole, component.CollectorClusterRoleName, "")
+	require.True(t, errors.IsNotFound(err))
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, clusterRoleBinding, component.CollectorClusterRoleBindingName, "")
+	require.True(t, errors.IsNotFound(err))
+	role := &rbacv1.Role{}
+	err = testutil.Get(k8sClient, role, component.CollectorRoleName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	roleBinding := &rbacv1.RoleBinding{}
+	err = testutil.Get(k8sClient, roleBinding, component.CollectorRoleBindingName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	configMap := &v1.ConfigMap{}
+	err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	configMap = &v1.ConfigMap{}
+	err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	deployment := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+
+	// TestCase: deploy metrics collector V1 and restart operator, collector should be reconciled
+	k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+
+	reregisterComponents()
+	driver = portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	driver.SetDefaultsOnStorageCluster(cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	err = testutil.Get(k8sClient, serviceAccount, component.CollectorServiceAccountName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, clusterRole, component.CollectorClusterRoleName, "")
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, clusterRoleBinding, component.CollectorClusterRoleBindingName, "")
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, role, component.CollectorRoleName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, roleBinding, component.CollectorRoleBindingName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+
+	// TestCase: upgrade to ccm go, new collector should be reconciled
+	cluster.Spec.Image = "portworx/oci-monitor:2.12.1"
+	driver.SetDefaultsOnStorageCluster(cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// old collector components got deleted
+	err = testutil.Get(k8sClient, serviceAccount, component.CollectorServiceAccountName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, clusterRole, component.CollectorClusterRoleName, "")
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, clusterRoleBinding, component.CollectorClusterRoleBindingName, "")
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, role, component.CollectorRoleName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, roleBinding, component.CollectorRoleBindingName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+
+	// new collector components created
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorV2, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryCollectorV2, cluster.Namespace)
+	require.NoError(t, err)
+
+	// TestCase: disable telemetry, restart operator and re-enable telemetry, collector v2 should not be created
+	cluster.Spec.Monitoring.Telemetry.Enabled = false
+	driver.SetDefaultsOnStorageCluster(cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	reregisterComponents()
+	driver = portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	cluster.Spec.Monitoring.Telemetry.Enabled = true
+	driver.SetDefaultsOnStorageCluster(cluster)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorV2, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryCollectorV2, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
 }
 

--- a/drivers/storage/portworx/testspec/pvcControllerClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerClusterRole.yaml
@@ -50,3 +50,6 @@ rules:
   resources: ["podsecuritypolicies"]
   resourceNames: ["px-privileged"]
   verbs: ["use"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["*"]

--- a/drivers/storage/portworx/testspec/pvcControllerDeployment_k8s_1.24.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerDeployment_k8s_1.24.yaml
@@ -32,6 +32,8 @@ spec:
         - --leader-elect=true
         - --controllers=persistentvolume-binder,persistentvolume-expander
         - --use-service-account-credentials=true
+        - --leader-elect-resource-name=portworx-pvc-controller
+        - --leader-elect-resource-namespace=kube-system
         - --address=0.0.0.0
         image: gcr.io/google_containers/kube-controller-manager-amd64:v0.0.0
         imagePullPolicy: Always

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -2997,9 +2997,10 @@ func ValidateTelemetryV2Enabled(pxImageList map[string]string, cluster *corev1.S
 		}
 
 		// Validate px-telemetry-metrics  deployment, pods and container images
-		if err := validatePxTelemetryMetricsCollectorV2(pxImageList, cluster, timeout, interval); err != nil {
-			return nil, true, err
-		}
+		// Skipped because PWX-27401
+		// if err := validatePxTelemetryMetricsCollectorV2(pxImageList, cluster, timeout, interval); err != nil {
+		// 	return nil, true, err
+		// }
 
 		// Validate px-telemetry-phonehome daemonset, pods and container images
 		if err := validatePxTelemetryPhonehomeV2(pxImageList, cluster, timeout, interval); err != nil {
@@ -3027,13 +3028,13 @@ func ValidateTelemetryV2Enabled(pxImageList map[string]string, cluster *corev1.S
 		}
 
 		// Verify telemetry configmaps
-		if _, err := coreops.Instance().GetConfigMap("px-telemetry-collector", cluster.Namespace); err != nil {
-			return nil, true, err
-		}
+		// if _, err := coreops.Instance().GetConfigMap("px-telemetry-collector", cluster.Namespace); err != nil {
+		// 	return nil, true, err
+		// }
 
-		if _, err := coreops.Instance().GetConfigMap("px-telemetry-collector-proxy", cluster.Namespace); err != nil {
-			return nil, true, err
-		}
+		// if _, err := coreops.Instance().GetConfigMap("px-telemetry-collector-proxy", cluster.Namespace); err != nil {
+		// 	return nil, true, err
+		// }
 
 		if _, err := coreops.Instance().GetConfigMap("px-telemetry-phonehome", cluster.Namespace); err != nil {
 			return nil, true, err
@@ -3249,53 +3250,53 @@ func validatePxTelemetryPhonehomeV2(pxImageList map[string]string, cluster *core
 	return nil
 }
 
-func validatePxTelemetryMetricsCollectorV2(pxImageList map[string]string, cluster *corev1.StorageCluster, timeout, interval time.Duration) error {
-	// Validate px-telemetry-metrics-collector deployment, pods and container images
-	logrus.Info("Validate px-telemetry-metrics-collector deployment and images")
-	metricsCollectorDep := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "px-telemetry-metrics-collector",
-			Namespace: cluster.Namespace,
-		},
-	}
-	if err := appops.Instance().ValidateDeployment(metricsCollectorDep, timeout, interval); err != nil {
-		return err
-	}
-
-	pods, err := appops.Instance().GetDeploymentPods(metricsCollectorDep)
-	if err != nil {
-		return err
-	}
-
-	// Validate image inside px-metric-collector[init-cont]
-	if image, ok := pxImageList["telemetryProxy"]; ok {
-		if err := validateContainerImageInsidePods(cluster, image, "init-cont", &v1.PodList{Items: pods}); err != nil {
-			return err
-		}
-	} else {
-		return fmt.Errorf("failed to find image for px-telemetry-metrics-collector[init-cont]")
-	}
-
-	// Validate image inside px-metrics-collector[collector]
-	if image, ok := pxImageList["metricsCollector"]; ok {
-		if err := validateContainerImageInsidePods(cluster, image, "collector", &v1.PodList{Items: pods}); err != nil {
-			return err
-		}
-	} else {
-		return fmt.Errorf("failed to find image for px-telemetry-metrics-collector[collector]")
-	}
-
-	// Validate image inside px-metric-collector[envoy]
-	if image, ok := pxImageList["telemetryProxy"]; ok {
-		if err := validateContainerImageInsidePods(cluster, image, "envoy", &v1.PodList{Items: pods}); err != nil {
-			return err
-		}
-	} else {
-		return fmt.Errorf("failed to find image for px-telemetry-metrics-collector[envoy]")
-	}
-
-	return nil
-}
+// func validatePxTelemetryMetricsCollectorV2(pxImageList map[string]string, cluster *corev1.StorageCluster, timeout, interval time.Duration) error {
+// 	// Validate px-telemetry-metrics-collector deployment, pods and container images
+// 	logrus.Info("Validate px-telemetry-metrics-collector deployment and images")
+// 	metricsCollectorDep := &appsv1.Deployment{
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:      "px-telemetry-metrics-collector",
+// 			Namespace: cluster.Namespace,
+// 		},
+// 	}
+// 	if err := appops.Instance().ValidateDeployment(metricsCollectorDep, timeout, interval); err != nil {
+// 		return err
+// 	}
+//
+// 	pods, err := appops.Instance().GetDeploymentPods(metricsCollectorDep)
+// 	if err != nil {
+// 		return err
+// 	}
+//
+// 	// Validate image inside px-metric-collector[init-cont]
+// 	if image, ok := pxImageList["telemetryProxy"]; ok {
+// 		if err := validateContainerImageInsidePods(cluster, image, "init-cont", &v1.PodList{Items: pods}); err != nil {
+// 			return err
+// 		}
+// 	} else {
+// 		return fmt.Errorf("failed to find image for px-telemetry-metrics-collector[init-cont]")
+// 	}
+//
+// 	// Validate image inside px-metrics-collector[collector]
+// 	if image, ok := pxImageList["metricsCollector"]; ok {
+// 		if err := validateContainerImageInsidePods(cluster, image, "collector", &v1.PodList{Items: pods}); err != nil {
+// 			return err
+// 		}
+// 	} else {
+// 		return fmt.Errorf("failed to find image for px-telemetry-metrics-collector[collector]")
+// 	}
+//
+// 	// Validate image inside px-metric-collector[envoy]
+// 	if image, ok := pxImageList["telemetryProxy"]; ok {
+// 		if err := validateContainerImageInsidePods(cluster, image, "envoy", &v1.PodList{Items: pods}); err != nil {
+// 			return err
+// 		}
+// 	} else {
+// 		return fmt.Errorf("failed to find image for px-telemetry-metrics-collector[envoy]")
+// 	}
+//
+// 	return nil
+// }
 
 func validatePxTelemetryRegistrationV2(pxImageList map[string]string, cluster *corev1.StorageCluster, timeout, interval time.Duration) error {
 	// Validate px-telemetry-registration deployment, pods and container images
@@ -3457,10 +3458,10 @@ func ValidateTelemetryV1Enabled(pxImageList map[string]string, cluster *corev1.S
 		expectedDeployment := GetExpectedDeployment(&testing.T{}, "metricsCollectorDeployment.yaml")
 		*/
 
-		deployment, err := appops.Instance().GetDeployment(dep.Name, dep.Namespace)
-		if err != nil {
-			return nil, true, err
-		}
+		// deployment, err := appops.Instance().GetDeployment(dep.Name, dep.Namespace)
+		// if err != nil {
+		// 	return nil, true, err
+		// }
 
 		/* TODO: We need to make this work for spawn
 		if equal, err := util.DeploymentDeepEqual(expectedDeployment, deployment); !equal {
@@ -3468,65 +3469,65 @@ func ValidateTelemetryV1Enabled(pxImageList map[string]string, cluster *corev1.S
 		}
 		*/
 
-		_, err = rbacops.Instance().GetRole("px-metrics-collector", cluster.Namespace)
-		if err != nil {
-			return nil, true, err
-		}
+		// _, err = rbacops.Instance().GetRole("px-metrics-collector", cluster.Namespace)
+		// if err != nil {
+		// 	return nil, true, err
+		// }
 
-		_, err = rbacops.Instance().GetRoleBinding("px-metrics-collector", cluster.Namespace)
-		if err != nil {
-			return nil, true, err
-		}
+		// _, err = rbacops.Instance().GetRoleBinding("px-metrics-collector", cluster.Namespace)
+		// if err != nil {
+		// 	return nil, true, err
+		// }
 
 		// Verify telemetry config map
-		_, err = coreops.Instance().GetConfigMap("px-telemetry-config", cluster.Namespace)
+		_, err := coreops.Instance().GetConfigMap("px-telemetry-config", cluster.Namespace)
 		if err != nil {
 			return nil, true, err
 		}
 
 		// Verify collector config map
-		_, err = coreops.Instance().GetConfigMap("px-collector-config", cluster.Namespace)
-		if err != nil {
-			return nil, true, err
-		}
+		// _, err = coreops.Instance().GetConfigMap("px-collector-config", cluster.Namespace)
+		// if err != nil {
+		// 	return nil, true, err
+		// }
 
 		// Verify collector proxy config map
-		_, err = coreops.Instance().GetConfigMap("px-collector-proxy-config", cluster.Namespace)
-		if err != nil {
-			return nil, true, err
-		}
+		// _, err = coreops.Instance().GetConfigMap("px-collector-proxy-config", cluster.Namespace)
+		// if err != nil {
+		// 	return nil, true, err
+		// }
 
 		// Verify collector service account
-		_, err = coreops.Instance().GetServiceAccount("px-metrics-collector", cluster.Namespace)
-		if err != nil {
-			return nil, true, err
-		}
+		// _, err = coreops.Instance().GetServiceAccount("px-metrics-collector", cluster.Namespace)
+		// if err != nil {
+		// 	return nil, true, err
+		// }
 
 		// Verify metrics collector image
-		imageName, ok := pxImageList["metricsCollector"]
-		if !ok {
-			return nil, true, fmt.Errorf("failed to find image for metrics collector")
-		}
-		imageName = util.GetImageURN(cluster, imageName)
+		// imageName, ok := pxImageList["metricsCollector"]
+		// if !ok {
+		// 	return nil, true, fmt.Errorf("failed to find image for metrics collector")
+		// }
+		// imageName = util.GetImageURN(cluster, imageName)
 
-		if deployment.Spec.Template.Spec.Containers[0].Image != imageName {
-			return nil, true, fmt.Errorf("collector image mismatch, image: %s, expected: %s",
-				deployment.Spec.Template.Spec.Containers[0].Image,
-				imageName)
-		}
+		// if deployment.Spec.Template.Spec.Containers[0].Image != imageName {
+		// 	return nil, true, fmt.Errorf("collector image mismatch, image: %s, expected: %s",
+		// 		deployment.Spec.Template.Spec.Containers[0].Image,
+		// 		imageName)
+		// }
 
-		// Verify metrics collector proxy image
-		imageName, ok = pxImageList["metricsCollectorProxy"]
-		if !ok {
-			return nil, true, fmt.Errorf("failed to find image for metrics collector proxy")
-		}
-		imageName = util.GetImageURN(cluster, imageName)
+		// // Verify metrics collector proxy image
+		// imageName, ok = pxImageList["metricsCollectorProxy"]
+		// if !ok {
+		// 	return nil, true, fmt.Errorf("failed to find image for metrics collector proxy")
+		// }
+		// imageName = util.GetImageURN(cluster, imageName)
 
-		if deployment.Spec.Template.Spec.Containers[1].Image != imageName {
-			return nil, true, fmt.Errorf("collector proxy image mismatch, image: %s, expected: %s",
-				deployment.Spec.Template.Spec.Containers[1].Image,
-				imageName)
-		}
+		// if deployment.Spec.Template.Spec.Containers[1].Image != imageName {
+		// 	return nil, true, fmt.Errorf("collector proxy image mismatch, image: %s, expected: %s",
+		// 		deployment.Spec.Template.Spec.Containers[1].Image,
+		// 		imageName)
+		// }
 
 		return nil, false, nil
 	}


### PR DESCRIPTION

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
[PWX-27353] Update PVC controller deployment and cluster role on k8s 1.24+
[PWX-27401] Disable metrics collector if it's not already running
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:



[PWX-27353]: https://portworx.atlassian.net/browse/PWX-27353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PWX-27401]: https://portworx.atlassian.net/browse/PWX-27401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ