### PR TITLE
PWX-27538 add registry.k8s.io as common registry

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -59,6 +59,7 @@ var (
 		"index.docker.io":             true,
 		"registry-1.docker.io":        true,
 		"registry.connect.redhat.com": true,
+		"registry.k8s.io":             true,
 	}
 
 	// podTopologySpreadConstraintKeys is a list of topology keys considered for pod spread constraints

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -108,6 +108,9 @@ func TestImageURN(t *testing.T) {
 
 	out = getImageURN("gcr.io,k8s.gcr.io", "registry.io", "testrepo/pause:3.1")
 	require.Equal(t, "registry.io/testrepo/pause:3.1", out)
+
+	out = getImageURN("", "customRegistry.io", "registry.k8s.io/pause:3.1")
+	require.Equal(t, "customRegistry.io/pause:3.1", out)
 }
 
 func TestImageURNPreserved(t *testing.T) {


### PR DESCRIPTION
k8s will move from k8s.gcr.io to registry.k8s.io, add this new registry as common registry, so if an image has the prefix it's handled correctly when replacing with custom registry. this is just a proactive change. at this moment we may not have any image in the new registry yet. 