### PR TITLE
PWX-27563: Setting stork as the default scheduler for px-csi-ext pods

### DIFF
--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -43,6 +43,8 @@ const (
 	CSIServiceName = "px-csi-service"
 	// CSIApplicationName name of the CSI application (deployment/statefulset)
 	CSIApplicationName = "px-csi-ext"
+	// CSIApplicationSchedulerName name of the CSI application pod scheduler
+	CSIApplicationSchedulerName = "stork"
 
 	csiProvisionerContainerName             = "csi-external-provisioner"
 	csiAttacherContainerName                = "csi-attacher"
@@ -650,6 +652,7 @@ func getCSIDeploymentSpec(
 							},
 						},
 					},
+					SchedulerName: CSIApplicationSchedulerName,
 					Volumes: []v1.Volume{
 						{
 							Name: "socket-dir",

--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -652,7 +652,6 @@ func getCSIDeploymentSpec(
 							},
 						},
 					},
-					SchedulerName: CSIApplicationSchedulerName,
 					Volumes: []v1.Volume{
 						{
 							Name: "socket-dir",
@@ -667,6 +666,10 @@ func getCSIDeploymentSpec(
 				},
 			},
 		},
+	}
+
+	if pxutil.IsStorkEnabled(cluster) {
+		deployment.Spec.Template.Spec.SchedulerName = CSIApplicationSchedulerName
 	}
 
 	if csiConfig.IncludeAttacher && attacherImage != "" {

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
@@ -41,6 +41,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
@@ -54,6 +54,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithPKS.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithPKS.yaml
@@ -68,6 +68,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
@@ -56,6 +56,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
@@ -67,6 +67,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1_17.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1_17.yaml
@@ -67,6 +67,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
@@ -69,6 +69,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
@@ -76,6 +76,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120.yaml
@@ -82,6 +82,7 @@ spec:
           args:
             - --v=3
             - --leader-election=true
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
@@ -83,6 +83,7 @@ spec:
           args:
             - --v=3
             - --leader-election=true
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
@@ -76,6 +76,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
@@ -100,6 +100,7 @@ spec:
             - name: http-endpoint
               containerPort: 8080
               protocol: TCP
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -400,6 +400,12 @@ func ImagePullPolicy(cluster *corev1.StorageCluster) v1.PullPolicy {
 	return imagePullPolicy
 }
 
+// IsStorkEnabled returns true is Stork scheduler is enabled in StorageCluster
+func IsStorkEnabled(cluster *corev1.StorageCluster) bool {
+	return cluster.Spec.Stork != nil &&
+		cluster.Spec.Stork.Enabled == true
+}
+
 // StartPort returns the start from the cluster if present,
 // else return the default start port
 func StartPort(cluster *corev1.StorageCluster) int {

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -403,7 +403,7 @@ func ImagePullPolicy(cluster *corev1.StorageCluster) v1.PullPolicy {
 // IsStorkEnabled returns true is Stork scheduler is enabled in StorageCluster
 func IsStorkEnabled(cluster *corev1.StorageCluster) bool {
 	return cluster.Spec.Stork != nil &&
-		cluster.Spec.Stork.Enabled == true
+		cluster.Spec.Stork.Enabled
 }
 
 // StartPort returns the start from the cluster if present,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -49,6 +49,9 @@ const (
 
 	// DefaultImageRegistry is the default registry when no registry is provided
 	DefaultImageRegistry = "docker.io"
+
+	// StorkSchedulerName is the default scheduler for px-csi-ext pods
+	StorkSchedulerName = "stork"
 )
 
 var (
@@ -282,6 +285,22 @@ func HasNodeAffinityChanged(
 		return cluster.Spec.Placement.NodeAffinity != nil
 	}
 	return !reflect.DeepEqual(cluster.Spec.Placement.NodeAffinity, existingAffinity.NodeAffinity)
+}
+
+// HasSchedulerStateChanged checks if the stork has been enabled/disabled in the StorageCluster
+func HasSchedulerStateChanged(
+	cluster *corev1.StorageCluster,
+	previouSchedulerName string,
+) bool {
+	if cluster.Spec.Stork == nil {
+		return false
+	}
+	currentSchedulerName := v1.DefaultSchedulerName
+	if cluster.Spec.Stork.Enabled {
+		currentSchedulerName = StorkSchedulerName
+	}
+	return currentSchedulerName != previouSchedulerName
+
 }
 
 // ExtractVolumesAndMounts returns a list of Kubernetes volumes and volume mounts from the

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -290,7 +290,7 @@ func HasNodeAffinityChanged(
 // HasSchedulerStateChanged checks if the stork has been enabled/disabled in the StorageCluster
 func HasSchedulerStateChanged(
 	cluster *corev1.StorageCluster,
-	previouSchedulerName string,
+	previousSchedulerName string,
 ) bool {
 	if cluster.Spec.Stork == nil {
 		return false
@@ -299,7 +299,7 @@ func HasSchedulerStateChanged(
 	if cluster.Spec.Stork.Enabled {
 		currentSchedulerName = StorkSchedulerName
 	}
-	return currentSchedulerName != previouSchedulerName
+	return currentSchedulerName != previousSchedulerName
 
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -293,7 +293,7 @@ func HasSchedulerStateChanged(
 	previousSchedulerName string,
 ) bool {
 	if cluster.Spec.Stork == nil {
-		return true
+		return v1.DefaultSchedulerName != previousSchedulerName
 	}
 	currentSchedulerName := v1.DefaultSchedulerName
 	if cluster.Spec.Stork.Enabled {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -293,14 +293,13 @@ func HasSchedulerStateChanged(
 	previousSchedulerName string,
 ) bool {
 	if cluster.Spec.Stork == nil {
-		return false
+		return true
 	}
 	currentSchedulerName := v1.DefaultSchedulerName
 	if cluster.Spec.Stork.Enabled {
 		currentSchedulerName = StorkSchedulerName
 	}
 	return currentSchedulerName != previousSchedulerName
-
 }
 
 // ExtractVolumesAndMounts returns a list of Kubernetes volumes and volume mounts from the

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -381,7 +381,7 @@ func TestHasSchedulerStateChanged(t *testing.T) {
 	require.False(t, HasSchedulerStateChanged(cluster, "stork"))
 
 	cluster.Spec.Stork = nil
-	require.True(t, HasSchedulerStateChanged(cluster, "default-scheduler"))
+	require.False(t, HasSchedulerStateChanged(cluster, "default-scheduler"))
 	require.True(t, HasSchedulerStateChanged(cluster, "stork"))
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -362,6 +362,29 @@ func TestHaveTopologySpreadConstraintsChanged(t *testing.T) {
 	require.False(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
 }
 
+func TestHasSchedulerStateChanged(t *testing.T) {
+	cluster := &corev1.StorageCluster{
+		Spec: corev1.StorageClusterSpec{
+			Stork: &corev1.StorkSpec{
+				Enabled: true,
+			},
+		},
+	}
+	require.False(t, HasSchedulerStateChanged(cluster, "stork"))
+
+	cluster.Spec.Stork.Enabled = false
+	require.True(t, HasSchedulerStateChanged(cluster, "stork"))
+	require.False(t, HasSchedulerStateChanged(cluster, "default-scheduler"))
+
+	cluster.Spec.Stork.Enabled = true
+	require.True(t, HasSchedulerStateChanged(cluster, "default-scheduler"))
+	require.False(t, HasSchedulerStateChanged(cluster, "stork"))
+
+	cluster.Spec.Stork = nil
+	require.True(t, HasSchedulerStateChanged(cluster, "default-scheduler"))
+	require.True(t, HasSchedulerStateChanged(cluster, "stork"))
+}
+
 func TestGetTopologySpreadConstraints(t *testing.T) {
 	fakeNode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

**What this PR does / why we need it**:
When CSI is enabled  PVC provisioning goes through px-csi-ext-* pods which is a deployment of 3 replicas. If these 3 PX nodes go offline none of the PVC creations would succeed even if the PX cluster is operational. In such cases we need to move the px-csi-ext pods to other nodes in the cluster.
This change will make Stork as the default scheduler for px-csi-ext-* pods. Change will be made in Stork to detect px-csi-ext pods are running on an offline PX node such that it can delete the csi-ext pod and schedule them on the online nodes.

**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PWX-27563

**Special notes for your reviewer**:
* Refer to https://portworx.atlassian.net/browse/PWX-27549 for details
* Tested  on dev setup that stork is the default scheduler for px-csi-ext-*  deployment.
* Ran the following job with these changes in this PR for regressions https://jenkins.pwx.dev.purestorage.com/job/test-op-csi-e2e/1/
