### PR TITLE
PWX-27563: Setting stork as the default scheduler for px-csi-ext pods…

### DIFF
--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -509,11 +509,11 @@ func (c *csi) createDeployment(
 		healthMonitorControllerImage != existingHealthMonitorControllerContainerName ||
 		util.HasPullSecretChanged(cluster, existingDeployment.Spec.Template.Spec.ImagePullSecrets) ||
 		util.HasNodeAffinityChanged(cluster, existingDeployment.Spec.Template.Spec.Affinity) ||
+		util.HasSchedulerStateChanged(cluster, existingDeployment.Spec.Template.Spec.SchedulerName) ||
 		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations) ||
 		util.HaveTopologySpreadConstraintsChanged(updatedTopologySpreadConstraints,
 			existingDeployment.Spec.Template.Spec.TopologySpreadConstraints) ||
 		hasCSITopologyChanged(cluster, existingDeployment)
-
 	if !c.isCreated || modified {
 		deployment := getCSIDeploymentSpec(cluster, csiConfig, ownerRef, provisionerImage, attacherImage,
 			snapshotterImage, resizerImage, snapshotControllerImage, healthMonitorControllerImage, updatedTopologySpreadConstraints)
@@ -664,6 +664,10 @@ func getCSIDeploymentSpec(
 				},
 			},
 		},
+	}
+
+	if pxutil.IsStorkEnabled(cluster) {
+		deployment.Spec.Template.Spec.SchedulerName = util.StorkSchedulerName
 	}
 
 	if csiConfig.IncludeAttacher && attacherImage != "" {

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
@@ -41,6 +41,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
@@ -54,6 +54,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithPKS.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithPKS.yaml
@@ -68,6 +68,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
@@ -56,6 +56,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
@@ -67,6 +67,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1_17.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1_17.yaml
@@ -67,6 +67,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
@@ -69,6 +69,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
@@ -76,6 +76,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120.yaml
@@ -82,6 +82,7 @@ spec:
           args:
             - --v=3
             - --leader-election=true
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
@@ -83,6 +83,7 @@ spec:
           args:
             - --v=3
             - --leader-election=true
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
@@ -76,6 +76,7 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
@@ -100,6 +100,7 @@ spec:
             - name: http-endpoint
               containerPort: 8080
               protocol: TCP
+      schedulerName: stork
       volumes:
         - name: socket-dir
           hostPath:

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -376,6 +376,12 @@ func ImagePullPolicy(cluster *corev1.StorageCluster) v1.PullPolicy {
 	return imagePullPolicy
 }
 
+// IsStorkEnabled returns true is Stork scheduler is enabled in StorageCluster
+func IsStorkEnabled(cluster *corev1.StorageCluster) bool {
+	return cluster.Spec.Stork != nil &&
+		cluster.Spec.Stork.Enabled
+}
+
 // StartPort returns the start from the cluster if present,
 // else return the default start port
 func StartPort(cluster *corev1.StorageCluster) int {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -49,6 +49,9 @@ const (
 
 	// DefaultImageRegistry is the default registry when no registry is provided
 	DefaultImageRegistry = "docker.io"
+
+	// StorkSchedulerName is the default scheduler for px-csi-ext pods
+	StorkSchedulerName = "stork"
 )
 
 var (
@@ -282,6 +285,21 @@ func HasNodeAffinityChanged(
 		return cluster.Spec.Placement.NodeAffinity != nil
 	}
 	return !reflect.DeepEqual(cluster.Spec.Placement.NodeAffinity, existingAffinity.NodeAffinity)
+}
+
+// HasSchedulerStateChanged checks if the stork has been enabled/disabled in the StorageCluster
+func HasSchedulerStateChanged(
+	cluster *corev1.StorageCluster,
+	previousSchedulerName string,
+) bool {
+	if cluster.Spec.Stork == nil {
+		return v1.DefaultSchedulerName != previousSchedulerName
+	}
+	currentSchedulerName := v1.DefaultSchedulerName
+	if cluster.Spec.Stork.Enabled {
+		currentSchedulerName = StorkSchedulerName
+	}
+	return currentSchedulerName != previousSchedulerName
 }
 
 // ExtractVolumesAndMounts returns a list of Kubernetes volumes and volume mounts from the

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -316,6 +316,29 @@ func TestHaveTopologySpreadConstraintsChanged(t *testing.T) {
 	require.False(t, HaveTopologySpreadConstraintsChanged(updatedConstraints, existingConstraints))
 }
 
+func TestHasSchedulerStateChanged(t *testing.T) {
+	cluster := &corev1.StorageCluster{
+		Spec: corev1.StorageClusterSpec{
+			Stork: &corev1.StorkSpec{
+				Enabled: true,
+			},
+		},
+	}
+	require.False(t, HasSchedulerStateChanged(cluster, "stork"))
+
+	cluster.Spec.Stork.Enabled = false
+	require.True(t, HasSchedulerStateChanged(cluster, "stork"))
+	require.False(t, HasSchedulerStateChanged(cluster, "default-scheduler"))
+
+	cluster.Spec.Stork.Enabled = true
+	require.True(t, HasSchedulerStateChanged(cluster, "default-scheduler"))
+	require.False(t, HasSchedulerStateChanged(cluster, "stork"))
+
+	cluster.Spec.Stork = nil
+	require.False(t, HasSchedulerStateChanged(cluster, "default-scheduler"))
+	require.True(t, HasSchedulerStateChanged(cluster, "stork"))
+}
+
 func TestGetTopologySpreadConstraints(t *testing.T) {
 	fakeNode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
… (#807)

* PWX-27563: Setting stork as the default scheduler for px-csi-ext pods

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

* PWX-27563: Using stork as the shecduler for csi only when it is enabled in StorageCluster

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

* PWX-27563: Fixing static check error.

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

* PWX-27563: Handling csi-ext-pod scheduler when stork is enabled or disabled at run time

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

* PWX-27563: Fixing typo in function param

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

* PWX-27563: Handling empty stork spec correctly and adding UTs

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

* PWX-27563: Do not change csi deployment if stork spec is missing and scheduler is set to default-scheduler

Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>


**What this PR does / why we need it**:
When CSI is enabled PVC provisioning goes through px-csi-ext-* pods which is a deployment of 3 replicas. If these 3 PX nodes go offline none of the PVC creations would succeed even if the PX cluster is operational. In such cases we need to move the px-csi-ext pods to other nodes in the cluster.
This change will make Stork as the default scheduler for px-csi-ext-* pods. Change will be made in Stork to detect px-csi-ext pods are running on an offline PX node such that it can delete the csi-ext pod and schedule them on the online nodes.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-27563

