### PR TITLE
PWX-27591: Default value for maxStorageNodesPerZone (#810)

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -1044,6 +1044,37 @@ func TestStorageUpgradeClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
 	testStoragelessNodesUpgrade(t, 6, 1, 0, 0, 0)
 }
 
+func getK8sClientWithNodesDisaggregated(
+	t *testing.T,
+	nodeCount uint32,
+	totalZones uint32,
+	cluster *corev1.StorageCluster,
+	storagelessCount ...uint32,
+) client.Client {
+	if len(storagelessCount) != 0 {
+		require.Equal(t, uint32(len(storagelessCount)), totalZones)
+	} else {
+		storagelessCount = make([]uint32, totalZones)
+	}
+	k8sClient := testutil.FakeK8sClient(cluster)
+	zoneCount := uint32(0)
+	for node := uint32(0); node < nodeCount; node++ {
+		nodename := "k8s-node-" + strconv.Itoa(int(node))
+		k8sNode := createK8sNode(nodename, 10)
+		zoneCount = zoneCount % totalZones
+		k8sNode.Labels[v1.LabelTopologyZone] = "Zone-" + strconv.Itoa(int(zoneCount))
+		if storagelessCount[zoneCount] > 0 {
+			storagelessCount[zoneCount]--
+			k8sNode.Labels[util.NodeTypeKey] = util.StoragelessNodeValue
+		} else {
+			k8sNode.Labels[util.NodeTypeKey] = util.StorageNodeValue
+		}
+		err := k8sClient.Create(context.TODO(), k8sNode)
+		require.NoError(t, err)
+		zoneCount++
+	}
+	return k8sClient
+}
 func testStoragelessNodesUpgrade(t *testing.T, expectedValue uint32, storageless ...uint32) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -1089,7 +1120,71 @@ func testStoragelessNodesUpgrade(t *testing.T, expectedValue uint32, storageless
 
 }
 
-func TestStorageClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
+func testStoragelessNodesDisaggregatedMode(t *testing.T, expectedValue uint32, storageless ...uint32) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "kube-test",
+		},
+	}
+	driver := testutil.MockDriver(mockCtrl)
+
+	totalNodes := uint32(24)
+	zones := uint32(len(storageless))
+	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+	cluster.Spec.CloudStorage.MaxStorageNodesPerZone = nil
+	k8sClient := getK8sClientWithNodesDisaggregated(t, totalNodes, zones, cluster, storageless...)
+	recorder := record.NewFakeRecorder(10)
+
+	controller := Controller{
+		client:   k8sClient,
+		Driver:   driver,
+		recorder: recorder,
+	}
+	driver.EXPECT().UpdateDriver(gomock.Any()).MinTimes(1)
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).MinTimes(1)
+
+	err := controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotNil(t, cluster.Spec.CloudStorage)
+	if expectedValue == 0 {
+		require.Nil(t, cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+	} else {
+		require.Equal(t, expectedValue, *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+	}
+
+}
+
+func TestStorageClusterDefaultsMaxStorageNodesPerZoneDisaggregatedMode(t *testing.T) {
+	// 24 node cluster will be created in each step
+	testStoragelessNodesDisaggregatedMode(t, 24, 0)
+	testStoragelessNodesDisaggregatedMode(t, 12, 0, 0)
+	testStoragelessNodesDisaggregatedMode(t, 8, 0, 0, 0)
+	testStoragelessNodesDisaggregatedMode(t, 6, 0, 0, 0, 0)
+
+	testStoragelessNodesDisaggregatedMode(t, 14, 10)
+	testStoragelessNodesDisaggregatedMode(t, 23, 1)
+	testStoragelessNodesDisaggregatedMode(t, 7, 5, 5)
+	testStoragelessNodesDisaggregatedMode(t, 2, 5, 10)
+	testStoragelessNodesDisaggregatedMode(t, 7, 5, 0)
+	testStoragelessNodesDisaggregatedMode(t, 1, 5, 7, 5)
+	testStoragelessNodesDisaggregatedMode(t, 3, 5, 5, 5)
+	testStoragelessNodesDisaggregatedMode(t, 0, 5, 8, 8)
+	testStoragelessNodesDisaggregatedMode(t, 0, 7, 8, 8)
+	testStoragelessNodesDisaggregatedMode(t, 0, 7, 0, 8)
+	testStoragelessNodesDisaggregatedMode(t, 7, 1, 0, 0)
+	testStoragelessNodesDisaggregatedMode(t, 0, 8, 8, 8)
+	testStoragelessNodesDisaggregatedMode(t, 0, 6, 6, 6, 6)
+	testStoragelessNodesDisaggregatedMode(t, 0, 6, 5, 6, 6)
+	testStoragelessNodesDisaggregatedMode(t, 5, 1, 1, 1, 1)
+	testStoragelessNodesDisaggregatedMode(t, 5, 1, 1, 1, 0)
+	testStoragelessNodesDisaggregatedMode(t, 5, 1, 0, 0, 0)
+}
+
+func testClusterDefaultsMaxStorageNodesPerZoneCase1(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
@@ -1115,52 +1210,88 @@ func TestStorageClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
 	require.Equal(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
 	require.Equal(t, "", cluster.Status.Phase)
 
-	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+}
 
-	err = controller.setStorageClusterDefaults(cluster)
-	require.NoError(t, err)
-	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
-	require.Equal(t, uint32(3), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+func testClusterDefaultsMaxStorageNodesPerZoneValueSpecified(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
 
-	err = controller.setStorageClusterDefaults(cluster)
-	require.NoError(t, err)
-	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
-	require.Equal(t, uint32(3), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "kube-test",
+		},
+	}
+	driver := testutil.MockDriver(mockCtrl)
 
-	/* 2 zones */
-	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
-	controller.client, _ = getK8sClientWithNodesZones(t, 8, 2, cluster)
-	err = controller.setStorageClusterDefaults(cluster)
-	require.NoError(t, err)
-	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
-	require.Equal(t, uint32(2), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
-
-	/* 3 zones */
-	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
-	controller.client, _ = getK8sClientWithNodesZones(t, 9, 3, cluster)
-	err = controller.setStorageClusterDefaults(cluster)
-	require.NoError(t, err)
-	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
-	require.Equal(t, uint32(1), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
-
-	/* 4 zones */
-	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
-	controller.client, _ = getK8sClientWithNodesZones(t, 8, 4, cluster)
-	err = controller.setStorageClusterDefaults(cluster)
-	require.NoError(t, err)
-	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
-	require.Equal(t, uint32(1), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+	driver.EXPECT().UpdateDriver(gomock.Any()).MinTimes(1)
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).MinTimes(1)
 
 	/* Value specified */
 	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{
 		MaxStorageNodesPerZone: new(uint32),
 	}
 	*cluster.Spec.CloudStorage.MaxStorageNodesPerZone = 7
-	controller.client, _ = getK8sClientWithNodesZones(t, 30, 3, cluster)
-	err = controller.setStorageClusterDefaults(cluster)
+	k8sClient, _ := getK8sClientWithNodesZones(t, 30, 3, cluster)
+	controller := Controller{
+		client: k8sClient,
+		Driver: driver,
+	}
+	err := controller.setStorageClusterDefaults(cluster)
 	require.NoError(t, err)
 	require.NotEqual(t, (*corev1.CloudStorageSpec)(nil), cluster.Spec.CloudStorage)
 	require.Equal(t, uint32(7), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+}
+
+func testClusterDefaultsMaxStorageNodesPerZone(t *testing.T, expectedValue uint32, totalNodes uint32, zones uint32) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "kube-test",
+		},
+	}
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient, _ := getK8sClientWithNodesZones(t, totalNodes, zones, cluster)
+
+	controller := Controller{
+		client: k8sClient,
+		Driver: driver,
+	}
+	driver.EXPECT().UpdateDriver(gomock.Any()).MinTimes(1)
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).MinTimes(1)
+
+	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+
+	err := controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.NotNil(t, cluster.Spec.CloudStorage)
+	require.NotNil(t, cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+	require.Equal(t, expectedValue, *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+}
+
+func TestStorageClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {
+	testClusterDefaultsMaxStorageNodesPerZoneCase1(t)
+	// 1 zone
+	testClusterDefaultsMaxStorageNodesPerZone(t, 6, 6, 1)
+	// 2 zones
+	testClusterDefaultsMaxStorageNodesPerZone(t, 4, 8, 2)
+	testClusterDefaultsMaxStorageNodesPerZone(t, 4, 9, 2)
+	// 3 zones
+	testClusterDefaultsMaxStorageNodesPerZone(t, 3, 9, 3)
+	testClusterDefaultsMaxStorageNodesPerZone(t, 3, 10, 3)
+	testClusterDefaultsMaxStorageNodesPerZone(t, 3, 11, 3)
+	testClusterDefaultsMaxStorageNodesPerZone(t, 33, 100, 3)
+	// 4 zones
+	testClusterDefaultsMaxStorageNodesPerZone(t, 2, 8, 4)
+	testClusterDefaultsMaxStorageNodesPerZone(t, 25, 100, 4)
+	testClusterDefaultsMaxStorageNodesPerZone(t, 25, 101, 4)
+	testClusterDefaultsMaxStorageNodesPerZone(t, 25, 102, 4)
+	testClusterDefaultsMaxStorageNodesPerZone(t, 25, 103, 4)
+	testClusterDefaultsMaxStorageNodesPerZone(t, 26, 104, 4)
+	testClusterDefaultsMaxStorageNodesPerZoneValueSpecified(t)
 }
 
 func TestStorageClusterDefaultsWithDriverOverrides(t *testing.T) {

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -21,9 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	storageapi "github.com/libopenstorage/openstorage/api"
-	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
-	"github.com/libopenstorage/operator/pkg/cloudprovider"
+	"math"
 	"reflect"
 	"sort"
 	"strconv"
@@ -32,6 +30,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	storageapi "github.com/libopenstorage/openstorage/api"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	"github.com/libopenstorage/operator/pkg/cloudprovider"
 	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 	operatorops "github.com/portworx/sched-ops/k8s/operator"
 	"github.com/sirupsen/logrus"
@@ -1173,22 +1174,93 @@ func (c *Controller) getCurrentMaxStorageNodesPerZone(
 	return 0, fmt.Errorf("storage disabled")
 }
 
+func getDefaultStorageNodesDisaggregatedMode(
+	nodeList *v1.NodeList,
+	cluster *corev1.StorageCluster,
+	recorder record.EventRecorder,
+) (uint64, bool, error) {
+	// Check if ENABLE_ASG_STORAGE_PARTITIONING is set to false. If not, we can look at the 'portworx.io/node-type' label
+	for _, envVar := range cluster.Spec.Env {
+		if envVar.Name == util.StoragePartitioningEnvKey {
+			if envVar.Value == "false" {
+				return 0, false, nil
+			}
+			break
+		}
+	}
+
+	// This will return a zone map of storage nodes in each zones
+	nodeTypeZoneMap, err := getZoneMap(nodeList, util.NodeTypeKey, util.StorageNodeValue)
+	if err != nil {
+		return 0, false, err
+	}
+	totalNodes := uint64(0)
+	// We'll find the zone with least number of labels
+	minValue := uint64(math.MaxUint64)
+	prevKey := ""
+	prevValue := uint64(math.MaxUint64)
+	for key, value := range nodeTypeZoneMap {
+		totalNodes += value
+		if value < minValue {
+			minValue = value
+		}
+		if prevValue != math.MaxUint64 && prevValue != value {
+			k8s.InfoEvent(
+				recorder, cluster, util.UnevenStorageNodesReason,
+				fmt.Sprintf("Uneven number of storage nodes labelled across zones."+
+					" %v has %v, %v has %v", prevKey, prevValue, key, value),
+			)
+		}
+		prevKey = key
+		prevValue = value
+	}
+	if totalNodes == 0 {
+		// no node is labelled with portworx.io/node-type
+		nodeTypeZoneMap, err = getZoneMap(nodeList, util.NodeTypeKey, util.StoragelessNodeValue)
+		if err == nil {
+			for _, value := range nodeTypeZoneMap {
+				totalNodes += value
+			}
+			if totalNodes > 0 {
+				k8s.InfoEvent(
+					recorder, cluster, util.AllStoragelessNodesReason,
+					fmt.Sprintf("%v nodes marked as storageless, none marked as storage nodes", totalNodes),
+				)
+				return 0, true, fmt.Errorf("storageless nodes found. None marked as storage node")
+			}
+		}
+		return 0, false, err
+	}
+	return minValue, true, nil
+}
+
 // getDefaultMaxStorageNodesPerZone aims to return a good value for MaxStorageNodesPerZone with the
 // intention of having at least 3 nodes in the cluster.
-func getDefaultMaxStorageNodesPerZone(zoneMap map[string]uint64) uint32 {
-	numZones := len(zoneMap)
-	switch numZones {
-	case 0, 1:
-		// If there is a single Zone, have all 3 nodes in the same zone
-		return 3
-	case 2:
-		// If there are two zones, it'll be tricky since we'll always lose quorum when a zone
-		// goes down. Let's have 2 nodes in a zone so that we have a 4 node cluster.
-		return 2
-	default:
-		// In a cluster with 3 or more zones, let's have one node in each zone.
-		return 1
+func getDefaultMaxStorageNodesPerZone(
+	nodeList *v1.NodeList,
+	cluster *corev1.StorageCluster,
+	recorder record.EventRecorder,
+) (uint32, error) {
+	if len(nodeList.Items) == 0 {
+		return 0, nil
 	}
+
+	// Check if storage nodes are explicitly set using labels
+	storageNodes, disaggregatedMode, err := getDefaultStorageNodesDisaggregatedMode(nodeList, cluster, recorder)
+	if err != nil {
+		return 0, err
+	}
+	if disaggregatedMode {
+		return uint32(storageNodes), nil
+	}
+
+	zoneMap, err := getZoneMap(nodeList, "", "")
+	if err != nil {
+		return 0, err
+	}
+	numZones := len(zoneMap)
+	storageNodes = uint64(len(nodeList.Items) / numZones)
+	return uint32(storageNodes), nil
 }
 
 func (c *Controller) isPxImageBeingUpdated(toUpdate *corev1.StorageCluster) bool {
@@ -1196,6 +1268,50 @@ func (c *Controller) isPxImageBeingUpdated(toUpdate *corev1.StorageCluster) bool
 	newVersion := pxutil.GetImageTag(strings.TrimSpace(toUpdate.Spec.Image))
 	return pxEnabled &&
 		(toUpdate.Spec.Version == "" || newVersion != toUpdate.Status.Version)
+}
+
+func getZoneMap(nodeList *v1.NodeList, filterLabelKey string, filterLabelValue string) (map[string]uint64, error) {
+	cloudProviderName := getCloudProviderName(nodeList)
+	cloudProvider := cloudprovider.New(cloudProviderName)
+	zoneMap := map[string]uint64{}
+	for _, node := range nodeList.Items {
+		if zone, err := cloudProvider.GetZone(&node); err == nil {
+			if len(filterLabelKey) > 0 {
+				value, ok := node.Labels[filterLabelKey]
+				// If provided filterLabelKey is not found or the value does not match with
+				// the provided filterLabelValue, no need to count in the zoneMap
+				if !ok || value != filterLabelValue {
+					if _, ok := zoneMap[zone]; !ok {
+						zoneMap[zone] = 0
+					}
+					continue
+				}
+				// provided filterLabel's value and key matched, let's count them in the zoneMap
+			}
+			instancesCount := zoneMap[zone]
+			zoneMap[zone] = instancesCount + 1
+		} else {
+			logrus.Errorf("count not find zone information: %v", err)
+			return nil, err
+		}
+	}
+	return zoneMap, nil
+}
+
+func getCloudProviderName(nodeList *v1.NodeList) string {
+	var cloudProviderName string
+	for _, node := range nodeList.Items {
+		// Get the cloud provider
+		// From kubernetes node spec:  <ProviderName>://<ProviderSpecificNodeID>
+		if len(node.Spec.ProviderID) != 0 {
+			tokens := strings.Split(node.Spec.ProviderID, "://")
+			if len(tokens) == 2 {
+				cloudProviderName = tokens[0]
+				break
+			} // else provider id is invalid
+		}
+	}
+	return cloudProviderName
 }
 
 func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) error {
@@ -1255,28 +1371,12 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		return fmt.Errorf("couldn't get list of nodes when syncing storage cluster %#v: %v",
 			toUpdate, err)
 	}
-	var cloudProviderName string
-	zoneMap := make(map[string]uint64)
 
-	for _, node := range nodeList.Items {
-		// Get the cloud provider
-		// From kubernetes node spec:  <ProviderName>://<ProviderSpecificNodeID>
-		if len(node.Spec.ProviderID) != 0 {
-			tokens := strings.Split(node.Spec.ProviderID, "://")
-			if len(tokens) == 2 {
-				cloudProviderName = tokens[0]
-				break
-			} // else provider id is invalid
-		}
-	}
-
+	cloudProviderName := getCloudProviderName(nodeList)
 	cloudProvider := cloudprovider.New(cloudProviderName)
-
-	for _, node := range nodeList.Items {
-		if zone, err := cloudProvider.GetZone(&node); err == nil {
-			instancesCount := zoneMap[zone]
-			zoneMap[zone] = instancesCount + 1
-		}
+	zoneMap, err := getZoneMap(nodeList, "", "")
+	if err != nil {
+		return err
 	}
 
 	if err := c.Driver.UpdateDriver(&storage.UpdateDriverInfo{
@@ -1295,7 +1395,10 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		err = nil
 		if toUpdate.Status.Phase == "" {
 			// Let's do this only when it's a fresh install of px
-			maxStorageNodesPerZone = getDefaultMaxStorageNodesPerZone(zoneMap)
+			maxStorageNodesPerZone, err = getDefaultMaxStorageNodesPerZone(nodeList, toUpdate, c.recorder)
+			if err != nil {
+				logrus.Errorf("could not set defult value for max_storage_nodes_per_zone (first install): %v", err)
+			}
 		} else {
 			// Upgrade scenario
 			if c.isPxImageBeingUpdated(toUpdate) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -41,6 +41,10 @@ const (
 	MigrationCompletedReason = "MigrationCompleted"
 	// MigrationFailed is added to an event when the migration fails.
 	MigrationFailedReason = "MigrationFailed"
+	// UnevenStorageNodesReason is added to an event when there are uneven number of storage nodes are labelled across zones
+	UnevenStorageNodesReason = "UnevenStorageNodes"
+	// AllStoragelessNodesReason is added to an event when all the nodes in the cluster is  labelled as storageless
+	AllStoragelessNodesReason = "AllStoragelessNodes"
 
 	// MigrationDryRunCompletedReason is added to an event when dry run is completed
 	MigrationDryRunCompletedReason = "MigrationDryRunCompleted"
@@ -52,6 +56,15 @@ const (
 
 	// StorkSchedulerName is the default scheduler for px-csi-ext pods
 	StorkSchedulerName = "stork"
+
+	// NodeTypeKey is the key of the label used to set node as storage or storageless
+	NodeTypeKey = "portworx.io/node-type"
+	// StorageNodeValue is the value for storage node
+	StorageNodeValue = "storage"
+	// StoragelessNodeValue is the value for storage node
+	StoragelessNodeValue = "storageless"
+	// StoragePartitioningEnvKey is the storage spec environment variable used to set storage/storageless node type
+	StoragePartitioningEnvKey = "ENABLE_ASG_STORAGE_PARTITIONING"
 )
 
 var (


### PR DESCRIPTION
* PWX-27591: Default value for maxStorageNodesPerZone

    The previous default of 3 storage nodes did not fit for all cluster
    sizes. This change will pick a default value during install based on
    1. If portworx.io/node-type=storage is specified, total number of
       storage nodes will be used to calculate maxStorageNodesPerZone
    2. If label is not specified, total nodes in the cluster will be the
       number of storage nodes

       maxStorageNodesPerZone = (total storage nodes)/ (number of zones)

Signed-off-by: Naveen Revanna <nrevanna@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

