### PR TITLE
PWX-27783: Add more zone labels

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -85,7 +85,6 @@ func (p *portworx) Init(
 func (p *portworx) Validate() error {
 	return nil
 }
-
 func (p *portworx) initializeComponents() {
 	for _, comp := range component.GetAll() {
 		comp.Initialize(p.k8sClient, *p.k8sVersion, p.scheme, p.recorder)

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -41,6 +41,47 @@ func TestDefaultGetZone(t *testing.T) {
 	require.Equal(t, "bar", zone, "Unexpected zone returned")
 }
 
+func TestDefaultGetZonePriority(t *testing.T) {
+	cp := New("default")
+	require.NotNil(t, cp, "Unexpected error on New")
+
+	zone, err := cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				failureDomainZoneKey:        "bar",
+				"topology.portworx.io/zone": "pxzone1",
+				"px/zone":                   "pxzone2",
+				v1.LabelZoneFailureDomain:   "pxzone3"},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "pxzone1", zone, "Unexpected zone returned")
+
+	zone, err = cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				failureDomainZoneKey:      "bar",
+				"px/zone":                 "pxzone2",
+				v1.LabelZoneFailureDomain: "pxzone3"},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "pxzone2", zone, "Unexpected zone returned")
+
+	zone, err = cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				failureDomainZoneKey:      "bar",
+				v1.LabelZoneFailureDomain: "pxzone3"},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "bar", zone, "Unexpected zone returned")
+}
+
 func TestAzureGetZoneNodeNil(t *testing.T) {
 	cp := New(azureName)
 	require.NotNil(t, cp, "Unexpected error on New")


### PR DESCRIPTION
   In vSphere, we allow customers to tag VMs with zone. Operator needs
   to recognize that and base it's decision of maxStorageNodesPerZone
   based on that. Currently, the change is in the default cloud
   provider. Clouds like GKE, EKS etc don't use that label. Hence we can
   have them also check and that will have no effect. This will solve
   the problem for vSphere. In a future release we can separate out the
   cloud providers.

Signed-off-by: Naveen Revanna <nrevanna@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

