### PR TITLE
PWX-27783: Add more zone labels (#822)

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -85,7 +85,6 @@ func (p *portworx) Init(
 func (p *portworx) Validate() error {
 	return nil
 }
-
 func (p *portworx) initializeComponents() {
 	for _, comp := range component.GetAll() {
 		comp.Initialize(p.k8sClient, *p.k8sVersion, p.scheme, p.recorder)

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/urfave/cli v1.22.2
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect
-	golang.org/x/tools v0.2.0 // indirect
+	golang.org/x/tools v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	google.golang.org/grpc v1.40.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -23,11 +23,11 @@ func (a *azure) GetZone(node *v1.Node) (string, error) {
 		return "", fmt.Errorf("node cannot be nil")
 	}
 	// if region is empty we want isAvailabilityZone to be false
-	region, ok := node.Labels[failureDomainRegionKey]
+	region, ok := node.Labels[v1.LabelTopologyRegion]
 	if !ok {
 		logrus.Warnf("Failed to get azure region info for node %v", node.Name)
 	}
-	zone, ok := node.Labels[failureDomainZoneKey]
+	zone, ok := node.Labels[v1.LabelTopologyZone]
 	if !ok {
 		logrus.Warnf("Failed to get azure zone info for node %v", node.Name)
 	}

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -8,9 +8,14 @@ import (
 )
 
 const (
-	failureDomainZoneKey   = v1.LabelTopologyZone
-	failureDomainRegionKey = v1.LabelTopologyRegion
+	pxTopologyLabel = "topology.portworx.io"
+	pxZoneLabel     = pxTopologyLabel + "/zone"
+	//Deprecated: having this only to support backward compatibility
+	pxZoneLabelDeprecated = "px/zone"
 )
+
+// zoneLabelsPriority is the priority of zone labels that px uses to determine the zone
+var zoneLabelsPriority = [4]string{pxZoneLabel, pxZoneLabelDeprecated, v1.LabelTopologyZone, v1.LabelZoneFailureDomain}
 
 var (
 	providerRegistry     map[string]Ops
@@ -50,7 +55,14 @@ func (d *defaultProvider) GetZone(node *v1.Node) (string, error) {
 	if node == nil {
 		return "", fmt.Errorf("node cannot be nil")
 	}
-	return node.Labels[failureDomainZoneKey], nil
+	zone := "default"
+	for _, label := range zoneLabelsPriority {
+		if name, ok := node.Labels[label]; ok {
+			zone = name
+			break
+		}
+	}
+	return zone, nil
 }
 
 func init() {

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -34,7 +34,48 @@ func TestDefaultGetZone(t *testing.T) {
 	zone, err := cp.GetZone(&v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
-			Labels: map[string]string{failureDomainZoneKey: "bar"},
+			Labels: map[string]string{v1.LabelTopologyZone: "bar"},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "bar", zone, "Unexpected zone returned")
+}
+
+func TestDefaultGetZonePriority(t *testing.T) {
+	cp := New("default")
+	require.NotNil(t, cp, "Unexpected error on New")
+
+	zone, err := cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				v1.LabelTopologyZone:        "bar",
+				"topology.portworx.io/zone": "pxzone1",
+				"px/zone":                   "pxzone2",
+				v1.LabelZoneFailureDomain:   "pxzone3"},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "pxzone1", zone, "Unexpected zone returned")
+
+	zone, err = cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				v1.LabelTopologyZone:      "bar",
+				"px/zone":                 "pxzone2",
+				v1.LabelZoneFailureDomain: "pxzone3"},
+		},
+	})
+	require.NoError(t, err, "Expected an error on nil Node object")
+	require.Equal(t, "pxzone2", zone, "Unexpected zone returned")
+
+	zone, err = cp.GetZone(&v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node1",
+			Labels: map[string]string{
+				v1.LabelTopologyZone:      "bar",
+				v1.LabelZoneFailureDomain: "pxzone3"},
 		},
 	})
 	require.NoError(t, err, "Expected an error on nil Node object")
@@ -58,8 +99,8 @@ func TestAzureGetZoneAvailabilityZone(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node1",
 			Labels: map[string]string{
-				failureDomainZoneKey:   "region-0",
-				failureDomainRegionKey: "region",
+				v1.LabelTopologyZone:   "region-0",
+				v1.LabelTopologyRegion: "region",
 			},
 		},
 	})
@@ -75,8 +116,8 @@ func TestAzureGetZoneAvailabilitySet(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node1",
 			Labels: map[string]string{
-				failureDomainZoneKey:   "0",
-				failureDomainRegionKey: "region",
+				v1.LabelTopologyZone:   "0",
+				v1.LabelTopologyRegion: "region",
 			},
 		},
 	})
@@ -92,7 +133,7 @@ func TestAzureGetZoneNoRegion(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "node1",
 			Labels: map[string]string{
-				failureDomainZoneKey: "region-0",
+				v1.LabelTopologyZone: "region-0",
 			},
 		},
 	})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -285,7 +285,7 @@ golang.org/x/text/unicode/norm
 golang.org/x/text/width
 # golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 golang.org/x/time/rate
-# golang.org/x/tools v0.2.0 => golang.org/x/tools v0.1.11
+# golang.org/x/tools v0.3.0 => golang.org/x/tools v0.1.11
 ## explicit
 golang.org/x/tools/go/ast/astutil
 golang.org/x/tools/imports


### PR DESCRIPTION
* PWX-27783: Add more zone labels

   In vSphere, we allow customers to tag VMs with zone. Operator needs
   to recognize that and base it's decision of maxStorageNodesPerZone
   based on that. Currently, the change is in the default cloud
   provider. Clouds like GKE, EKS etc don't use that label. Hence we can
   have them also check and that will have no effect. This will solve
   the problem for vSphere. In a future release we can separate out the
   cloud providers.

Signed-off-by: Naveen Revanna <nrevanna@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

