### PR TITLE
PWX-27901: Count accurate number of total nodes

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -1145,6 +1145,8 @@ func testStoragelessNodesDisaggregatedMode(t *testing.T, expectedValue uint32, s
 		recorder: recorder,
 	}
 	driver.EXPECT().UpdateDriver(gomock.Any()).MinTimes(1)
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return("mockDriverName").AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).MinTimes(1)
 
 	err := controller.setStorageClusterDefaults(cluster)
@@ -1261,6 +1263,8 @@ func testClusterDefaultsMaxStorageNodesPerZone(t *testing.T, expectedValue uint3
 		Driver: driver,
 	}
 	driver.EXPECT().UpdateDriver(gomock.Any()).MinTimes(1)
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return("mockDriverName").AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).MinTimes(1)
 
 	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1259,7 +1259,18 @@ func getDefaultMaxStorageNodesPerZone(
 		return 0, err
 	}
 	numZones := len(zoneMap)
-	storageNodes = uint64(len(nodeList.Items) / numZones)
+	totalPxNodes := 0
+	for _, node := range nodeList.Items {
+		shouldRun, _, err := k8s.CheckPredicatesForStoragePod(&node, cluster, nil)
+		if err != nil {
+			return 0, err
+		}
+		if shouldRun {
+			totalPxNodes++
+		}
+	}
+
+	storageNodes = uint64(totalPxNodes / numZones)
 	return uint32(storageNodes), nil
 }
 

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1236,7 +1236,7 @@ func getDefaultStorageNodesDisaggregatedMode(
 
 // getDefaultMaxStorageNodesPerZone aims to return a good value for MaxStorageNodesPerZone with the
 // intention of having at least 3 nodes in the cluster.
-func getDefaultMaxStorageNodesPerZone(
+func (c *Controller) getDefaultMaxStorageNodesPerZone(
 	nodeList *v1.NodeList,
 	cluster *corev1.StorageCluster,
 	recorder record.EventRecorder,
@@ -1244,9 +1244,19 @@ func getDefaultMaxStorageNodesPerZone(
 	if len(nodeList.Items) == 0 {
 		return 0, nil
 	}
+	filteredList := v1.NodeList{}
+	for _, node := range nodeList.Items {
+		shouldRun, _, err := c.nodeShouldRunStoragePod(&node, cluster)
+		if err != nil {
+			return 0, err
+		}
+		if shouldRun {
+			filteredList.Items = append(filteredList.Items, node)
+		}
+	}
 
 	// Check if storage nodes are explicitly set using labels
-	storageNodes, disaggregatedMode, err := getDefaultStorageNodesDisaggregatedMode(nodeList, cluster, recorder)
+	storageNodes, disaggregatedMode, err := getDefaultStorageNodesDisaggregatedMode(&filteredList, cluster, recorder)
 	if err != nil {
 		return 0, err
 	}
@@ -1254,23 +1264,12 @@ func getDefaultMaxStorageNodesPerZone(
 		return uint32(storageNodes), nil
 	}
 
-	zoneMap, err := getZoneMap(nodeList, "", "")
+	zoneMap, err := getZoneMap(&filteredList, "", "")
 	if err != nil {
 		return 0, err
 	}
 	numZones := len(zoneMap)
-	totalPxNodes := 0
-	for _, node := range nodeList.Items {
-		shouldRun, _, err := k8s.CheckPredicatesForStoragePod(&node, cluster, nil)
-		if err != nil {
-			return 0, err
-		}
-		if shouldRun {
-			totalPxNodes++
-		}
-	}
-
-	storageNodes = uint64(totalPxNodes / numZones)
+	storageNodes = uint64(len(filteredList.Items) / numZones)
 	return uint32(storageNodes), nil
 }
 
@@ -1406,7 +1405,7 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		err = nil
 		if toUpdate.Status.Phase == "" {
 			// Let's do this only when it's a fresh install of px
-			maxStorageNodesPerZone, err = getDefaultMaxStorageNodesPerZone(nodeList, toUpdate, c.recorder)
+			maxStorageNodesPerZone, err = c.getDefaultMaxStorageNodesPerZone(nodeList, toUpdate, c.recorder)
 			if err != nil {
 				logrus.Errorf("could not set defult value for max_storage_nodes_per_zone (first install): %v", err)
 			}


### PR DESCRIPTION
   Master nodes are counted towards total nodes while counting default
   value for maxStorageNodesPerZOne. This fixes that

Signed-off-by: Naveen Revanna <nrevanna@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Testing:
Verified that maxStorageNodesPerZone is 5 for the below

> kn get nodes
NAME                          STATUS   ROLES                  AGE   VERSION
nrevanna-vms-luminous-foe-0   Ready    <none>                 33d   v1.21.1
nrevanna-vms-luminous-foe-1   Ready    <none>                 33d   v1.21.1
nrevanna-vms-luminous-foe-2   Ready    <none>                 33d   v1.21.1
nrevanna-vms-luminous-foe-3   Ready    control-plane,master   33d   v1.21.1
nrevanna-vms-luminous-foe-4   Ready    <none>                 33d   v1.21.1
nrevanna-vms-luminous-foe-5   Ready    <none>                 33d   v1.21.1
