### PR TITLE
PWX-25288-pt2: Adding support for 'auto-tls'

### DIFF
--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -65,11 +65,6 @@ func main() {
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
-			Name:   "trace",
-			Usage:  "Enable trace logging",
-			Hidden: true,
-		},
-		cli.BoolFlag{
 			Name:  "verbose",
 			Usage: "Enable verbose logging",
 		},
@@ -131,12 +126,10 @@ func run(c *cli.Context) {
 		log.Fatalf("driver option is required")
 	}
 
-	if c.Bool("trace") {
-		log.SetLevel(log.TraceLevel)
-	} else if c.Bool("verbose") {
+	verbose := c.Bool("verbose")
+	if verbose {
 		log.SetLevel(log.DebugLevel)
 	} else {
-		// set INFO logs as default
 		log.SetLevel(log.InfoLevel)
 	}
 

--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -65,6 +65,11 @@ func main() {
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
+			Name:   "trace",
+			Usage:  "Enable trace logging",
+			Hidden: true,
+		},
+		cli.BoolFlag{
 			Name:  "verbose",
 			Usage: "Enable verbose logging",
 		},
@@ -126,10 +131,12 @@ func run(c *cli.Context) {
 		log.Fatalf("driver option is required")
 	}
 
-	verbose := c.Bool("verbose")
-	if verbose {
+	if c.Bool("trace") {
+		log.SetLevel(log.TraceLevel)
+	} else if c.Bool("verbose") {
 		log.SetLevel(log.DebugLevel)
 	} else {
+		// set INFO logs as default
 		log.SetLevel(log.InfoLevel)
 	}
 

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -979,7 +979,7 @@ func (t *template) getArguments() []string {
 	}
 
 	if pxutil.IsTLSEnabledOnCluster(&t.cluster.Spec) {
-		logrus.Tracef("TLS is enabled! Getting oci-monitor arugments")
+		logrus.Tracef("TLS is enabled! Getting oci-monitor arguments")
 		if tlsArgs, err := pxutil.GetOciMonArgumentsForTLS(t.cluster); err == nil {
 			logrus.Tracef("oci-monitor arguments for TLS: %v\n", tlsArgs)
 			args = append(args, tlsArgs...)
@@ -989,7 +989,7 @@ func (t *template) getArguments() []string {
 	}
 
 	if t.autoTLSEnabled {
-		logrus.Tracef("AutoTLS is enabled! Setting oci-monitor arugments")
+		logrus.Tracef("AutoTLS is enabled! Setting oci-monitor arguments")
 		args = append(args, "--auto-tls")
 	}
 

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -79,7 +79,7 @@ type template struct {
 	isIKS           bool
 	isOpenshift     bool
 	isK3s           bool
-	isAutoTLS       bool
+	autoTLSEnabled  bool
 	runOnMaster     bool
 	imagePullPolicy v1.PullPolicy
 	serviceType     v1.ServiceType
@@ -131,7 +131,7 @@ func newTemplate(
 	t.serviceType = pxutil.ServiceType(cluster, "")
 	t.imagePullPolicy = pxutil.ImagePullPolicy(cluster)
 	t.startPort = pxutil.StartPort(cluster)
-	t.isAutoTLS = pxutil.IsAutoTLS(cluster)
+	t.autoTLSEnabled = pxutil.IsAutoTLSEnabled(cluster)
 
 	return t, nil
 }
@@ -988,7 +988,7 @@ func (t *template) getArguments() []string {
 		}
 	}
 
-	if t.isAutoTLS {
+	if t.autoTLSEnabled {
 		logrus.Tracef("AutoTLS is enabled! Setting oci-monitor arugments")
 		args = append(args, "--auto-tls")
 	}
@@ -1126,7 +1126,7 @@ func (t *template) getEnvList() []v1.EnvVar {
 	}
 
 	// We're setting this to signal to porx that tls is enabled
-	if pxutil.IsTLSEnabledOnCluster(&t.cluster.Spec) || t.isAutoTLS {
+	if pxutil.IsTLSEnabledOnCluster(&t.cluster.Spec) || t.autoTLSEnabled {
 		// Set:
 		//    env:
 		//    - name: PX_ENABLE_TLS

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2469,6 +2469,9 @@ func TestUpdateClusterStatus(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
@@ -2700,6 +2703,9 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
 
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
@@ -3068,6 +3074,9 @@ func TestUpdateClusterStatusForNodeVersions(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
@@ -3416,6 +3425,9 @@ func TestUpdateClusterStatusInspectClusterFailure(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
@@ -3554,6 +3566,9 @@ func TestUpdateClusterStatusEnumerateNodesFailure(t *testing.T) {
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
 
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
@@ -3758,6 +3773,9 @@ func TestUpdateClusterStatusShouldUpdateStatusIfChanged(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
@@ -3872,6 +3890,9 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
 
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
@@ -4151,6 +4172,9 @@ func TestUpdateClusterStatusWithoutSchedulerNodeName(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
@@ -4360,6 +4384,9 @@ func TestUpdateClusterStatusShouldDeleteStorageNodeForNonExistingNodes(t *testin
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
@@ -4471,6 +4498,9 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
 
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
@@ -4772,6 +4802,9 @@ func TestUpdateClusterStatusShouldDeleteStorageNodeIfSchedulerNodeNameNotPresent
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
@@ -4912,6 +4945,9 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
 
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
@@ -5434,6 +5470,9 @@ func TestDeleteClusterShouldResetSDKConnection(t *testing.T) {
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
 
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
@@ -7339,6 +7378,9 @@ func TestUpdateStorageNodeKVDB(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+"."+clusterNS)
+	defer restoreEtcHosts(t)
+
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pxutil.PortworxServiceName,
@@ -7575,6 +7617,9 @@ func TestUpdateStorageNodeKVDBWhenOverwriteClusterID(t *testing.T) {
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+"."+clusterNS)
+	defer restoreEtcHosts(t)
 
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -8030,6 +8075,9 @@ func TestGetStorageNodes(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
 	// Create fake k8s client with fake service that will point the client
 	// to the mock sdk server address
 	k8sClient := testutil.FakeK8sClient(&v1.Service{
@@ -8244,6 +8292,9 @@ func testStoragelessNodesUpgrade(t *testing.T, expectedValue uint32, storageless
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
 
 	versionClient := fakek8sclient.NewSimpleClientset()
 	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{

--- a/drivers/storage/portworx/status_test.go
+++ b/drivers/storage/portworx/status_test.go
@@ -205,6 +205,9 @@ func TestUpdateStorageNodePhase(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
 	cluster := &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"net"
 	"os"
@@ -762,7 +761,7 @@ func GetDialOptions(tls bool) ([]grpc.DialOption, error) {
 		capool = x509.NewCertPool()
 	}
 	// add K8s CA if cert available
-	content, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	content, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 	if err == nil && len(content) > 0 {
 		if capool.AppendCertsFromPEM(content) {
 			logrus.Tracef("> GetDialOptions() - added K8s CA into CA-pool")

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -132,8 +132,6 @@ const (
 	AnnotationClusterID = pxAnnotationPrefix + "/cluster-id"
 	// AnnotationPreflightCheck do preflight check before installing Portworx
 	AnnotationPreflightCheck = pxAnnotationPrefix + "/preflight-check"
-	// AnnotationAutoTLS annotation whether to set up cluster with automatic SSL/TLS credentials
-	AnnotationAutoTLS = pxAnnotationPrefix + "/auto-tls"
 
 	// EnvKeyPXImage key for the environment variable that specifies Portworx image
 	EnvKeyPXImage = "PX_IMAGE"

--- a/drivers/storage/portworx/util/util_test.go
+++ b/drivers/storage/portworx/util/util_test.go
@@ -98,6 +98,16 @@ func TestGetOciMonArgumentsForTLS(t *testing.T) {
 	cluster = testutil.CreateClusterWithTLS(nil, serverCertFileName, serverKeyFileName)
 	_, err = GetOciMonArgumentsForTLS(cluster)
 	assert.Nil(t, err)
+
+	// test auto-ssl setup
+	cluster.Spec.Version = "3.0.0"
+	cluster.Spec.Security.TLS.ServerCert = nil
+	cluster.Spec.Security.TLS.ServerKey = nil
+	cluster.Spec.Security.TLS.RootCA = nil
+	args, err = GetOciMonArgumentsForTLS(cluster)
+	// validate
+	assert.Nil(t, err)
+	assert.ElementsMatch(t, []string{"--auto-tls"}, args)
 }
 
 func TestAuthEnabled(t *testing.T) {

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1395,10 +1395,10 @@ func (c *Controller) log(clus *corev1.StorageCluster) *logrus.Entry {
 
 // setSecuritySpecDefaults resets SSL/TLS env-vars depending on the given cluster settings
 func (c *Controller) setSecuritySpecDefaults(clus *corev1.StorageCluster) {
-	if pxutil.IsAutoTLSEnabled(clus) {
+	if pxutil.IsTLSEnabledOnCluster(&clus.Spec) {
 		os.Setenv(pxutil.EnvKeyPortworxEnableTLS, "true")
 		os.Setenv(pxutil.EnvKeyPortworxEnforceTLS, "true")
-	} else if !pxutil.IsTLSEnabledOnCluster(&clus.Spec) {
+	} else {
 		os.Unsetenv(pxutil.EnvKeyPortworxEnableTLS)
 		os.Unsetenv(pxutil.EnvKeyPortworxEnforceTLS)
 	}

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1262,14 +1262,7 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		return err
 	}
 
-	// set / reset TLS env-vars depending on the updated cluster settings
-	if pxutil.IsAutoTLS(toUpdate) {
-		os.Setenv(pxutil.EnvKeyPortworxEnableTLS, "true")
-		os.Setenv(pxutil.EnvKeyPortworxEnforceTLS, "true")
-	} else if !pxutil.IsTLSEnabledOnCluster(&toUpdate.Spec) {
-		os.Unsetenv(pxutil.EnvKeyPortworxEnableTLS)
-		os.Unsetenv(pxutil.EnvKeyPortworxEnforceTLS)
-	}
+	c.setSecuritySpecDefaults(toUpdate)
 
 	// Update the cluster only if anything has changed
 	if !reflect.DeepEqual(cluster, toUpdate) {
@@ -1398,6 +1391,17 @@ func (c *Controller) log(clus *corev1.StorageCluster) *logrus.Entry {
 	}
 
 	return logrus.WithFields(logFields)
+}
+
+// setSecuritySpecDefaults resets SSL/TLS env-vars depending on the given cluster settings
+func (c *Controller) setSecuritySpecDefaults(clus *corev1.StorageCluster) {
+	if pxutil.IsAutoTLSEnabled(clus) {
+		os.Setenv(pxutil.EnvKeyPortworxEnableTLS, "true")
+		os.Setenv(pxutil.EnvKeyPortworxEnforceTLS, "true")
+	} else if !pxutil.IsTLSEnabledOnCluster(&clus.Spec) {
+		os.Unsetenv(pxutil.EnvKeyPortworxEnableTLS)
+		os.Unsetenv(pxutil.EnvKeyPortworxEnforceTLS)
+	}
 }
 
 func storagePodsEnabled(


### PR DESCRIPTION
* adding new 'is-auto-tls' annotation
* this annotation initiates automatic SSL setup for porx
* gRPC-dialing now automatically adds K8s CA, since porx APIs will also switch to SSL-mode
* modified access to `portworx-service` to use K8s DNS, rather than ClusterIP

Additional:
* added support for `--trace` logging option

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is adding the support, and setup for "automatic SSL" for Portworx

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-25288   (part 2)

**Special notes for your reviewer**:
This change depends on https://github.com/portworx/px-installer/pull/1497 for OCI-Monitor  (<< linked to ClusterIP change)
Unit-tests pending