### PR TITLE
PTX-13942 Modified operator tests to run from container

### DIFF
--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.16.10
 # Install dependancies
 RUN apt-get update && \ 
     /usr/local/go/bin/go install gotest.tools/gotestsum@latest
+RUN apt-get install -y jq
 
 # Install aws-iam-authenticator
 # This is needed by test running inside EKS cluster and making API calls to aws.
@@ -10,8 +11,14 @@ RUN curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/
     chmod a+x aws-iam-authenticator && \
     mv aws-iam-authenticator /bin
 
+# Install kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin
+
 WORKDIR /
 
 COPY operator.test /
 COPY testspec /testspec
 COPY test-deploy.sh /
+COPY operator-test-pod-template.yaml /

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -x
 
-test_pod_template="/testspecs/operator-test-pod-template.yaml"
-test_pod_spec="/testspecs/operator-test-pod.yaml"
+test_pod_template="operator-test-pod-template.yaml"
+test_pod_spec="operator-test-pod.yaml"
 
 test_image_name="openstorage/px-operator-test:latest"
 default_portworx_spec_gen_url="https://install.portworx.com/"
@@ -134,12 +134,6 @@ case $i in
         ;;
 esac
 done
-
-apk update
-apk add jq
-
-apt-get -y update
-apt-get install -y jq
 
 # Copy test pod template to a new file
 cp $test_pod_template $test_pod_spec


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Modified operator tests to run from container

**Which issue(s) this PR fixes** (optional)
Closes https://portworx.atlassian.net/browse/PTX-13942

**Special notes for your reviewer**:
With above changes we don't need any other containers and operator repository. The test run command will look like this:
```
docker run --rm -t -v ${KUBECONFIG_PATH}:/tmp/kubeconfig -e KUBECONFIG=/tmp/kubeconfig --entrypoint /bin/bash px-operator-test:master /test-deploy.sh --operator-test-image px-operator-test:master --log-level debug --short-test true --focus-tests ${FOCUS_TEST} --portworx-spec-gen-url ${URL}/${ENDPOINT} --portworx-docker-username **** --portworx-docker-password ****
```
