### PR TITLE
[PWX-27588] Add support for EKS cloud storage capacity based configuration

### DIFF
--- a/drivers/storage/portworx/cloud_storage.go
+++ b/drivers/storage/portworx/cloud_storage.go
@@ -15,6 +15,9 @@ import (
 	// importing azure cloud provider so that it registers itself
 	// as a provider of the StorageManager interface
 	_ "github.com/libopenstorage/cloudops/azure/storagemanager"
+	// importing aws cloud provider so that it registers itself
+	// as a provider of the StorageManager interface
+	_ "github.com/libopenstorage/cloudops/aws/storagemanager"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/cloudstorage"
 	v1 "k8s.io/api/core/v1"

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -1008,7 +1008,8 @@ func setPortworxCloudStorageSpecDefaults(toUpdate *corev1.StorageCluster) {
 		if toUpdate.Spec.CloudStorage == nil {
 			toUpdate.Spec.CloudStorage = &corev1.CloudStorageSpec{}
 		}
-		if toUpdate.Spec.CloudStorage.DeviceSpecs == nil {
+		if len(toUpdate.Spec.CloudStorage.CapacitySpecs) == 0 &&
+			toUpdate.Spec.CloudStorage.DeviceSpecs == nil {
 			defaultEKSCloudStorageDevice := defaultEksCloudStorageDevice
 			deviceSpecs := []string{defaultEKSCloudStorageDevice}
 			toUpdate.Spec.CloudStorage.DeviceSpecs = &deviceSpecs

--- a/vendor/github.com/libopenstorage/cloudops/aws/storagemanager/aws.go
+++ b/vendor/github.com/libopenstorage/cloudops/aws/storagemanager/aws.go
@@ -1,0 +1,94 @@
+package storagemanager
+
+import (
+	"fmt"
+
+	"github.com/libopenstorage/cloudops"
+	"github.com/libopenstorage/cloudops/pkg/storagedistribution"
+	"github.com/libopenstorage/cloudops/unsupported"
+)
+
+type awsStorageManager struct {
+	cloudops.StorageManager
+	decisionMatrix *cloudops.StorageDecisionMatrix
+}
+
+const (
+	// DriveTypeGp3 is a constant for gp3 drive types
+	DriveTypeGp3 = "gp3"
+	// DriveTypeGp2 is a constant for gp2 drive types
+	DriveTypeGp2 = "gp2"
+	// DriveTypeIo1 is a constant for io1 drive types
+	DriveTypeIo1 = "io1"
+	// Gp2IopsMultiplier is the amount with which a given gp2 GiB size is multiplied
+	// in order to get that drive's baseline IOPS performance
+	Gp2IopsMultiplier = 3
+)
+
+// NewAWSStorageManager returns an aws implementation for Storage Management
+func NewAWSStorageManager(
+	decisionMatrix cloudops.StorageDecisionMatrix,
+) (cloudops.StorageManager, error) {
+	return &awsStorageManager{
+		StorageManager: unsupported.NewUnsupportedStorageManager(),
+		decisionMatrix: &decisionMatrix}, nil
+}
+
+func (a *awsStorageManager) GetStorageDistribution(
+	request *cloudops.StorageDistributionRequest,
+) (*cloudops.StorageDistributionResponse, error) {
+	response := &cloudops.StorageDistributionResponse{}
+	for _, userRequest := range request.UserStorageSpec {
+		// for for request, find how many instances per zone needs to have storage
+		// and the storage spec for each of them
+		instStorage, instancePerZone, row, err :=
+			storagedistribution.GetStorageDistributionForPool(
+				a.decisionMatrix,
+				userRequest,
+				request.InstancesPerZone,
+				request.ZoneCount,
+			)
+		if err != nil {
+			return nil, err
+		}
+		response.InstanceStorage = append(
+			response.InstanceStorage,
+			&cloudops.StoragePoolSpec{
+				DriveCapacityGiB: instStorage.DriveCapacityGiB,
+				DriveType:        instStorage.DriveType,
+				InstancesPerZone: instancePerZone,
+				DriveCount:       instStorage.DriveCount,
+				IOPS:             determineIOPSForPool(instStorage, row, userRequest.IOPS),
+			},
+		)
+
+	}
+	return response, nil
+}
+
+func (a *awsStorageManager) RecommendStoragePoolUpdate(
+	request *cloudops.StoragePoolUpdateRequest) (*cloudops.StoragePoolUpdateResponse, error) {
+	resp, row, err := storagedistribution.GetStorageUpdateConfig(request, a.decisionMatrix)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || len(resp.InstanceStorage) != 1 {
+		return nil, fmt.Errorf("could not find a valid instance storage object")
+	}
+	resp.InstanceStorage[0].IOPS = determineIOPSForPool(resp.InstanceStorage[0], row, request.CurrentIOPS /*we do not support updating IOPS yet*/)
+	return resp, nil
+}
+
+func determineIOPSForPool(instStorage *cloudops.StoragePoolSpec, row *cloudops.StorageDecisionMatrixRow, currentIOPS uint64) uint64 {
+	if instStorage.DriveType == DriveTypeGp2 {
+		return instStorage.DriveCapacityGiB * Gp2IopsMultiplier
+	} else if instStorage.DriveType == DriveTypeIo1 {
+		// For io1 volumes we need to specify the requested iops as the provisioned iops
+		return currentIOPS
+	}
+	return row.MinIOPS
+}
+
+func init() {
+	cloudops.RegisterStorageManager(cloudops.AWS, NewAWSStorageManager)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -517,6 +517,7 @@ github.com/leonklingele/grouper/pkg/analyzer/vars
 ## explicit; go 1.13
 github.com/libopenstorage/cloudops
 github.com/libopenstorage/cloudops/aws
+github.com/libopenstorage/cloudops/aws/storagemanager
 github.com/libopenstorage/cloudops/azure/storagemanager
 github.com/libopenstorage/cloudops/backoff
 github.com/libopenstorage/cloudops/mock


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* if cloud storage capacity spec is configured on EKS, operator will use that to create cloud drives

**Which issue(s) this PR fixes** (optional)
Closes # PWX-27588

**Special notes for your reviewer**:
spec to deploy px on eks
```
spec:
  cloudStorage:
    capacitySpecs:
    - minCapacityInGiB: 300
      minIOPS: 3000
    maxStorageNodesPerZone: 1
```
pod args generated from decision matrix:
```
    - -cloud_provider
    - aws
    - -s
    - type=gp3,size=12,iops=3000
    - -s
    - type=gp3,size=12,iops=3000
    - -s
    - type=gp3,size=12,iops=3000
    - -s
    - type=gp3,size=12,iops=3000
    - -s
    - type=gp3,size=12,iops=3000
    - -s
    - type=gp3,size=12,iops=3000
    - -s
    - type=gp3,size=12,iops=3000
    - -s
    - type=gp3,size=12,iops=3000
    - -max_storage_nodes_per_zone
    - "1"
```
pxctl status
```
Status: PX is operational
Telemetry: Disabled or Unhealthy
Metering: Disabled or Unhealthy
License: Trial (expires in 31 days)
Node ID: ce1c0a16-5f00-4c79-95bc-5dc25cea270e
	IP: 172.31.16.42
 	Local Storage Pool: 1 pool
	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE		REGION
	0	HIGH		raid0		96 GiB	13 GiB	Online	us-east-1d	us-east-1
	Local Storage Devices: 8 devices
	Device	Path		Media Type		Size		Last-Scan
	0:1	/dev/nvme7n1	STORAGE_MEDIUM_NVME	12 GiB		08 Dec 22 01:17 UTC
	0:2	/dev/nvme6n1	STORAGE_MEDIUM_NVME	12 GiB		08 Dec 22 01:17 UTC
	0:3	/dev/nvme8n1	STORAGE_MEDIUM_NVME	12 GiB		08 Dec 22 01:17 UTC
	0:4	/dev/nvme2n1	STORAGE_MEDIUM_NVME	12 GiB		08 Dec 22 01:17 UTC
	0:5	/dev/nvme4n1	STORAGE_MEDIUM_NVME	12 GiB		08 Dec 22 01:17 UTC
	0:6	/dev/nvme3n1	STORAGE_MEDIUM_NVME	12 GiB		08 Dec 22 01:17 UTC
	0:7	/dev/nvme5n1	STORAGE_MEDIUM_NVME	12 GiB		08 Dec 22 01:17 UTC
	0:8	/dev/nvme1n1	STORAGE_MEDIUM_NVME	12 GiB		08 Dec 22 01:17 UTC
	total			-			96 GiB
	Cache Devices:
	 * No cache devices
	Kvdb Device:
	Device Path	Size
	/dev/nvme9n1	150 GiB
	 * Internal kvdb on this node is using this dedicated kvdb device to store its data.
Cluster Summary
	Cluster ID: px-cluster-d05a0856-61cd-4951-88e1-57209ae0f6b5
	Cluster UUID: 71a44d97-0fd0-49d1-b6b8-20d08d7a6c35
	Scheduler: kubernetes
	Nodes: 3 node(s) with storage (3 online)
	IP		ID					SchedulerNodeName		Auth		StorageNode	Used	Capacity	Status	StorageStatus	Version		Kernel				OS
	172.31.16.42	ce1c0a16-5f00-4c79-95bc-5dc25cea270e	ip-172-31-16-42.ec2.internal	Disabled	Yes		13 GiB	96 GiB		Online	Up (This node)	2.12.0-02bd5b0	5.4.219-126.411.amzn2.x86_64	Amazon Linux 2
	172.31.80.218	9cd474e0-ec61-4779-888b-cc9b71f03c4d	ip-172-31-80-218.ec2.internal	Disabled	Yes		13 GiB	96 GiB		Online	Up		2.12.0-02bd5b0	5.4.219-126.411.amzn2.x86_64	Amazon Linux 2
	172.31.34.122	2a7476cd-90c0-4d0b-9781-5af7c40b5617	ip-172-31-34-122.ec2.internal	Disabled	Yes		13 GiB	96 GiB		Online	Up		2.12.0-02bd5b0	5.4.219-126.411.amzn2.x86_64	Amazon Linux 2
Global Storage Pool
	Total Used    	:  38 GiB
	Total Capacity	:  288 GiB
```