### PR TITLE
PWX-28189_pt2: Auto-TLS/SSL support for stork

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3716,7 +3716,7 @@ func TestAutopilotWithTLSEnabled(t *testing.T) {
 	}
 	require.ElementsMatch(t, expectedEnv, autopilotDeployment.Spec.Template.Spec.Containers[0].Env)
 
-	// TestCase: remove PX_ENABLE_TLS=true when AutoPilot disabled
+	// TestCase: remove PX_ENABLE_TLS=true when AutoPilot disabled.
 	cluster = &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3633,10 +3633,14 @@ func TestAutopilotWithTLSEnabled(t *testing.T) {
 				Enabled: true,
 				Image:   "portworx/autopilot:test",
 			},
+			Image:   "portworx/oci-monitor:" + pxutil.MinimumPxVersionAutoTLS.String(),
 			Version: pxutil.MinimumPxVersionAutoTLS.String(),
 		},
 	}
+
 	// test
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
 	err = driver.PreInstall(cluster)
 
 	// validate
@@ -3658,6 +3662,104 @@ func TestAutopilotWithTLSEnabled(t *testing.T) {
 		},
 	}
 	require.ElementsMatch(t, expectedEnv, autopilotDeployment.Spec.Template.Spec.Containers[0].Env)
+
+	// TestCase: remove PX_ENABLE_TLS=true when TLS disabled
+	cluster = &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					Enabled: boolPtr(false),
+				},
+				TLS: &corev1.TLSSpec{
+					Enabled: boolPtr(false),
+				},
+			},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: true,
+				Image:   "portworx/autopilot:test",
+				Env: []v1.EnvVar{
+					{
+						Name:  pxutil.EnvKeyPortworxEnableTLS,
+						Value: "true",
+					},
+				},
+			},
+			Image:   "portworx/oci-monitor:" + pxutil.MinimumPxVersionAutoTLS.String(),
+			Version: pxutil.MinimumPxVersionAutoTLS.String(),
+		},
+	}
+
+	// test
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.Empty(t, cluster.Spec.Autopilot.Env)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+
+	// validate
+	require.NoError(t, err)
+	require.Len(t, recorder.Events, 0) // no warnings
+	autopilotDeployment = &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Len(t, autopilotDeployment.Spec.Template.Spec.Containers[0].Env, 1)
+
+	expectedEnv = []v1.EnvVar{
+		{
+			Name:  pxutil.EnvKeyPortworxNamespace,
+			Value: cluster.Namespace,
+		},
+	}
+	require.ElementsMatch(t, expectedEnv, autopilotDeployment.Spec.Template.Spec.Containers[0].Env)
+
+	// TestCase: remove PX_ENABLE_TLS=true when AutoPilot disabled
+	cluster = &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					Enabled: boolPtr(false),
+				},
+				TLS: &corev1.TLSSpec{
+					Enabled: boolPtr(true),
+				},
+			},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: false,
+				Image:   "portworx/autopilot:test",
+				Env: []v1.EnvVar{
+					{
+						Name:  pxutil.EnvKeyPortworxEnableTLS,
+						Value: "true",
+					},
+				},
+			},
+			Image:   "portworx/oci-monitor:" + pxutil.MinimumPxVersionAutoTLS.String(),
+			Version: pxutil.MinimumPxVersionAutoTLS.String(),
+		},
+	}
+
+	// test
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	require.Empty(t, cluster.Spec.Autopilot.Env)
+	err = driver.PreInstall(cluster)
+
+	// validate
+	require.NoError(t, err)
+	require.Len(t, recorder.Events, 0) // no warnings
+
+	autopilotDeployment = &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
+	require.Error(t, err)
 }
 
 func TestAutopilotWithDesiredImage(t *testing.T) {


### PR DESCRIPTION
* manage "PX_ENABLE_TLS=true" env var for both Autopilot and Stork, depending on the TLS-setup
* updated UTs

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

We need to manage the `PX_ENABLE_TLS=true` environment variable both for Stork and Autopilot components
* refactored code accordingly, updated UTs
* note, the `PX_ENABLE_TLS=true` environment variable for Stork and Autopilot will be managed exclusively by PX-Operator, and it will depend on the global `security: tls: enabled` setting

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-28189  (part 2)

**Special notes for your reviewer**:
~This change depends on the update from https://github.com/libopenstorage/openstorage/pull/2169 -- review and go-vendor pending~
* **UPDATE**: the openstorage-change listed above is actually NOT a part of this project -- there is no need to vendor it in