### PR TITLE
PWX-28312: Fix stork-scheduler image validation failure

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -121,10 +121,10 @@ const (
 var TestSpecPath = "testspec"
 
 var (
-	pxVer2_12, _   = version.NewVersion("2.12.0-")
-	opVer1_10, _   = version.NewVersion("1.10.0-")
-	opVer1_9_1, _  = version.NewVersion("1.9.1-")
-	opVer1_10_1, _ = version.NewVersion("1.10.1-")
+	pxVer2_12, _                      = version.NewVersion("2.12.0-")
+	opVer1_10, _                      = version.NewVersion("1.10.0-")
+	opVer1_9_1, _                     = version.NewVersion("1.9.1-")
+	minOpVersionForKubeSchedConfig, _ = version.NewVersion("1.10.2")
 )
 
 // MockDriver creates a mock storage driver
@@ -1480,7 +1480,7 @@ func ValidateStorkEnabled(pxImageList map[string]string, cluster *corev1.Storage
 		}
 
 		opVersion, _ := GetPxOperatorVersion()
-		if opVersion.LessThanOrEqual(opVer1_10_1) {
+		if opVersion.LessThan(minOpVersionForKubeSchedConfig) {
 			if kubeVersion != nil && kubeVersion.GreaterThanOrEqual(K8sVer1_22) {
 				// Image tag for stork-scheduler is hardcoded to v1.21.4 for clusters 1.22 and up for Operator version 1.10.1 and below
 				if err = validateImageTag("v1.21.4", cluster.Namespace, map[string]string{"name": "stork-scheduler"}); err != nil {


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

**What this PR does / why we need it**:
Fixing stork-scheduler image validation failure

**Which issue(s) this PR fixes** (optional)
Closes # PWX-28312

**Special notes for your reviewer**:
opVersion.LessThanOrEqual(opVer1_10_1)  -> "1.10.1".LessThanOrEqual("1.10.1-") check resolves to false. I realized it's better to use minOpVersionForKubeSchedConfig and check for versions lower than this version. 
I tested operator-integration-basic and operator-integration-telemetry test with this and they are passing 
https://jenkins.pwx.dev.purestorage.com/job/Operator/view/Operator%20Release%20Dashboard/job/operator-integration-basic/489/console
https://jenkins.pwx.dev.purestorage.com/job/Operator/view/Operator%20Release%20Dashboard/job/operator-integration-telemetry/136/
