### PR TITLE
[PWX-27588] Calculate EKS cloud drive spec using totalCapacity/storageNodesCount

### DIFF
--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/libopenstorage/cloudops"
 	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/cloudprovider"
+	"github.com/libopenstorage/operator/pkg/preflight"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 	coreops "github.com/portworx/sched-ops/k8s/core"
@@ -1311,8 +1313,8 @@ func TestPodSpecWithCloudStorageSpec(t *testing.T) {
 	expectedArgs = []string{
 		"-c", "px-cluster",
 		"-x", "kubernetes",
-		"-s", "type=foo,size=120,iops=110,foo1=bar1",
-		"-s", "type=bar,size=220,iops=210,foo3=bar3",
+		"-s", "foo1=bar1,iops=110,size=120,type=foo",
+		"-s", "foo3=bar3,iops=210,size=220,type=bar",
 		"-max_storage_nodes_per_zone", "2",
 	}
 
@@ -1387,8 +1389,8 @@ func TestPodSpecWithCloudStorageSpec(t *testing.T) {
 	expectedArgs = []string{
 		"-c", "px-cluster",
 		"-x", "kubernetes",
-		"-s", "type=foo,size=120,iops=110,foo1=bar1",
-		"-s", "type=bar,size=220,iops=210,foo3=bar3",
+		"-s", "foo1=bar1,iops=110,size=120,type=foo",
+		"-s", "foo3=bar3,iops=210,size=220,type=bar",
 		"-max_storage_nodes_per_zone", "2",
 	}
 
@@ -1480,6 +1482,109 @@ func TestPodSpecWithCloudStorageSpec(t *testing.T) {
 	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
 
 	cluster.Spec.CloudStorage.Provider = nil
+}
+
+func TestPodSpecWithCloudStorageSpecOnEKS(t *testing.T) {
+	fakeK8sNodes := &v1.NodeList{Items: []v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1",
+				Labels: map[string]string{v1.LabelTopologyZone: "zone1"},
+			},
+			Spec: v1.NodeSpec{ProviderID: "aws://node-id-1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node2",
+				Labels: map[string]string{v1.LabelTopologyZone: "zone2"},
+			},
+			Spec: v1.NodeSpec{ProviderID: "aws://node-id-2"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node3",
+				Labels: map[string]string{v1.LabelTopologyZone: "zone3"},
+			},
+			Spec: v1.NodeSpec{ProviderID: "aws://node-id-3"},
+		},
+	}}
+	versionClient := fakek8sclient.NewSimpleClientset(fakeK8sNodes)
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.21.14-eks-ba74326",
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+	err := preflight.InitPreflightChecker()
+	require.NoError(t, err)
+
+	k8sClient := testutil.FakeK8sClient(fakeK8sNodes)
+	driver := portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
+	require.NoError(t, err)
+	driver.zoneToInstancesMap, err = cloudprovider.GetZoneMap(k8sClient, "", "")
+	require.NoError(t, err)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			CloudStorage: &corev1.CloudStorageSpec{
+				CapacitySpecs: []corev1.CloudStorageCapacitySpec{
+					{
+						MinCapacityInGiB: 300,
+						Options: map[string]string{
+							"foo1": "bar1",
+						},
+					},
+					{
+						MinCapacityInGiB: 600,
+						Options: map[string]string{
+							"foo2": "bar2",
+							"type": "io1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	expectedCapacitySpec := []corev1.CloudStorageCapacitySpec{
+		{
+			MinCapacityInGiB: 300,
+			Options: map[string]string{
+				"foo1": "bar1",
+				"type": "gp3",
+			},
+		},
+		{
+			MinCapacityInGiB: 600,
+			Options: map[string]string{
+				"foo2": "bar2",
+				"type": "io1",
+			},
+		},
+	}
+	require.Equal(t, expectedCapacitySpec, cluster.Spec.CloudStorage.CapacitySpecs)
+	require.NotNil(t, cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+	require.Equal(t, uint32(1), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+
+	expectedArgs := []string{
+		"-c", "px-cluster",
+		"-x", "kubernetes",
+		"-b",
+		"-cloud_provider", "aws",
+		"-s", "foo1=bar1,size=100,type=gp3",
+		"-s", "foo2=bar2,size=200,type=io1",
+		"-max_storage_nodes_per_zone", "1",
+		"-secret_type", "k8s",
+	}
+	actual, _ := driver.GetStoragePodSpec(cluster, fakeK8sNodes.Items[0].Name)
+	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
+
+	// Reset preflight for other tests
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	err = preflight.InitPreflightChecker()
+	require.NoError(t, err)
 }
 
 func TestPodSpecWithCapacitySpecsAndDeviceSpecs(t *testing.T) {
@@ -1599,8 +1704,8 @@ func TestPodSpecWithCapacitySpecsAndDeviceSpecs(t *testing.T) {
 	expectedArgs := []string{
 		"-c", "px-cluster",
 		"-x", "kubernetes",
-		"-s", "type=foo,size=120,iops=110,foo1=bar1",
-		"-s", "type=bar,size=220,iops=210,foo3=bar3",
+		"-s", "foo1=bar1,iops=110,size=120,type=foo",
+		"-s", "foo3=bar3,iops=210,size=220,type=bar",
 		"-max_storage_nodes_per_zone", "2",
 	}
 
@@ -3352,8 +3457,8 @@ func TestStorageNodeConfig(t *testing.T) {
 	expectedArgs = []string{
 		"-c", "px-cluster",
 		"-x", "kubernetes",
-		"-s", "type=foo,size=120,iops=110,foo1=bar1",
-		"-s", "type=bar,size=220,iops=210,foo3=bar3",
+		"-s", "foo1=bar1,iops=110,size=120,type=foo",
+		"-s", "foo3=bar3,iops=210,size=220,type=bar",
 		"-max_storage_nodes_per_zone", "2",
 	}
 
@@ -3422,8 +3527,8 @@ func TestStorageNodeConfig(t *testing.T) {
 	expectedArgs = []string{
 		"-c", "px-cluster",
 		"-x", "kubernetes",
-		"-s", "type=foo,size=120,iops=110,foo1=bar1",
-		"-s", "type=bar,size=220,iops=210,foo3=bar3",
+		"-s", "foo1=bar1,iops=110,size=120,type=foo",
+		"-s", "foo3=bar3,iops=210,size=220,type=bar",
 		"-max_storage_nodes_per_zone", "2",
 	}
 


### PR DESCRIPTION

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* use totalCapacity/storageNodesCount to calculate the EKS cloud drive spec, don't use the decision matrix for now

**Which issue(s) this PR fixes** (optional)
Closes # PWX-27588

**Special notes for your reviewer**:
spec:
```
spec:
  cloudStorage:
    capacitySpecs:
    - minCapacityInGiB: 500
      options:
        type: gp3
    maxStorageNodesPerZone: 1
```
args
```
    - -s
    - size=166,type=gp3
```
pxctl status
```
sh-4.4# /opt/pwx/bin/pxctl status
Status: PX is operational
Telemetry: Disabled or Unhealthy
Metering: Disabled or Unhealthy
License: Trial (expires in 31 days)
Node ID: 9cb18810-2b38-447e-99fe-8fa6ad1d987a
	IP: 172.31.36.44
 	Local Storage Pool: 1 pool
	POOL	IO_PRIORITY	RAID_LEVEL	USABLE	USED	STATUS	ZONE		REGION
	0	HIGH		raid0		166 GiB	8.3 GiB	Online	us-east-1c	us-east-1
	Local Storage Devices: 1 device
	Device	Path		Media Type		Size		Last-Scan
	0:1	/dev/nvme3n1	STORAGE_MEDIUM_NVME	166 GiB		21 Dec 22 02:22 UTC
	total			-			166 GiB
	Cache Devices:
	 * No cache devices
	Kvdb Device:
	Device Path	Size
	/dev/nvme4n1	150 GiB
	 * Internal kvdb on this node is using this dedicated kvdb device to store its data.
Cluster Summary
	Cluster ID: px-cluster-d05a0856-61cd-4951-88e1-57209ae0f6b5
	Cluster UUID: 435c8754-318b-43f6-b108-8cc63ce43675
	Scheduler: kubernetes
	Nodes: 3 node(s) with storage (3 online)
	IP		ID					SchedulerNodeName		Auth		StorageNode	UsedCapacity	Status	StorageStatus	Version		Kernel				OS
	172.31.23.156	d7bdecf0-f91f-4aaf-8048-c41b82ca7bc5	ip-172-31-23-156.ec2.internal	Disabled	Yes		8.3 GiB	166 GiB		Online	Up		2.12.0-02bd5b0	5.4.219-126.411.amzn2.x86_64	Amazon Linux 2
	172.31.36.44	9cb18810-2b38-447e-99fe-8fa6ad1d987a	ip-172-31-36-44.ec2.internal	Disabled	Yes		8.3 GiB	166 GiB		Online	Up (This node)	2.12.0-02bd5b0	5.4.219-126.411.amzn2.x86_64	Amazon Linux 2
	172.31.62.73	50e0ab4e-9454-4fa9-b96e-dae36607d8b2	ip-172-31-62-73.ec2.internal	Disabled	Yes		8.3 GiB	166 GiB		Online	Up		2.12.0-02bd5b0	5.4.219-126.411.amzn2.x86_64	Amazon Linux 2
Global Storage Pool
	Total Used    	:  25 GiB
	Total Capacity	:  498 GiB
```

