### PR TITLE
PWX-27934: fix CSI socket path is not mounted in portworx container

### DIFF
--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -677,7 +677,8 @@ func (t *telemetry) createCCMJavaConfigMap(
             "/var/cores/*px-cores*",
             "/var/cores/*.heap",
             "/var/cores/*.stack",
-            "/var/cores/.alerts/alerts*"
+            "/var/cores/.alerts/alerts*",
+			"/var/cores/px_status/*.log"
         ],
         "skip_patterns": [],
         "additional_files": [
@@ -687,7 +688,9 @@ func (t *telemetry) createCCMJavaConfigMap(
             "/var/cores/px_cache_mon.log",
             "/var/cores/px_cache_mon_watch.log",
             "/var/cores/px_healthmon_watch.log",
-            "/var/cores/px_event_watch.log"
+            "/var/cores/px_event_watch.log",
+			"/var/cores/px_info.log",
+			"/var/cores/px_patch_fs.log"
         ],
         "phonehome_sent": "/var/cache/phonehome.sent"
       },

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -678,7 +678,7 @@ func (t *telemetry) createCCMJavaConfigMap(
             "/var/cores/*.heap",
             "/var/cores/*.stack",
             "/var/cores/.alerts/alerts*",
-			"/var/cores/px_status/*.log"
+            "/var/cores/px_status/*.log"
         ],
         "skip_patterns": [],
         "additional_files": [
@@ -689,8 +689,8 @@ func (t *telemetry) createCCMJavaConfigMap(
             "/var/cores/px_cache_mon_watch.log",
             "/var/cores/px_healthmon_watch.log",
             "/var/cores/px_event_watch.log",
-			"/var/cores/px_info.log",
-			"/var/cores/px_patch_fs.log"
+            "/var/cores/px_info.log",
+            "/var/cores/px_patch_fs.log"
         ],
         "phonehome_sent": "/var/cache/phonehome.sent"
       },

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1233,6 +1233,7 @@ func (t *template) getEnvList() []v1.EnvVar {
 func (t *template) getVolumeMounts() []v1.VolumeMount {
 	volumeInfoList := getDefaultVolumeInfoList(t.pxVersion)
 	extensions := []func() []volumeInfo{
+		t.getCSIVolumeInfoList,
 		t.getK3sVolumeInfoList,
 		t.getPKSVolumeInfoList,
 		t.getBottleRocketVolumeInfoList,
@@ -1422,6 +1423,7 @@ func (t *template) getCSIVolumeInfoList() []volumeInfo {
 		volumeInfo{
 			name:         "csi-driver-path",
 			hostPath:     t.csiConfig.DriverBasePath(),
+			mountPath:    t.csiConfig.DriverBasePath(),
 			hostPathType: hostPathTypePtr(v1.HostPathDirectoryOrCreate),
 		},
 	)

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
@@ -22,7 +22,8 @@ data:
           "/var/cores/*px-cores*",
           "/var/cores/*.heap",
           "/var/cores/*.stack",
-          "/var/cores/.alerts/alerts*"
+          "/var/cores/.alerts/alerts*",
+          "/var/cores/px_status/*.log"
         ],
         "skip_patterns": [
           "/var/cores/*skip*",
@@ -35,7 +36,9 @@ data:
           "/var/cores/px_cache_mon.log",
           "/var/cores/px_cache_mon_watch.log",
           "/var/cores/px_healthmon_watch.log",
-          "/var/cores/px_event_watch.log"
+          "/var/cores/px_event_watch.log",
+          "/var/cores/px_info.log",
+          "/var/cores/px_patch_fs.log"
         ],
         "phonehome_hour_range": 8760,
         "phonehome_sent": "/var/logs/phonehome.sent",

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
@@ -22,8 +22,7 @@ data:
           "/var/cores/*px-cores*",
           "/var/cores/*.heap",
           "/var/cores/*.stack",
-          "/var/cores/.alerts/alerts*",
-          "/var/cores/px_status/*.log"
+          "/var/cores/.alerts/alerts*"
         ],
         "skip_patterns": [
           "/var/cores/*skip*",
@@ -36,9 +35,7 @@ data:
           "/var/cores/px_cache_mon.log",
           "/var/cores/px_cache_mon_watch.log",
           "/var/cores/px_healthmon_watch.log",
-          "/var/cores/px_event_watch.log",
-          "/var/cores/px_info.log",
-          "/var/cores/px_patch_fs.log"
+          "/var/cores/px_event_watch.log"
         ],
         "phonehome_hour_range": 8760,
         "phonehome_sent": "/var/logs/phonehome.sent",

--- a/drivers/storage/portworx/testspec/ccmconfig.yaml
+++ b/drivers/storage/portworx/testspec/ccmconfig.yaml
@@ -42,7 +42,8 @@ data:
                 "/var/cores/*px-cores*",
                 "/var/cores/*.heap",
                 "/var/cores/*.stack",
-                "/var/cores/.alerts/alerts*"
+                "/var/cores/.alerts/alerts*",
+                "/var/cores/px_status/*.log"
             ],
             "skip_patterns": [],
             "additional_files": [
@@ -52,7 +53,9 @@ data:
                 "/var/cores/px_cache_mon.log",
                 "/var/cores/px_cache_mon_watch.log",
                 "/var/cores/px_healthmon_watch.log",
-                "/var/cores/px_event_watch.log"
+                "/var/cores/px_event_watch.log",
+                "/var/cores/px_info.log",
+                "/var/cores/px_patch_fs.log"
             ],
             "phonehome_sent": "/var/cache/phonehome.sent"
           },

--- a/drivers/storage/portworx/testspec/px_csi_0.3.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_0.3.yaml
@@ -60,6 +60,8 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
+            - name: csi-driver-path
+              mountPath: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
             - name: diagsdump
               mountPath: /var/cores
             - name: dockersock

--- a/drivers/storage/portworx/testspec/px_csi_1.0.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_1.0.yaml
@@ -58,6 +58,8 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
+            - name: csi-driver-path
+              mountPath: /var/lib/kubelet/csi-plugins/com.openstorage.pxd
             - name: diagsdump
               mountPath: /var/cores
             - name: dockersock

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -70,6 +70,8 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
+            - name: csi-driver-path
+              mountPath: /var/lib/kubelet/plugins/pxd.portworx.com
             - name: diagsdump
               mountPath: /var/cores
             - name: dockersock

--- a/drivers/storage/portworx/testspec/px_master.yaml
+++ b/drivers/storage/portworx/testspec/px_master.yaml
@@ -72,6 +72,8 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
+            - name: csi-driver-path
+              mountPath: /var/lib/kubelet/csi-plugins/pxd.portworx.com
             - name: diagsdump
               mountPath: /var/cores
             - name: dockersock

--- a/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
+++ b/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
@@ -58,6 +58,8 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
+            - name: csi-driver-path
+              mountPath: /var/vcap/data/kubelet/csi-plugins/pxd.portworx.com
             - name: diagsdump
               mountPath: /var/cores
             - name: dockersock

--- a/test/integration_test/testspec/migration/daemonset-with-all-components.yaml
+++ b/test/integration_test/testspec/migration/daemonset-with-all-components.yaml
@@ -105,6 +105,8 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
+            - name: csi-driver-path
+              mountPath: /var/lib/kubelet/plugins/pxd.portworx.com
             - name: diagsdump
               mountPath: /var/cores
             - name: dockersock


### PR DESCRIPTION
add CSI mount path to portworx container

Signed-off-by: Shivanjan Chakravorty <schakravorty@purestorage.com>

**What this PR does / why we need it**:

With the new installation method with operator, CSI socket path is not mounted in portworx container.
The fix for this was to include the CSI volume mount path in while creating portworx container