### PR TITLE
PTX-14810 Increase defaultTelemetryInPxctlValidationTimeout due to 5 mins is not enough sometimes

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -106,7 +106,7 @@ const (
 	defaultTelemetrySecretValidationTimeout  = 30 * time.Second
 	defaultTelemetrySecretValidationInterval = time.Second
 
-	defaultTelemetryInPxctlValidationTimeout  = 5 * time.Minute
+	defaultTelemetryInPxctlValidationTimeout  = 20 * time.Minute
 	defaultTelemetryInPxctlValidationInterval = 30 * time.Second
 
 	defaultPxAuthValidationTimeout  = 20 * time.Minute


### PR DESCRIPTION
Increase defaultTelemetryInPxctlValidationTimeout, due to 5 mins is not enough sometimes. Seems sometimes when infra is overloaded, 5 mins is not enough to bounce PX pods and start PX on all nodes.

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>