### PR TITLE
PWX-28101 read custom kubelet path from env

### DIFF
--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -71,6 +71,8 @@ const (
 	EssentialsUserIDKey = "px-essen-user-id"
 	// EssentialsOSBEndpointKey is the secret key for Essentials OSB endpoint
 	EssentialsOSBEndpointKey = "px-osb-endpoint"
+	// EnvKeyKubeletDir env var to set custom kubelet directory
+	EnvKeyKubeletDir = "KUBELET_DIR"
 
 	// AnnotationIsPKS annotation indicating whether it is a PKS cluster
 	AnnotationIsPKS = pxAnnotationPrefix + "/is-pks"
@@ -438,6 +440,13 @@ func KubeletPath(cluster *corev1.StorageCluster) string {
 	if IsPKS(cluster) {
 		return "/var/vcap/data/kubelet"
 	}
+
+	for _, env := range cluster.Spec.Env {
+		if env.Name == EnvKeyKubeletDir && len(env.Value) > 0 {
+			return env.Value
+		}
+	}
+
 	return "/var/lib/kubelet"
 }
 


### PR DESCRIPTION
Signed-off-by: Shivanjan Chakravorty <schakravorty@purestorage.com>

**What this PR does / why we need it**:
PX Operator allows to pass a non standard kubelet config path and setup the csi sidecars accordingly

**Which issue(s) this PR fixes**
PX Operator should allow to pass a non standard kubelet config path and setup the csi sidecars accordingly

Closes #879
