### PR TITLE
PTX-14937 Fix stork-scheduler pod validation for 1.10.2+

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -125,7 +125,7 @@ var (
 	opVer1_11, _                      = version.NewVersion("1.11.0-")
 	opVer1_10, _                      = version.NewVersion("1.10.0-")
 	opVer1_9_1, _                     = version.NewVersion("1.9.1-")
-	minOpVersionForKubeSchedConfig, _ = version.NewVersion("1.10.2")
+	minOpVersionForKubeSchedConfig, _ = version.NewVersion("1.10.2-")
 )
 
 // MockDriver creates a mock storage driver


### PR DESCRIPTION
Fix stork-scheduler pod validation for 1.10.2+
NOTE: Looks like for version formats for operator we need to add `-` at the end

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>