### PR TITLE
[PWX-27622] Use provided AWS credentials to run permission check on EKS

### DIFF
--- a/cmd/operator/operator.go
+++ b/cmd/operator/operator.go
@@ -229,7 +229,7 @@ func run(c *cli.Context) {
 		log.Warnf("Failed to expose metrics port: %v", err)
 	}
 
-	if err := preflight.InitPreflightChecker(); err != nil {
+	if err := preflight.InitPreflightChecker(mgr.GetClient()); err != nil {
 		log.Fatalf("Error initializing preflight checker: %v", err)
 	}
 

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -1588,10 +1588,10 @@ func TestPodSpecWithCloudStorageSpecOnEKS(t *testing.T) {
 		GitVersion: "v1.21.14-eks-ba74326",
 	}
 	coreops.SetInstance(coreops.New(versionClient))
-	err := preflight.InitPreflightChecker()
+	k8sClient := testutil.FakeK8sClient(fakeK8sNodes)
+	err := preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
 
-	k8sClient := testutil.FakeK8sClient(fakeK8sNodes)
 	driver := portworx{}
 	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
 	require.NoError(t, err)
@@ -1661,7 +1661,7 @@ func TestPodSpecWithCloudStorageSpecOnEKS(t *testing.T) {
 
 	// Reset preflight for other tests
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
-	err = preflight.InitPreflightChecker()
+	err = preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
 }
 

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -439,7 +439,7 @@ func TestSetDefaultsOnStorageClusterOnEKS(t *testing.T) {
 	}
 
 	// TestCase: default cloud provider
-	err = preflight.InitPreflightChecker()
+	err = preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
@@ -461,7 +461,7 @@ func TestSetDefaultsOnStorageClusterOnEKS(t *testing.T) {
 		GitVersion: "v1.21.14-eks-ba74326",
 	}
 	coreops.SetInstance(coreops.New(versionClient))
-	err = preflight.InitPreflightChecker()
+	err = preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
 	cluster.Spec = corev1.StorageClusterSpec{}
 	err = driver.SetDefaultsOnStorageCluster(cluster)
@@ -507,7 +507,7 @@ func TestSetDefaultsOnStorageClusterOnEKS(t *testing.T) {
 
 	// Reset preflight for other tests
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
-	err = preflight.InitPreflightChecker()
+	err = preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
 }
 

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/libopenstorage/cloudops"
 	"github.com/libopenstorage/operator/pkg/preflight"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 )
 
@@ -160,7 +161,7 @@ func TestGetProvidersFromPreflightChecker(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node3"}},
 	}}
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset(fakeK8sNodes)))
-	err := preflight.InitPreflightChecker()
+	err := preflight.InitPreflightChecker(testutil.FakeK8sClient(fakeK8sNodes))
 	require.NoError(t, err)
 	cp = Get()
 	require.Empty(t, cp.Name())
@@ -172,7 +173,7 @@ func TestGetProvidersFromPreflightChecker(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node3"}, Spec: v1.NodeSpec{ProviderID: "azure://node-id-3"}},
 	}}
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset(fakeK8sNodes)))
-	err = preflight.InitPreflightChecker()
+	err = preflight.InitPreflightChecker(testutil.FakeK8sClient(fakeK8sNodes))
 	require.NoError(t, err)
 	cp = Get()
 	require.Equal(t, cloudops.Azure, cp.Name())
@@ -184,7 +185,7 @@ func TestGetProvidersFromPreflightChecker(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node3"}, Spec: v1.NodeSpec{ProviderID: "aws://node-id-3"}},
 	}}
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset(fakeK8sNodes)))
-	err = preflight.InitPreflightChecker()
+	err = preflight.InitPreflightChecker(testutil.FakeK8sClient(fakeK8sNodes))
 	require.NoError(t, err)
 	cp = Get()
 	require.Equal(t, string(cloudops.AWS), cp.Name())

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -2960,7 +2960,7 @@ func TestUpdateDriverWithInstanceInformation(t *testing.T) {
 	err = k8sClient.Update(context.TODO(), k8sNode3)
 	require.NoError(t, err)
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset(k8sNode1, k8sNode2, k8sNode3)))
-	err = preflight.InitPreflightChecker()
+	err = preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
 
 	expectedDriverInfo.CloudProvider = "testcloud"

--- a/pkg/preflight/aws_test.go
+++ b/pkg/preflight/aws_test.go
@@ -3,17 +3,20 @@ package preflight
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakek8sclient "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/libopenstorage/cloudops"
 	"github.com/libopenstorage/cloudops/mock"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 )
 
@@ -53,7 +56,7 @@ func TestEKSCloudPermissionPassed(t *testing.T) {
 	fakeAWSOps.EXPECT().Delete(gomock.Any(), dryRunOption).Return(errors.New(dryRunErrMsg)).Times(1)
 
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
-	err := InitPreflightChecker()
+	err := InitPreflightChecker(testutil.FakeK8sClient())
 	require.NoError(t, err)
 	SetInstance(&aws{ops: fakeAWSOps})
 	require.NoError(t, Instance().CheckCloudDrivePermission(cluster))
@@ -82,7 +85,7 @@ func TestEKSCloudPermissionRetry(t *testing.T) {
 	fakeAWSOps.EXPECT().Attach(gomock.Any(), dryRunOption).Return("", fmt.Errorf("failed")).Times(1)
 
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
-	err := InitPreflightChecker()
+	err := InitPreflightChecker(testutil.FakeK8sClient())
 	require.NoError(t, err)
 	SetInstance(&aws{ops: fakeAWSOps})
 	require.Error(t, Instance().CheckCloudDrivePermission(cluster))
@@ -99,6 +102,115 @@ func TestEKSCloudPermissionRetry(t *testing.T) {
 	fakeAWSOps.EXPECT().Delete(gomock.Any(), dryRunOption).Return(errors.New(dryRunErrMsg)).Times(1)
 
 	require.NoError(t, Instance().CheckCloudDrivePermission(cluster))
+}
+
+func TestSetAWSCredentialEnvVars(t *testing.T) {
+	defer func() {
+		os.Setenv(awsAccessKeyEnvName, "")
+		os.Setenv(awsSecretKeyEnvName, "")
+	}()
+
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	err := InitPreflightChecker(testutil.FakeK8sClient())
+	require.NoError(t, err)
+	SetInstance(&aws{})
+
+	expectedAccessKey := "accesskey"
+	expectedSecretKey := "secretkey"
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			CommonConfig: corev1.CommonConfig{
+				Env: []v1.EnvVar{
+					{
+						Name:  awsAccessKeyEnvName,
+						Value: expectedAccessKey,
+					},
+					{
+						Name:  awsSecretKeyEnvName,
+						Value: expectedSecretKey,
+					},
+				},
+			},
+		},
+	}
+
+	// TestCase: both access and secret key are specified in the stc env
+	require.Error(t, Instance().CheckCloudDrivePermission(cluster), "expected error setting up aws client")
+	require.Equal(t, expectedAccessKey, os.Getenv(awsAccessKeyEnvName))
+	require.Equal(t, expectedSecretKey, os.Getenv(awsSecretKeyEnvName))
+
+	// TestCase: credentials are updated
+	newAccessKey := "newaccesskey"
+	newSecretKey := "newsecretkey"
+	cluster.Spec.Env = []v1.EnvVar{
+		{
+			Name:  awsAccessKeyEnvName,
+			Value: newAccessKey,
+		},
+		{
+			Name:  awsSecretKeyEnvName,
+			Value: newSecretKey,
+		},
+	}
+	require.Error(t, Instance().CheckCloudDrivePermission(cluster), "expected error setting up aws client")
+	require.Equal(t, newAccessKey, os.Getenv(awsAccessKeyEnvName))
+	require.Equal(t, newSecretKey, os.Getenv(awsSecretKeyEnvName))
+
+	// TestCase: only one key provided in the stc env
+	cluster.Spec.Env = []v1.EnvVar{{
+		Name:  awsAccessKeyEnvName,
+		Value: expectedAccessKey,
+	}}
+	err = Instance().CheckCloudDrivePermission(cluster)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "both AWS_ACCESS_KEY_ID and AWS_ACCESS_KEY_ID need to be provided")
+
+	// TestCase: setup env vars from secret
+	cluster.Spec.Env = []v1.EnvVar{
+		{
+			Name: awsAccessKeyEnvName,
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					Key: "access-key",
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "aws-secret",
+					},
+				},
+			},
+		},
+		{
+			Name: awsSecretKeyEnvName,
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					Key: "secret-key",
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "aws-secret",
+					},
+				},
+			},
+		},
+	}
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "aws-secret",
+			Namespace: cluster.Namespace,
+		},
+		Data: map[string][]byte{
+			"access-key": []byte(expectedAccessKey),
+			"secret-key": []byte(expectedSecretKey),
+		},
+	}
+	k8sClient := testutil.FakeK8sClient(secret)
+	SetInstance(&aws{checker: checker{
+		k8sClient: k8sClient,
+	}})
+	require.Error(t, Instance().CheckCloudDrivePermission(cluster), "expected error setting up aws client")
+	require.Equal(t, expectedAccessKey, os.Getenv(awsAccessKeyEnvName))
+	require.Equal(t, expectedSecretKey, os.Getenv(awsSecretKeyEnvName))
 }
 
 func stringPtr(val string) *string {

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	coreops "github.com/portworx/sched-ops/k8s/core"
@@ -18,6 +19,7 @@ var (
 type checker struct {
 	providerName     string
 	distributionName string
+	k8sClient        client.Client
 }
 
 // CheckerOps is a list of APIs to do preflight check
@@ -60,7 +62,7 @@ func SetInstance(i CheckerOps) {
 }
 
 // InitPreflightChecker initialize the preflight check instance
-func InitPreflightChecker() error {
+func InitPreflightChecker(client client.Client) error {
 	providerName, err := getCloudProviderName()
 	if err != nil {
 		return err
@@ -73,6 +75,7 @@ func InitPreflightChecker() error {
 	c := &checker{
 		providerName:     providerName,
 		distributionName: distributionName,
+		k8sClient:        client,
 	}
 	instance = c
 	if IsEKS() {

--- a/pkg/preflight/preflight_test.go
+++ b/pkg/preflight/preflight_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/libopenstorage/cloudops"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 )
 
@@ -30,7 +31,7 @@ func TestDefaultProviders(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node3"}},
 	}}
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset(fakeK8sNodes)))
-	err := InitPreflightChecker()
+	err := InitPreflightChecker(testutil.FakeK8sClient(fakeK8sNodes))
 	require.NoError(t, err)
 
 	c := Instance()
@@ -45,7 +46,7 @@ func TestDefaultProviders(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node3"}, Spec: v1.NodeSpec{ProviderID: "azure://node-id-3"}},
 	}}
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset(fakeK8sNodes)))
-	err = InitPreflightChecker()
+	err = InitPreflightChecker(testutil.FakeK8sClient(fakeK8sNodes))
 	require.NoError(t, err)
 
 	c = Instance()
@@ -60,7 +61,7 @@ func TestDefaultProviders(t *testing.T) {
 		{ObjectMeta: metav1.ObjectMeta{Name: "node3"}, Spec: v1.NodeSpec{ProviderID: "aws://node-id-3"}},
 	}}
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset(fakeK8sNodes)))
-	err = InitPreflightChecker()
+	err = InitPreflightChecker(testutil.FakeK8sClient(fakeK8sNodes))
 	require.NoError(t, err)
 
 	c = Instance()
@@ -75,7 +76,7 @@ func TestDefaultProviders(t *testing.T) {
 		GitVersion: "v1.21.14-eks-ba74326",
 	}
 	coreops.SetInstance(coreops.New(versionClient))
-	err = InitPreflightChecker()
+	err = InitPreflightChecker(testutil.FakeK8sClient(fakeK8sNodes))
 	require.NoError(t, err)
 	require.True(t, IsEKS())
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* When AWS credentials are provided in stc env, preflight check will use that to create a client to check cloud permission instead of using privileged instances.
* User can modify specified credentials and retrigger preflight check again.
* Credentials can be passed from string or k8s secret object

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Test manually:
1. without privileged instances, preflight respond 403 error in the condition list
2. with wrong credentials provided then rerun preflight, got a different 401 error in the condition list
3. update stc to use correct credentials then rerun preflight, px is deployed successfully
4. uninstall and add privileges to node group iam, remove aws credentials, redeploy portworx, preflight passed successfully

