### PR TITLE
[PWX-28585] Avoid parsing git sha to valid operator versions in automation

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -2875,14 +2875,17 @@ func GetPxOperatorVersion() (*version.Version, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	// tag is not a valid version, e.g. commit sha in PR automation builds "1a6a788" can be parsed to "1.0.0-a6a788"
+	if !strings.Contains(imageTag, ".") {
+		logrus.Errorf("Operator tag %s is not a valid version tag, assuming its latest and setting it to %s", imageTag, PxOperatorMasterVersion)
+		imageTag = PxOperatorMasterVersion
+	}
 	// We may run the automation on operator installed using private images,
 	// so assume we are testing the latest operator version if failed to parse the tag
 	opVersion, err := version.NewVersion(imageTag)
 	if err != nil {
-		masterVersionTag := PxOperatorMasterVersion
 		logrus.WithError(err).Warnf("Failed to parse portworx-operator tag to version, assuming its latest and setting it to %s", PxOperatorMasterVersion)
-		opVersion, _ = version.NewVersion(masterVersionTag)
+		opVersion, _ = version.NewVersion(PxOperatorMasterVersion)
 	}
 
 	logrus.Infof("Testing portworx-operator version [%s]", opVersion.String())

--- a/test/integration_test/utils/px_operator.go
+++ b/test/integration_test/utils/px_operator.go
@@ -32,14 +32,18 @@ var (
 
 // GetPXOperatorVersion returns the portworx operator version found
 func GetPXOperatorVersion() (*version.Version, error) {
-	pxImageTag, err := getPXOperatorImageTag()
+	imageTag, err := getPXOperatorImageTag()
 	if err != nil {
 		return nil, err
 	}
-
+	// tag is not a valid version, e.g. commit sha in PR automation builds "1a6a788" can be parsed to "1.0.0-a6a788"
+	if !strings.Contains(imageTag, ".") {
+		logrus.Errorf("Operator tag %s is not a valid version tag, assuming its latest and setting it to %s", imageTag, pxOperatorMasterVersion)
+		imageTag = pxOperatorMasterVersion
+	}
 	// We may run the automation on operator installed using private images,
 	// so assume we are testing the latest operator version if failed to parse the tag
-	opVersion, err := version.NewVersion(pxImageTag)
+	opVersion, err := version.NewVersion(imageTag)
 	if err != nil {
 		logrus.WithError(err).Warnf("Failed to parse portworx-operator tag to version, assuming its latest and setting it to %s", pxOperatorMasterVersion)
 		opVersion, _ = version.NewVersion(pxOperatorMasterVersion)


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
During PR automation, operator tag such as "1a6a788" and be parsed into "1.0.0-a6a788"

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

