### PR TITLE
read custom kubelet path from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,45 @@
 
 # Openstorage Operator
 Operator to manage storage cluster in Kubernetes
+
+# Development
+
+## Clone the operator repository
+
+```sh
+git clone git@github.com:libopenstorage/operator.git
+cd operator
+```
+## Build operator
+
+```sh
+make downloads all
+```
+
+Troubleshooting: 
+
+If you get errors like 
+
+```sh
+/usr/local/go/src/math/erf.go:189:6: Erf defined in both Go and assembly
+/usr/local/go/src/math/erf.go:274:6: Erfc defined in both Go and assembly
+```
+
+
+try to switch to go 1.18. 
+
+Make sure not only $GOPATH but also $GOPATH/bin are in your system $PATH, otherwise `staticcheck` would fail.
+
+## Build operator container
+
+Set environment variables
+
+```sh
+export DOCKER_HUB_REPO=<eg. mybuildx>
+```
+
+## Build container and push container
+
+```sh
+make container deploy
+```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you get errors like
 ```
 
 
-try to switch to go 1.18. 
+try to switch to go 1.19. 
 
 Make sure not only $GOPATH but also $GOPATH/bin are in your system $PATH, otherwise `staticcheck` would fail.
 

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -21,6 +21,7 @@ import (
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	ocp_secv1 "github.com/openshift/api/security/v1"
+	"github.com/sirupsen/logrus"
 
 	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 	coreops "github.com/portworx/sched-ops/k8s/core"
@@ -6012,7 +6013,7 @@ func TestCSIInstallWithCustomKubeletDir(t *testing.T) {
 		},
 	}
 
-	err = driver.SetDefaultsOnStorageCluster(cluster)
+	driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 
 	err = driver.PreInstall(cluster)

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -5949,6 +5949,88 @@ func TestCSI_0_3_NodeAffinityChange(t *testing.T) {
 	require.Nil(t, csiStatefulSet.Spec.Template.Spec.Affinity)
 }
 
+func TestCSIInstallWithCustomKubeletDir(t *testing.T) {
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.11.4",
+	}
+	nodeName := "testNode"
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	customKubeletPath := "/data/kubelet"
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "false",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/image:2.1.2",
+			Placement: &corev1.PlacementSpec{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "px/enabled",
+										Operator: v1.NodeSelectorOpNotIn,
+										Values:   []string{"false"},
+									},
+									{
+										Key:      "node-role.kubernetes.io/master",
+										Operator: v1.NodeSelectorOpDoesNotExist,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			CSI: &corev1.CSISpec{
+				Enabled: true,
+			},
+			Kvdb: &corev1.KvdbSpec{
+				Internal: true,
+			},
+			CommonConfig: corev1.CommonConfig{
+				Env: []v1.EnvVar{
+					{
+						Name:  pxutil.EnvKeyKubeletDir,
+						Value: customKubeletPath,
+					},
+				},
+			},
+		},
+	}
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+
+	spec, err := driver.GetStoragePodSpec(cluster, nodeName)
+	require.NoError(t, err)
+	logrus.Infof("Volumes %+v", spec.Volumes)
+
+	// CSI driver path
+	var ok bool
+	for _, v := range spec.Volumes {
+		if v.Name == "csi-driver-path" && v.HostPath.Path == customKubeletPath+"/csi-plugins/com.openstorage.pxd" {
+			ok = true
+		}
+	}
+	require.True(t, ok)
+}
+
 func TestPrometheusUpgradeDefaultDesiredImages(t *testing.T) {
 	versionClient := fakek8sclient.NewSimpleClientset()
 	coreops.SetInstance(coreops.New(versionClient))

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -6016,6 +6016,7 @@ func TestCSIInstallWithCustomKubeletDir(t *testing.T) {
 	require.NoError(t, err)
 
 	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
 
 	// CSI StatefulSet
 	statefulSetList := &appsv1.StatefulSetList{}

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -90,6 +90,84 @@ func TestBasicRuncPodSpec(t *testing.T) {
 	assertPodSpecEqual(t, expected, &actual)
 }
 
+func TestPodSpecWithCustomKubeletDir(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	// expected := getExpectedPodSpecFromDaemonset(t, "testspec/runc.yaml")
+	nodeName := "testNode"
+	customKubeletPath := "/data/kubelet"
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-system",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/oci-monitor:2.0.3.4",
+			Placement: &corev1.PlacementSpec{
+				NodeAffinity: &v1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+						NodeSelectorTerms: []v1.NodeSelectorTerm{
+							{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									{
+										Key:      "px/enabled",
+										Operator: v1.NodeSelectorOpNotIn,
+										Values:   []string{"false"},
+									},
+									{
+										Key:      "node-role.kubernetes.io/master",
+										Operator: v1.NodeSelectorOpDoesNotExist,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			CSI: &corev1.CSISpec{
+				Enabled: true,
+			},
+			Kvdb: &corev1.KvdbSpec{
+				Internal: true,
+			},
+			SecretsProvider: stringPtr("k8s"),
+			CommonConfig: corev1.CommonConfig{
+				Storage: &corev1.StorageSpec{
+					UseAll:        boolPtr(true),
+					ForceUseDisks: boolPtr(true),
+				},
+				Env: []v1.EnvVar{
+					{
+						Name:  "TEST_KEY",
+						Value: "TEST_VALUE",
+					},
+					{
+						Name:  pxutil.EnvKeyKubeletDir,
+						Value: customKubeletPath,
+					},
+				},
+				RuntimeOpts: map[string]string{
+					"op1": "10",
+				},
+			},
+		},
+	}
+
+	driver := portworx{}
+
+	actual, err := driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+
+	// CSI driver path
+	var ok bool
+	for _, v := range actual.Volumes {
+		if v.Name == "csi-driver-path" && v.VolumeSource.HostPath.Path == customKubeletPath+"/csi-plugins/com.openstorage.pxd" {
+			ok = true
+		}
+	}
+	require.True(t, ok)
+
+}
+
 func TestPodSpecWithImagePullSecrets(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	nodeName := "testNode"

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -398,14 +398,14 @@ func StartPort(cluster *corev1.StorageCluster) int {
 
 // KubeletPath returns the kubelet path
 func KubeletPath(cluster *corev1.StorageCluster) string {
-	if IsPKS(cluster) {
-		return "/var/vcap/data/kubelet"
-	}
-
 	for _, env := range cluster.Spec.Env {
 		if env.Name == EnvKeyKubeletDir && len(env.Value) > 0 {
 			return env.Value
 		}
+	}
+
+	if IsPKS(cluster) {
+		return "/var/vcap/data/kubelet"
 	}
 
 	return "/var/lib/kubelet"

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -66,6 +66,8 @@ const (
 	EssentialsUserIDKey = "px-essen-user-id"
 	// EssentialsOSBEndpointKey is the secret key for Essentials OSB endpoint
 	EssentialsOSBEndpointKey = "px-osb-endpoint"
+	// EnvKeyKubeletDir env var to set custom kubelet directory
+	EnvKeyKubeletDir = "KUBELET_DIR"
 
 	// AnnotationIsPKS annotation indicating whether it is a PKS cluster
 	AnnotationIsPKS = pxAnnotationPrefix + "/is-pks"
@@ -399,6 +401,13 @@ func KubeletPath(cluster *corev1.StorageCluster) string {
 	if IsPKS(cluster) {
 		return "/var/vcap/data/kubelet"
 	}
+
+	for _, env := range cluster.Spec.Env {
+		if env.Name == EnvKeyKubeletDir && len(env.Value) > 0 {
+			return env.Value
+		}
+	}
+
 	return "/var/lib/kubelet"
 }
 


### PR DESCRIPTION
Signed-off-by: Shivanjan Chakravorty [schakravorty@purestorage.com](mailto:schakravorty@purestorage.com)

What this PR does / why we need it:
PX Operator allows to pass a non standard kubelet config path and setup the csi sidecars accordingly

Which issue(s) this PR fixes
PX Operator should allow to pass a non standard kubelet config path and setup the csi sidecars accordingly

Closes https://github.com/libopenstorage/operator/pull/879