### PR TITLE
[PWX-28134] Update k8s min version for PDB

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -299,7 +299,7 @@ func TestRegisterDeprecatedCRD(t *testing.T) {
 func TestKubernetesVersionValidation(t *testing.T) {
 	fakeClient := fakek8sclient.NewSimpleClientset()
 	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &kversion.Info{
-		GitVersion: "v1.11.99",
+		GitVersion: "v1.20.99",
 	}
 	coreops.SetInstance(coreops.New(fakeClient))
 

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -82,7 +82,7 @@ const (
 	crdBasePath                         = "/crds"
 	deprecatedCRDBasePath               = "/crds/deprecated"
 	storageClusterCRDFile               = "core_v1_storagecluster_crd.yaml"
-	minSupportedK8sVersion              = "1.12.0"
+	minSupportedK8sVersion              = "1.21.0"
 )
 
 var _ reconcile.Reconciler = &Controller{}

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -341,6 +341,10 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 		schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 		require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
+		minK8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+		if k8sVersion.GreaterThanOrEqual(minK8sVersion) {
+			expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = "k8s.gcr.io/kube-scheduler-amd64:v1.21.0"
+		}
 		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
 			expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minSupportedK8sVersion, k8sVersionStr, -1)
 		require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
@@ -919,7 +923,7 @@ func TestStorkCustomRegistryChange(t *testing.T) {
 	err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		customRegistry+"/gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
+		customRegistry+"/k8s.gcr.io/kube-scheduler-amd64:v"+k8sVersion.String(),
 		schedDeployment.Spec.Template.Spec.Containers[0].Image,
 	)
 
@@ -942,7 +946,7 @@ func TestStorkCustomRegistryChange(t *testing.T) {
 	err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		customRegistry+"/gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
+		customRegistry+"/k8s.gcr.io/kube-scheduler-amd64:v"+k8sVersion.String(),
 		schedDeployment.Spec.Template.Spec.Containers[0].Image,
 	)
 
@@ -964,7 +968,7 @@ func TestStorkCustomRegistryChange(t *testing.T) {
 	err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		"gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
+		"k8s.gcr.io/kube-scheduler-amd64:v"+k8sVersion.String(),
 		schedDeployment.Spec.Template.Spec.Containers[0].Image,
 	)
 
@@ -989,7 +993,7 @@ func TestStorkCustomRegistryChange(t *testing.T) {
 	err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		customRegistry+"/gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
+		customRegistry+"/k8s.gcr.io/kube-scheduler-amd64:v"+k8sVersion.String(),
 		schedDeployment.Spec.Template.Spec.Containers[0].Image,
 	)
 }
@@ -1097,7 +1101,7 @@ func TestStorkCustomRepoRegistryChange(t *testing.T) {
 	err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		"gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
+		"k8s.gcr.io/kube-scheduler-amd64:v"+k8sVersion.String(),
 		schedDeployment.Spec.Template.Spec.Containers[0].Image,
 	)
 
@@ -2132,7 +2136,7 @@ func TestStorkSchedulerRollbackImageChange(t *testing.T) {
 	err = testutil.Get(k8sClient, deployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		"gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
+		"k8s.gcr.io/kube-scheduler-amd64:v"+k8sVersion.String(),
 		deployment.Spec.Template.Spec.Containers[0].Image,
 	)
 
@@ -2147,7 +2151,7 @@ func TestStorkSchedulerRollbackImageChange(t *testing.T) {
 	err = testutil.Get(k8sClient, deployment, storkSchedDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t,
-		"gcr.io/google_containers/kube-scheduler-amd64:v"+k8sVersion.String(),
+		"k8s.gcr.io/kube-scheduler-amd64:v"+k8sVersion.String(),
 		deployment.Spec.Template.Spec.Containers[0].Image,
 	)
 }

--- a/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
@@ -36,7 +36,7 @@ spec:
         - --policy-configmap=stork-config
         - --policy-configmap-namespace=kube-test
         - --lock-object-name=stork-scheduler
-        image: gcr.io/google_containers/kube-scheduler-amd64:v1.12.0
+        image: gcr.io/google_containers/kube-scheduler-amd64:v1.21.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
PDB v1 was supported starting k8s 1.21, this PR changed min k8s version from 1.12.0 to 1.21.0 so it throws an error at a lower version than 1.21. 

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

