### PR TITLE
PTX-15283 Improve validation for PX pods and add automation test case to cover issue that was found in CEE-744

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -640,14 +640,14 @@ func ValidateStorageCluster(
 		return err
 	}
 
-	// Validate StorageNodes
-	if err = validateStorageNodes(pxImageList, clusterSpec, timeout, interval); err != nil {
+	// Get list of expected Portworx node names
+	expectedPxNodeList, err := GetExpectedPxNodeList(clusterSpec)
+	if err != nil {
 		return err
 	}
 
-	// Get list of expected Portworx node names
-	expectedPxNodeNameList, err := GetExpectedPxNodeNameList(clusterSpec)
-	if err != nil {
+	// Validate StorageNodes
+	if err = validateStorageNodes(pxImageList, clusterSpec, len(expectedPxNodeList), timeout, interval); err != nil {
 		return err
 	}
 
@@ -655,12 +655,12 @@ func ValidateStorageCluster(
 	podTestFn := func(pod v1.Pod) bool {
 		return coreops.Instance().IsPodReady(pod)
 	}
-	if err = validateStorageClusterPods(clusterSpec, expectedPxNodeNameList, timeout, interval, podTestFn); err != nil {
+	if err = validateStorageClusterPods(clusterSpec, expectedPxNodeList, timeout, interval, podTestFn); err != nil {
 		return err
 	}
 
 	// Validate Portworx nodes
-	if err = validatePortworxNodes(liveCluster, len(expectedPxNodeNameList)); err != nil {
+	if err = validatePortworxNodes(liveCluster, len(expectedPxNodeList)); err != nil {
 		return err
 	}
 
@@ -681,7 +681,70 @@ func ValidateStorageCluster(
 	return nil
 }
 
-func validateStorageNodes(pxImageList map[string]string, cluster *corev1.StorageCluster, timeout, interval time.Duration) error {
+// ValidatePxPodsAreReadyOnGivenNodes takes list of node and validates PX pods are present and ready on these nodes
+func ValidatePxPodsAreReadyOnGivenNodes(clusterSpec *corev1.StorageCluster, nodeList []v1.Node, timeout, interval time.Duration) error {
+	labelSelector := map[string]string{"name": "portworx"}
+	expectedPxPodCount := len(nodeList)
+
+	t := func() (interface{}, bool, error) {
+		var podsReady []string
+		var podsNotReady []string
+
+		// Get StorageCluster
+		cluster, err := operatorops.Instance().GetStorageCluster(clusterSpec.Name, clusterSpec.Namespace)
+		if err != nil {
+			return "", true, err
+		}
+
+		for _, node := range nodeList {
+			// Get PX pods from node
+			podList, err := coreops.Instance().GetPodsByNodeAndLabels(node.Name, clusterSpec.Namespace, labelSelector)
+			if err != nil {
+				return nil, true, err
+			}
+
+			// Validate PX pod is found on node and only 1
+			if len(podList.Items) == 0 {
+				return nil, true, fmt.Errorf("Didn't find any Portworx pods on node [%s]", node.Name)
+			} else if len(podList.Items) > 1 {
+				return nil, true, fmt.Errorf("Found [%d] Portworx pods on node [%s], should only have 1 per node", len(podList.Items), node.Name)
+			}
+			pxPod := podList.Items[0]
+
+			// Validate PX pod has right owner
+			for _, owner := range pxPod.OwnerReferences {
+				if owner.UID != cluster.UID {
+					return nil, true, fmt.Errorf("Failed to match pod owner reference UID [%s] to StorageCluster UID [%s]", owner.UID, cluster.UID)
+				}
+			}
+
+			// Get list of ready and not ready PX pods
+			logrus.Infof("Found Portworx pod [%s] on node [%s]", pxPod.Name, node.Name)
+			if coreops.Instance().IsPodReady(pxPod) {
+				logrus.Infof("Portworx pod [%s] is ready on node [%s]", pxPod.Name, node.Name)
+				podsReady = append(podsReady, pxPod.Name)
+			} else {
+				logrus.Infof("Portworx pod [%s] is not ready on node [%s]", pxPod.Name, node.Name)
+				podsNotReady = append(podsNotReady, pxPod.Name)
+			}
+		}
+
+		// Validate count of PX pods equals to number of expected nodes
+		if len(podsReady) == expectedPxPodCount {
+			logrus.Infof("All Portworx pods are ready: %s", podsReady)
+			return nil, false, nil
+		}
+		return nil, true, fmt.Errorf("Some Portworx pods are still not ready: %s. Expected ready pods: %d, Got: %d", podsNotReady, expectedPxPodCount, len(podsReady))
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, timeout, interval); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateStorageNodes(pxImageList map[string]string, cluster *corev1.StorageCluster, expectedNumberOfStorageNodes int, timeout, interval time.Duration) error {
 	var expectedPxVersion string
 
 	imageOverride := ""
@@ -727,8 +790,8 @@ func validateStorageNodes(pxImageList map[string]string, cluster *corev1.Storage
 			readyNodes++
 		}
 
-		if readyNodes != len(storageNodeList.Items) {
-			return nil, true, fmt.Errorf("waiting for all storagenodes to be ready: %d/%d", readyNodes, len(storageNodeList.Items))
+		if readyNodes != expectedNumberOfStorageNodes {
+			return nil, true, fmt.Errorf("waiting for all storagenodes to be ready: %d/%d", readyNodes, expectedNumberOfStorageNodes)
 		}
 		return nil, false, nil
 	}
@@ -947,10 +1010,11 @@ type podTestFnType func(pod v1.Pod) bool
 
 func validateStorageClusterPods(
 	clusterSpec *corev1.StorageCluster,
-	expectedPxNodeNameList []string,
+	expectedPxNodeList []v1.Node,
 	timeout, interval time.Duration,
 	podTestFn podTestFnType,
 ) error {
+	expectedPxNodeNameList := ConvertNodeListToNodeNameList(expectedPxNodeList)
 	t := func() (interface{}, bool, error) {
 		cluster, err := operatorops.Instance().GetStorageCluster(clusterSpec.Name, clusterSpec.Namespace)
 		if err != nil {
@@ -1113,14 +1177,15 @@ func validatePortworxAPIService(cluster *corev1.StorageCluster, timeout, interva
 	return nil
 }
 
-// GetExpectedPxNodeNameList will get the list of node names that should be included
+// GetExpectedPxNodeList will get the list of nodes that should be included
 // in the given Portworx cluster, by seeing if each non-master node matches the given
 // node selectors and affinities.
-func GetExpectedPxNodeNameList(cluster *corev1.StorageCluster) ([]string, error) {
-	var nodeNameListWithPxPods []string
+func GetExpectedPxNodeList(cluster *corev1.StorageCluster) ([]v1.Node, error) {
+	var nodeListWithPxPods []v1.Node
+
 	nodeList, err := coreops.Instance().GetNodes()
 	if err != nil {
-		return nodeNameListWithPxPods, err
+		return nodeListWithPxPods, err
 	}
 
 	dummyPod := &v1.Pod{}
@@ -1161,11 +1226,21 @@ func GetExpectedPxNodeNameList(cluster *corev1.StorageCluster) ([]string, error)
 
 		matches, err := affinityhelper.GetRequiredNodeAffinity(dummyPod).Match(&node)
 		if err == nil && matches {
-			nodeNameListWithPxPods = append(nodeNameListWithPxPods, node.Name)
+			nodeListWithPxPods = append(nodeListWithPxPods, node)
 		}
 	}
 
-	return nodeNameListWithPxPods, nil
+	return nodeListWithPxPods, nil
+}
+
+// ConvertNodeListToNodeNameList takes list of nodes and return list of node names
+func ConvertNodeListToNodeNameList(nodeList []v1.Node) []string {
+	var nodeNameList []string
+
+	for _, node := range nodeList {
+		nodeNameList = append(nodeNameList, node.Name)
+	}
+	return nodeNameList
 }
 
 // GetFullVersion returns the full kubernetes server version
@@ -3927,7 +4002,7 @@ func ValidateStorageClusterFailedEvents(
 	}
 
 	// Get list of expected Portworx node names
-	expectedPxNodeNameList, err := GetExpectedPxNodeNameList(clusterSpec)
+	expectedPxNodeList, err := GetExpectedPxNodeList(clusterSpec)
 	if err != nil {
 		return err
 	}
@@ -3945,7 +4020,7 @@ func ValidateStorageClusterFailedEvents(
 		}
 		return false
 	}
-	if err = validateStorageClusterPods(clusterSpec, expectedPxNodeNameList, timeout, interval, podTestFn); err != nil {
+	if err = validateStorageClusterPods(clusterSpec, expectedPxNodeList, timeout, interval, podTestFn); err != nil {
 		return err
 	}
 

--- a/test/integration_test/regression_test.go
+++ b/test/integration_test/regression_test.go
@@ -40,13 +40,8 @@ var regressionTestCases = []types.TestCase{
 	},
 }
 
-func shouldSkipRegressionTests(tc *types.TestCase) bool {
-	return false
-}
-
 func TestRegression(t *testing.T) {
 	for _, tc := range regressionTestCases {
-		tc.ShouldSkip = shouldSkipRegressionTests
 		tc.RunTest(t)
 	}
 }
@@ -80,7 +75,8 @@ func NodeOutOfCpu(tc *types.TestCase) func(*testing.T) {
 
 		// Deploy StorageCluster
 		logrus.Infof("Deploying StorageCluster once [%s]", cluster.Name)
-		cluster = ci_utils.DeployStorageCluster(cluster, ci_utils.PxSpecImages, t)
+		cluster, err = ci_utils.DeployStorageCluster(cluster, ci_utils.PxSpecImages)
+		require.NoError(t, err)
 
 		// Validate StorageCluster is failing, using shorter timeout than usual (ci_utils.DefaultValidateDeployTimeout, ci_utils.DefaultValidateDeployRetryInterval)
 		//if err := testutil.ValidateStorageCluster(ci_utils.PxSpecImages, cluster, 5*time.Minute, 30*time.Second, true); err == nil {

--- a/test/integration_test/regression_test.go
+++ b/test/integration_test/regression_test.go
@@ -1,0 +1,321 @@
+//go:build integrationtest
+// +build integrationtest
+
+package integrationtest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
+	"github.com/libopenstorage/operator/test/integration_test/types"
+	ci_utils "github.com/libopenstorage/operator/test/integration_test/utils"
+	appops "github.com/portworx/sched-ops/k8s/apps"
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/portworx/sched-ops/task"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var regressionTestCases = []types.TestCase{
+	{
+		TestName:        "NodeOutOfCpu",
+		TestrailCaseIDs: []string{""},
+		TestSpec: func(t *testing.T) interface{} {
+			// Construct StorageCluster
+			cluster := &corev1.StorageCluster{}
+			cluster.Name = clusterName
+			err := ci_utils.ConstructStorageCluster(cluster, ci_utils.PxSpecGenURL, ci_utils.PxSpecImages)
+			require.NoError(t, err)
+			return cluster
+		},
+		TestFunc: NodeOutOfCpu,
+	},
+}
+
+func shouldSkipRegressionTests(tc *types.TestCase) bool {
+	return false
+}
+
+func TestRegression(t *testing.T) {
+	for _, tc := range regressionTestCases {
+		tc.ShouldSkip = shouldSkipRegressionTests
+		tc.RunTest(t)
+	}
+}
+
+func NodeOutOfCpu(tc *types.TestCase) func(*testing.T) {
+	return func(t *testing.T) {
+		// Get the StorageCluster to start with
+		testSpec := tc.TestSpec(t)
+		cluster, ok := testSpec.(*corev1.StorageCluster)
+		require.True(t, ok)
+
+		// Pick a random node and label it with 'insufficient=cpu'
+		nodeNameWithLabel := ci_utils.AddLabelToRandomNode(t, "insufficient", "cpu")
+
+		// Create app deployment with node affinity to match above node
+		appDeployment, err := deployAppWithNodeAffinity()
+		require.NoError(t, err)
+
+		// Scale app 1 pod at a time until new pod is Pending due to '1 Insufficient cpu' message in status
+		err = scaleAppUntilInsufficientCpu(appDeployment)
+		require.NoError(t, err)
+
+		// Set resources for StorageCluster
+		resources := &v1.ResourceRequirements{
+			Requests: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceMemory: resource.MustParse("2Gi"),
+				v1.ResourceCPU:    resource.MustParse("2000m"),
+			},
+		}
+		cluster.Spec.Resources = resources
+
+		// Deploy StorageCluster
+		logrus.Infof("Deploying StorageCluster once [%s]", cluster.Name)
+		cluster = ci_utils.DeployStorageCluster(cluster, ci_utils.PxSpecImages, t)
+
+		// Validate StorageCluster is failing, using shorter timeout than usual (ci_utils.DefaultValidateDeployTimeout, ci_utils.DefaultValidateDeployRetryInterval)
+		//if err := testutil.ValidateStorageCluster(ci_utils.PxSpecImages, cluster, 5*time.Minute, 30*time.Second, true); err == nil {
+		//	require.NoError(t, fmt.Errorf("Was expecting to fail validation deployment, but it was successful"))
+		//}
+		//logrus.Infof("Validation for StorageCluster [%s] failed as expected", cluster.Name)
+
+		// Validate PX pods are healthy on all nodes except the labeled node
+		err = validatePxPodOnNodesExceptLabelenNode(cluster, nodeNameWithLabel, cluster.Namespace)
+		require.NoError(t, err)
+
+		// Get more info PX pod on a node we deploying apps on, PX pod shouldn't be provisioning due to 'Insufficient cpu'
+		err = validatePxPodOnNodeIsOutOfCpu(nodeNameWithLabel, cluster.Namespace)
+		require.NoError(t, err)
+
+		// Scale down or delete the app, will need to check what is better
+		err = deleteAndValidateAppDeployment(appDeployment)
+		require.NoError(t, err)
+
+		// Validate all PX pods are up and running
+		err = testutil.ValidateStorageCluster(ci_utils.PxSpecImages, cluster, ci_utils.DefaultValidateDeployTimeout, ci_utils.DefaultValidateDeployRetryInterval, true)
+		require.NoError(t, err)
+
+		// Remove 'insufficient=cpu' label from node
+		ci_utils.RemoveLabelFromNode(t, nodeNameWithLabel, "insufficient")
+
+		// Delete and validate StorageCluster deletion
+		ci_utils.UninstallAndValidateStorageCluster(cluster, t)
+	}
+}
+
+func validatePxPodOnNodesExceptLabelenNode(cluster *corev1.StorageCluster, nodeNameToExclude, namespace string) error {
+	var expectedNodeList []v1.Node
+
+	// Get nodes we expect PX to be deployed on
+	nodeList, err := testutil.GetExpectedPxNodeList(cluster)
+	if err != nil {
+		return err
+	}
+
+	// Exclude labeled node from the list
+	for _, node := range nodeList {
+		if node.Name == nodeNameToExclude {
+			continue
+		}
+		expectedNodeList = append(expectedNodeList, node)
+	}
+
+	// Validate PX pods are running on expected nodes
+	if err := testutil.ValidatePxPodsAreReadyOnGivenNodes(cluster, expectedNodeList, ci_utils.DefaultValidateDeployTimeout, ci_utils.DefaultValidateDeployRetryInterval); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validatePxPodOnNodeIsOutOfCpu(nodeName, namespace string) error {
+	labelSelector := map[string]string{"name": "portworx"}
+
+	logrus.Infof("Validate PX pod on node [%s] is in Out of CPU state", nodeName)
+
+	t := func() (interface{}, bool, error) {
+		podList, err := coreops.Instance().GetPodsByNodeAndLabels(nodeName, namespace, labelSelector)
+		if err != nil {
+			return nil, true, err
+		}
+		if len(podList.Items) == 0 {
+			return nil, true, fmt.Errorf("Didn't find any PX pods on node [%s]", nodeName)
+		}
+		pod := podList.Items[0]
+		logrus.Infof("Found PX pod [%s] on node [%s]", pod.Name, nodeName)
+		if !coreops.Instance().IsPodReady(pod) {
+			logrus.Infof("PX pod [%s] is in [%s] state due to [%s], with message [%s]", pod.Name, pod.Status.Phase, pod.Status.Reason, pod.Status.Message)
+			if strings.Contains(pod.Status.Message, "Insufficient cpu") || strings.Contains(pod.Status.Message, "enough resource: cpu") || pod.Status.Reason == "OutOfcpu" {
+				logrus.Infof("PX pod [%s] is failing to be created due to expected reason [%s], message [%s]", pod.Name, pod.Status.Reason, pod.Status.Message)
+				return nil, false, nil
+			}
+			return nil, true, fmt.Errorf("Failed to match expected reason and message for failing in PX pod [%s], reason [%s], message [%s]", pod.Name, pod.Status.Reason, pod.Status.Message)
+		}
+		return nil, false, fmt.Errorf("PX Pod [%s] should not be in ready state, it should be failing", pod.Name)
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, 5*time.Minute, 5*time.Second); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deployAppWithNodeAffinity() (*appsv1.Deployment, error) {
+	var appDeploymentSpec *appsv1.Deployment
+
+	logrus.Infof("Configuring and creating nginx deployment with custom resouces and node affinity")
+
+	// Parse object specs
+	appObjects, err := ci_utils.ParseApplicationSpecs("nginx-no-volumes")
+	if err != nil {
+		return nil, err
+	}
+
+	// Get app spec objects
+	for _, appObject := range appObjects {
+		if object, ok := appObject.(*appsv1.Deployment); ok {
+			appDeploymentSpec = object
+			break
+		}
+	}
+
+	// Start with replica 1
+	replicasCount := int32(1)
+	appDeploymentSpec.Spec.Replicas = &replicasCount
+
+	// Set resources
+	resources := v1.ResourceRequirements{
+		Requests: map[v1.ResourceName]resource.Quantity{
+			v1.ResourceMemory: resource.MustParse("1Gi"),
+			v1.ResourceCPU:    resource.MustParse("2000m"),
+		},
+		Limits: map[v1.ResourceName]resource.Quantity{
+			v1.ResourceMemory: resource.MustParse("1Gi"),
+			v1.ResourceCPU:    resource.MustParse("2000m"),
+		},
+	}
+
+	// Set node affinity
+	nodeAffinity := &v1.Affinity{
+		NodeAffinity: &v1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+				NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{
+						MatchExpressions: []v1.NodeSelectorRequirement{
+							{
+								Key:      "insufficient",
+								Operator: v1.NodeSelectorOpIn,
+								Values:   []string{"cpu"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	appDeploymentSpec.Spec.Template.Spec.Affinity = nodeAffinity
+
+	// Set resources
+	for i, container := range appDeploymentSpec.Spec.Template.Spec.Containers {
+		if container.Name == "nginx" {
+			appDeploymentSpec.Spec.Template.Spec.Containers[i].Resources = resources
+			break
+		}
+	}
+
+	// Create app deployment
+	appDeployment, err := appops.Instance().CreateDeployment(appDeploymentSpec, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate app deployment
+	err = appops.Instance().ValidateDeployment(appDeploymentSpec, 2*time.Minute, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Successfully created and validated nginx deployment")
+	return appDeployment, nil
+}
+
+func deleteAndValidateAppDeployment(appDeployment *appsv1.Deployment) error {
+	logrus.Infof("Delete nginx deployment")
+
+	// Delete app deployment
+	err := appops.Instance().DeleteDeployment(appDeployment.Name, appDeployment.Namespace)
+	if err != nil {
+		return err
+	}
+
+	// Va;idate app deployment is terminated
+	err = appops.Instance().ValidateTerminatedDeployment(appDeployment, 5*time.Minute, 5*time.Second)
+	if err != nil {
+		return err
+	}
+
+	logrus.Infof("Successfully deleted and validated nginx deployment")
+	return nil
+}
+
+func scaleAppUntilInsufficientCpu(appDeployment *appsv1.Deployment) error {
+	logrus.Infof("Scaling up app [%s] until we cannot anymore due to CPU resource limits", appDeployment.Name)
+
+	t := func() (interface{}, bool, error) {
+		appDeployment, err := appops.Instance().GetDeployment(appDeployment.Name, appDeployment.Namespace)
+		if err != nil {
+			return nil, true, err
+		}
+
+		// Scale deployment replica by 1
+		currentDeploymentReplicasCount := int(*appDeployment.Spec.Replicas)
+		newDeploymentReplicaseCount := currentDeploymentReplicasCount + 1
+		replicasCount := int32(newDeploymentReplicaseCount)
+		appDeployment.Spec.Replicas = &replicasCount
+		logrus.Infof("Scaling up app [%s] replicas from [%d] to [%d]", appDeployment.Name, currentDeploymentReplicasCount, newDeploymentReplicaseCount)
+		appDeployment, err = appops.Instance().UpdateDeployment(appDeployment)
+		if err != nil {
+			return nil, true, err
+		}
+
+		err = appops.Instance().ValidateDeployment(appDeployment, 30*time.Second, 5*time.Second)
+		if err != nil {
+			pods, err := appops.Instance().GetDeploymentPods(appDeployment)
+			if err != nil {
+				return nil, true, err
+			}
+			for _, pod := range pods {
+				if !coreops.Instance().IsPodReady(pod) {
+					logrus.Infof("Found pod [%s] in not ready state", pod.Name)
+					for _, podCondition := range pod.Status.Conditions {
+						logrus.Infof("Pod [%s] message [%v]", pod.Name, podCondition.Message)
+						if strings.Contains(podCondition.Message, "Insufficient cpu") {
+							logrus.Infof("Successfully hit an issue with app scaling where pod [%s] is unable to get provisioned due to Insufficient CPU, message [%v]", pod.Name, podCondition.Message)
+							return nil, false, nil
+						}
+					}
+					return nil, true, fmt.Errorf("Failed to find expected message for pod [%s] about Insufficient CPU", pod.Name)
+				}
+			}
+			return nil, true, fmt.Errorf("Failed to find not ready pods, need to create more pods")
+		}
+		return nil, true, fmt.Errorf("Deployment is healthy, need to create more pods..")
+	}
+
+	if _, err := task.DoRetryWithTimeout(t, 5*time.Minute, 10*time.Second); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/integration_test/testspec/apps/nginx-no-volumes/nginx-no-volumes-app.yaml
+++ b/test/integration_test/testspec/apps/nginx-no-volumes/nginx-no-volumes-app.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1Gi
+          requests:
+            cpu: "2"
+            memory: 1Gi

--- a/test/integration_test/utils/constants.go
+++ b/test/integration_test/utils/constants.go
@@ -72,7 +72,7 @@ const (
 	// DefaultValidateDeployTimeout is a default timeout for deployment validation
 	DefaultValidateDeployTimeout = 15 * time.Minute
 	// DefaultValidateDeployRetryInterval is a default retry interval for deployment validation
-	DefaultValidateDeployRetryInterval = 15 * time.Second
+	DefaultValidateDeployRetryInterval = 30 * time.Second
 	// DefaultValidateUpgradeTimeout is a default timeout for upgrade validation
 	DefaultValidateUpgradeTimeout = 30 * time.Minute
 	// DefaultValidateUpgradeRetryInterval is a default retry interval for upgrade validation
@@ -84,7 +84,7 @@ const (
 	// DefaultValidateUninstallTimeout is a default timeout for uninstall validation
 	DefaultValidateUninstallTimeout = 15 * time.Minute
 	// DefaultValidateUninstallRetryInterval is a default retry interval for uninstall validation
-	DefaultValidateUninstallRetryInterval = 15 * time.Second
+	DefaultValidateUninstallRetryInterval = 30 * time.Second
 
 	// DefaultValidateComponentTimeout is a default timeout for component validation
 	DefaultValidateComponentTimeout = 10 * time.Minute

--- a/test/integration_test/utils/fafb_config.go
+++ b/test/integration_test/utils/fafb_config.go
@@ -141,10 +141,12 @@ func GenerateFleet(t *testing.T, namespace string,
 func PopulateStorageCluster(tc *types.TestCase, cluster *corev1.StorageCluster) error {
 	cluster.Name = MakeDNS1123Compatible(strings.Join(tc.TestrailCaseIDs, "-"))
 
-	names, err := testutil.GetExpectedPxNodeNameList(cluster)
+	nodes, err := testutil.GetExpectedPxNodeList(cluster)
 	if err != nil {
 		return err
 	}
+	names := testutil.ConvertNodeListToNodeNameList(nodes)
+
 	// Sort for consistent order between multiple tests
 	sort.Strings(names)
 


### PR DESCRIPTION
Improve validation for PX pods and add automation test case to cover issue that was found in CEE-744

Test case is to restrict from PX pods to be scheduled on a specific node due to resource limit (CPU) and then remove load to unblock CPU limit and validate PX is getting provisioned on the node as expected
Also some validation improvements

Signed-off-by: nikolaypopov <nikolay.popov86@gmail.com>
