### PR TITLE
[PWX-28868] Restart telemetry phonehome DaemonSet when ccm ConfigMap gets updated

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -218,7 +218,7 @@ func (c *autopilot) createConfigMap(
 		}
 	}
 
-	return k8sutil.CreateOrUpdateConfigMap(
+	_, err := k8sutil.CreateOrUpdateConfigMap(
 		c.k8sClient,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -232,6 +232,7 @@ func (c *autopilot) createConfigMap(
 		},
 		ownerRef,
 	)
+	return err
 }
 
 func (c *autopilot) createServiceAccount(

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -479,7 +479,8 @@ func (t *telemetry) createCollectorProxyConfigMap(
 	ownerRef *metav1.OwnerReference,
 ) error {
 	configMap := t.getCollectorProxyConfigMap(cluster, ownerRef)
-	return k8sutil.CreateOrUpdateConfigMap(t.k8sClient, configMap, ownerRef)
+	_, err := k8sutil.CreateOrUpdateConfigMap(t.k8sClient, configMap, ownerRef)
+	return err
 }
 
 func (t *telemetry) getCollectorProxyConfigMap(
@@ -619,7 +620,7 @@ forwardConfig:
 		CollectorConfigFileName: config,
 	}
 
-	return k8sutil.CreateOrUpdateConfigMap(
+	_, err := k8sutil.CreateOrUpdateConfigMap(
 		t.k8sClient,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -631,6 +632,7 @@ forwardConfig:
 		},
 		ownerRef,
 	)
+	return err
 }
 
 func (t *telemetry) createCCMJavaConfigMap(
@@ -714,7 +716,7 @@ func (t *telemetry) createCCMJavaConfigMap(
 		TelemetryArcusLocationFilename: getArcusTelemetryLocation(cluster),
 	}
 
-	return k8sutil.CreateOrUpdateConfigMap(
+	_, err := k8sutil.CreateOrUpdateConfigMap(
 		t.k8sClient,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -726,6 +728,7 @@ func (t *telemetry) createCCMJavaConfigMap(
 		},
 		ownerRef,
 	)
+	return err
 }
 
 func (t *telemetry) reconcileCCMJavaProxyConfigMap(
@@ -738,7 +741,7 @@ func (t *telemetry) reconcileCCMJavaProxyConfigMap(
 		return k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef)
 	}
 
-	return k8sutil.CreateOrUpdateConfigMap(
+	_, err := k8sutil.CreateOrUpdateConfigMap(
 		t.k8sClient,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -752,4 +755,5 @@ func (t *telemetry) reconcileCCMJavaProxyConfigMap(
 		},
 		ownerRef,
 	)
+	return err
 }

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -304,7 +304,7 @@ func (c *Controller) createStorkConfigMap(
 		dataKey = "policy.cfg"
 	}
 
-	return k8sutil.CreateOrUpdateConfigMap(
+	_, err = k8sutil.CreateOrUpdateConfigMap(
 		c.client,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -318,6 +318,7 @@ func (c *Controller) createStorkConfigMap(
 		},
 		ownerRef,
 	)
+	return err
 }
 
 func (c *Controller) createStorkSnapshotStorageClass() error {

--- a/pkg/migration/backup.go
+++ b/pkg/migration/backup.go
@@ -102,7 +102,7 @@ func (h *Handler) backup(configMapName, namespace string, overwrite bool) error 
 		"backup": sb.String(),
 	}
 
-	return k8sutil.CreateOrUpdateConfigMap(h.client,
+	_, err = k8sutil.CreateOrUpdateConfigMap(h.client,
 		&v1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      configMapName,
@@ -111,6 +111,7 @@ func (h *Handler) backup(configMapName, namespace string, overwrite bool) error 
 			Data: data,
 		},
 		nil)
+	return err
 }
 
 func (h *Handler) addObject(

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -536,13 +536,13 @@ func DeleteClusterRoleBinding(
 	return k8sClient.Delete(context.TODO(), crb)
 }
 
-// CreateOrUpdateConfigMap creates a config map if not present,
-// else updates it if it has changed
+// CreateOrUpdateConfigMap creates a config map if not present, else updates it if it has changed
+// returns whether data is modified
 func CreateOrUpdateConfigMap(
 	k8sClient client.Client,
 	configMap *v1.ConfigMap,
 	ownerRef *metav1.OwnerReference,
-) error {
+) (bool, error) {
 	existingConfigMap := &v1.ConfigMap{}
 	err := k8sClient.Get(
 		context.TODO(),
@@ -554,14 +554,14 @@ func CreateOrUpdateConfigMap(
 	)
 	if errors.IsNotFound(err) {
 		logrus.Infof("Creating %v ConfigMap", configMap.Name)
-		return k8sClient.Create(context.TODO(), configMap)
+		return false, k8sClient.Create(context.TODO(), configMap)
 	} else if err != nil {
-		return err
+		return false, err
 	}
 
 	enabled, err := strconv.ParseBool(existingConfigMap.Annotations[constants.AnnotationReconcileObject])
 	if err == nil && !enabled {
-		return nil
+		return false, nil
 	}
 
 	modified := !reflect.DeepEqual(configMap.Data, existingConfigMap.Data) ||
@@ -575,9 +575,9 @@ func CreateOrUpdateConfigMap(
 
 	if modified || len(configMap.OwnerReferences) > len(existingConfigMap.OwnerReferences) {
 		logrus.Infof("Updating %v ConfigMap", configMap.Name)
-		return k8sClient.Update(context.TODO(), configMap)
+		return modified, k8sClient.Update(context.TODO(), configMap)
 	}
-	return nil
+	return false, nil
 }
 
 // DeleteConfigMap deletes a config map if present and owned


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* when ccm config got updated during operator upgrade, phonehome doesn't reload the latest config, so restarting all phonehome pods as a workaround for now.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

