### PR TITLE
PWX-26956 handle telemetry cert owenrRef in storageCluster finalizer

### DIFF
--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -53,7 +53,7 @@ const (
 	// TelemetryArcusLocationFilename is name of the file storing the location of arcus endpoint to use
 	TelemetryArcusLocationFilename = "location"
 	// TelemetryCertName is name of the telemetry cert.
-	TelemetryCertName = "pure-telemetry-certs"
+	TelemetryCertName = pxutil.TelemetryCertName
 
 	defaultCollectorMemoryRequest = "64Mi"
 	defaultCollectorMemoryLimit   = "128Mi"

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -30,6 +30,8 @@ import (
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -246,6 +248,9 @@ const (
 	// EnvKeyPortworxEnableTLS is a flag for enabling operator TLS with PX
 	EnvKeyPortworxEnableTLS  = "PX_ENABLE_TLS"
 	EnvKeyPortworxEnforceTLS = "PX_ENFORCE_TLS"
+
+	// TelemetryCertName is name of the telemetry cert.
+	TelemetryCertName = "pure-telemetry-certs"
 )
 
 var (
@@ -1238,4 +1243,54 @@ func IsFreshInstall(cluster *corev1.StorageCluster) bool {
 		cluster.Status.Phase == string(corev1.ClusterStateInit) ||
 		(cluster.Status.Phase == string(corev1.ClusterStateDegraded) &&
 			util.GetStorageClusterCondition(cluster, PortworxComponentName, corev1.ClusterConditionTypeRuntimeState) == nil)
+}
+
+func SetTelemetryCertOwnerRef(
+	cluster *corev1.StorageCluster,
+	ownerRef *metav1.OwnerReference,
+	k8sClient client.Client,
+) error {
+	secret := &v1.Secret{}
+	err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      TelemetryCertName,
+			Namespace: cluster.Namespace,
+		},
+		secret,
+	)
+
+	// The cert is created after ccm container starts, so we may not have it for a while.
+	if errors.IsNotFound(err) {
+		logrus.Infof("telemetry cert %s/%s not found", cluster.Namespace, TelemetryCertName)
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// Only delete the secret when delete strategy is UninstallAndWipe
+	deleteCert := cluster.Spec.DeleteStrategy != nil &&
+		cluster.Spec.DeleteStrategy.Type == corev1.UninstallAndWipeStorageClusterStrategyType
+
+	referenceMap := make(map[types.UID]*metav1.OwnerReference)
+	for _, ref := range secret.OwnerReferences {
+		referenceMap[ref.UID] = &ref
+	}
+
+	_, ownerSet := referenceMap[ownerRef.UID]
+	if deleteCert && !ownerSet {
+		referenceMap[ownerRef.UID] = ownerRef
+	} else if !deleteCert && ownerSet {
+		delete(referenceMap, ownerRef.UID)
+	} else {
+		return nil
+	}
+
+	var references []metav1.OwnerReference
+	for _, v := range referenceMap {
+		references = append(references, *v)
+	}
+	secret.OwnerReferences = references
+
+	return k8sClient.Update(context.TODO(), secret)
 }

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -3388,6 +3388,108 @@ func TestDeleteStorageClusterWithFinalizers(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 }
 
+func TestDeleteStorageClusterShouldSetTelemetryCertOwnerRef(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cluster := createStorageCluster()
+	cluster.Spec.DeleteStrategy = &corev1.StorageClusterDeleteStrategy{
+		Type: corev1.UninstallAndWipeStorageClusterStrategyType,
+	}
+	deletionTimeStamp := metav1.Now()
+	cluster.DeletionTimestamp = &deletionTimeStamp
+
+	driverName := "mock-driver"
+	storageLabels := map[string]string{
+		constants.LabelKeyClusterName: cluster.Name,
+		constants.LabelKeyDriverName:  driverName,
+	}
+
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient := testutil.FakeK8sClient(cluster)
+	podControl := &k8scontroller.FakePodControl{}
+	recorder := record.NewFakeRecorder(10)
+	controller := Controller{
+		client:            k8sClient,
+		Driver:            driver,
+		podControl:        podControl,
+		recorder:          recorder,
+		kubernetesVersion: k8sVersion,
+		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+	}
+
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
+	// Empty delete condition should not remove finalizer
+	driver.EXPECT().DeleteStorage(gomock.Any()).Return(nil, nil)
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return(driverName).AnyTimes()
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
+
+	k8sNode := createK8sNode("k8s-node", 10)
+	storagePod := createStoragePod(cluster, "storage-pod", k8sNode.Name, storageLabels)
+
+	err := k8sClient.Create(context.TODO(), k8sNode)
+	require.NoError(t, err)
+	err = k8sClient.Create(context.TODO(), storagePod)
+	require.NoError(t, err)
+
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+	result, err := controller.Reconcile(context.TODO(), request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+	require.Empty(t, recorder.Events)
+
+	require.Empty(t, podControl.Templates)
+	require.ElementsMatch(t, []string{storagePod.Name}, podControl.DeletePodName)
+
+	updatedCluster := &corev1.StorageCluster{}
+	err = testutil.Get(k8sClient, updatedCluster, cluster.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Len(t, updatedCluster.Status.Conditions, 1)
+	require.Equal(t, pxutil.PortworxComponentName, updatedCluster.Status.Conditions[0].Source)
+	require.Equal(t, corev1.ClusterConditionTypeDelete, updatedCluster.Status.Conditions[0].Type)
+	require.Equal(t, corev1.ClusterConditionStatusInProgress, updatedCluster.Status.Conditions[0].Status)
+	require.Equal(t, string(corev1.ClusterStateUninstall), updatedCluster.Status.Phase)
+	require.Equal(t, []string{deleteFinalizerName}, updatedCluster.Finalizers)
+
+	condition := &corev1.ClusterCondition{
+		Source: pxutil.PortworxComponentName,
+		Type:   corev1.ClusterConditionTypeDelete,
+		Status: corev1.ClusterConditionStatusCompleted,
+	}
+	driver.EXPECT().DeleteStorage(gomock.Any()).Return(condition, nil)
+
+	telemetryCert := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pxutil.TelemetryCertName,
+			Namespace: cluster.Namespace,
+		},
+	}
+	err = k8sClient.Create(context.TODO(), telemetryCert)
+	require.NoError(t, err)
+
+	result, err = controller.Reconcile(context.TODO(), request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+	require.Empty(t, recorder.Events)
+
+	updatedCluster = &corev1.StorageCluster{}
+	err = testutil.Get(k8sClient, updatedCluster, cluster.Name, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+
+	secret := &v1.Secret{}
+	err = testutil.Get(k8sClient, secret, pxutil.TelemetryCertName, cluster.Namespace)
+	require.NoError(t, err)
+
+	require.Equal(t, len(secret.OwnerReferences), 1)
+}
+
 func TestDeleteStorageClusterShouldDeleteStork(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -697,6 +697,15 @@ func (c *Controller) deleteStorageCluster(
 		}
 
 		if deleteCondition.Status == corev1.ClusterConditionStatusCompleted {
+			// We should update telemetry cert ownerRef here, telemetry cert is created by PX, and the ownerRef
+			// should be updated by telemetry component. However there is race condition that causes telemetry
+			// component not setting it correct, it happens when uninstallStrategy is changed in StorageCluster
+			// spec then uninstall immediately, as component reconcile takes 30 second to trigger.
+			ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+			if err := pxutil.SetTelemetryCertOwnerRef(cluster, ownerRef, c.client); err != nil {
+				return err
+			}
+
 			if err := c.removeMigrationLabels(); err != nil {
 				return fmt.Errorf("failed to remove migration labels from nodes: %v", err)
 			}


### PR DESCRIPTION
When storageCluster delete strategy is changed and then uninstalled, telemetry reconcile may not uninstall correctly as reconcile loop needs 30s to reconcile according to delete strategy. hence add the fix in finalizer of storagecluster.