### PR TITLE
[pwx-28655] Add Portworx Install and Upgrade conditions to StorageCluster status

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2431,7 +2431,7 @@ func TestUpdateClusterStatusFirstTime(t *testing.T) {
 		},
 	}
 
-	err := driver.UpdateStorageClusterStatus(cluster)
+	err := driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	// Status should be set to initializing if not set
@@ -2441,7 +2441,11 @@ func TestUpdateClusterStatusFirstTime(t *testing.T) {
 }
 
 func TestUpdateClusterStatusWithPortworxDisabled(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	k8sClient := testutil.FakeK8sClient()
 	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
+	require.NoError(t, err)
 
 	cluster := &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2453,7 +2457,7 @@ func TestUpdateClusterStatusWithPortworxDisabled(t *testing.T) {
 		},
 	}
 
-	err := driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	require.Equal(t, cluster.Name, cluster.Status.ClusterName)
@@ -2461,7 +2465,7 @@ func TestUpdateClusterStatusWithPortworxDisabled(t *testing.T) {
 	require.Empty(t, cluster.Status.Conditions)
 
 	// If portworx is disabled, change status as online
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	require.Equal(t, cluster.Name, cluster.Status.ClusterName)
@@ -2503,7 +2507,7 @@ func TestUpdateClusterStatusMarkMigrationCompleted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Migration is still in progress, PX is online
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateInit), cluster.Status.Phase)
 	condition := util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeMigration)
@@ -2517,7 +2521,7 @@ func TestUpdateClusterStatusMarkMigrationCompleted(t *testing.T) {
 	err = k8sClient.Delete(context.TODO(), ds)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeMigration)
@@ -2602,7 +2606,7 @@ func TestUpdateDeprecatedClusterStatus(t *testing.T) {
 	cluster.Status = corev1.StorageClusterStatus{
 		Phase: string(corev1.ClusterConditionStatusOnline),
 	}
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
@@ -2619,7 +2623,7 @@ func TestUpdateDeprecatedClusterStatus(t *testing.T) {
 	cluster.Status = corev1.StorageClusterStatus{
 		Phase: string(corev1.ClusterConditionStatusOffline),
 	}
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	require.Equal(t, string(corev1.ClusterStateDegraded), cluster.Status.Phase)
@@ -2707,7 +2711,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Type:   corev1.ClusterConditionTypeMigration,
 		Status: corev1.ClusterConditionStatusPending,
 	})
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, "cluster-name", cluster.Status.ClusterName)
 	require.Equal(t, "cluster-id", cluster.Status.ClusterUID)
@@ -2725,7 +2729,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Type:   corev1.ClusterConditionTypeMigration,
 		Status: corev1.ClusterConditionStatusCompleted,
 	})
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, "cluster-name", cluster.Status.ClusterName)
 	require.Equal(t, "cluster-id", cluster.Status.ClusterUID)
@@ -2741,7 +2745,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateDegraded), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2755,7 +2759,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateDegraded), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2769,7 +2773,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateDegraded), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2783,7 +2787,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateDegraded), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2797,7 +2801,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2811,7 +2815,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2825,7 +2829,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateDegraded), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2839,7 +2843,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateDegraded), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2853,7 +2857,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2867,7 +2871,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2881,7 +2885,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2895,7 +2899,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2909,7 +2913,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Return(expectedClusterResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2922,7 +2926,7 @@ func TestUpdateClusterStatus(t *testing.T) {
 		InspectCurrent(gomock.Any(), &api.SdkClusterInspectCurrentRequest{}).
 		Return(expectedClusterResp, nil).
 		Times(2)
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateDegraded), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
@@ -2934,12 +2938,566 @@ func TestUpdateClusterStatus(t *testing.T) {
 		Type:   corev1.ClusterConditionTypeDelete,
 		Status: corev1.ClusterConditionStatusInProgress,
 	})
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateUninstall), cluster.Status.Phase)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
 	require.NotNil(t, condition)
 	require.Equal(t, corev1.ClusterConditionStatusUnknown, condition.Status)
+}
+
+func TestPortworxInstallCondition(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// Create the mock servers that can be used to mock SDK calls
+	mockClusterServer := mock.NewMockOpenStorageClusterServer(mockCtrl)
+	mockNodeServer := mock.NewMockOpenStorageNodeServer(mockCtrl)
+
+	// Start a sdk server that implements the mock servers
+	sdkServerIP := "127.0.0.1"
+	sdkServerPort := 21883
+	mockSdk := mock.NewSdkServer(mock.SdkServers{
+		Cluster: mockClusterServer,
+		Node:    mockNodeServer,
+	})
+	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
+	require.NoError(t, err)
+	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
+	// Create fake k8s client with fake service that will point the client
+	// to the mock sdk server address
+	k8sClient := testutil.FakeK8sClient(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pxutil.PortworxServiceName,
+			Namespace: "kube-test",
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: sdkServerIP,
+			Ports: []v1.ServicePort{
+				{
+					Name: pxutil.PortworxSDKPortName,
+					Port: int32(sdkServerPort),
+				},
+			},
+		},
+	})
+
+	// Create driver object with the fake k8s client
+	driver := portworx{
+		k8sClient: k8sClient,
+		recorder:  record.NewFakeRecorder(10),
+	}
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Status: corev1.StorageClusterStatus{
+			Phase: string(corev1.ClusterStateInit),
+		},
+	}
+	hash := "latest-hash"
+
+	// Add Portworx Install InProgress condition
+	expectedClusterResp := &api.SdkClusterInspectCurrentResponse{
+		Cluster: &api.StorageCluster{
+			Id:     "cluster-id",
+			Name:   "cluster-name",
+			Status: api.Status_STATUS_INIT,
+		},
+	}
+	mockClusterServer.EXPECT().
+		InspectCurrent(gomock.Any(), &api.SdkClusterInspectCurrentRequest{}).
+		Return(expectedClusterResp, nil).
+		Times(1)
+	node1 := &api.StorageNode{
+		Id:                "node-1",
+		SchedulerNodeName: "node-one",
+		Status:            api.Status_STATUS_INIT,
+	}
+	node2 := &api.StorageNode{
+		Id:                "node-2",
+		SchedulerNodeName: "node-two",
+		Status:            api.Status_STATUS_INIT,
+	}
+	expectedNodeEnumerateResp := &api.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*api.StorageNode{node1, node2},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	err = driver.UpdateStorageClusterStatus(cluster, hash)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.ClusterStateInit), cluster.Status.Phase)
+	condition := util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeInstall)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusInProgress, condition.Status)
+	require.Equal(t, "Portworx installation completed on 0/2 nodes, 2 nodes remaining", condition.Message)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusOffline, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeUpdate)
+	require.Empty(t, condition)
+
+	nodeStatusList := &corev1.StorageNodeList{}
+	err = testutil.List(k8sClient, nodeStatusList)
+	require.NoError(t, err)
+	require.Len(t, nodeStatusList.Items, 2)
+
+	storageNode := &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, "node-one", cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeInitStatus), storageNode.Status.Phase)
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, "node-two", cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeInitStatus), storageNode.Status.Phase)
+
+	// One node becomes ready
+	expectedClusterResp.Cluster.Status = api.Status_STATUS_NOT_IN_QUORUM
+	mockClusterServer.EXPECT().
+		InspectCurrent(gomock.Any(), &api.SdkClusterInspectCurrentRequest{}).
+		Return(expectedClusterResp, nil).
+		Times(1)
+	node1.Status = api.Status_STATUS_OK
+	expectedNodeEnumerateResp = &api.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*api.StorageNode{node1, node2},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	err = driver.UpdateStorageClusterStatus(cluster, hash)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.ClusterStateInit), cluster.Status.Phase)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeInstall)
+	require.NotEmpty(t, condition)
+	require.Equal(t, "Portworx installation completed on 1/2 nodes, 1 nodes remaining", condition.Message)
+	require.Equal(t, corev1.ClusterConditionStatusInProgress, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusNotInQuorum, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeUpdate)
+	require.Empty(t, condition)
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, "node-one", cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, "node-two", cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeInitStatus), storageNode.Status.Phase)
+
+	// All nodes become ready
+	expectedClusterResp.Cluster.Status = api.Status_STATUS_OK
+	mockClusterServer.EXPECT().
+		InspectCurrent(gomock.Any(), &api.SdkClusterInspectCurrentRequest{}).
+		Return(expectedClusterResp, nil).
+		Times(1)
+	node2.Status = api.Status_STATUS_OK
+	expectedNodeEnumerateResp = &api.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*api.StorageNode{node1, node2},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	err = driver.UpdateStorageClusterStatus(cluster, hash)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeInstall)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusCompleted, condition.Status)
+	require.Equal(t, "Portworx installation completed on 2 nodes", condition.Message)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusOnline, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeUpdate)
+	require.Empty(t, condition)
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, "node-one", cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, "node-two", cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+
+	// Init a 3rd node, install condition should not be updated
+	mockClusterServer.EXPECT().
+		InspectCurrent(gomock.Any(), &api.SdkClusterInspectCurrentRequest{}).
+		Return(expectedClusterResp, nil).
+		Times(1)
+	node3 := &api.StorageNode{
+		Id:                "node-3",
+		SchedulerNodeName: "node-three",
+		Status:            api.Status_STATUS_INIT,
+	}
+	expectedNodeEnumerateResp = &api.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*api.StorageNode{node1, node2, node3},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	err = driver.UpdateStorageClusterStatus(cluster, hash)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeInstall)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusCompleted, condition.Status)
+	require.Equal(t, "Portworx installation completed on 2 nodes", condition.Message)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusOnline, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeUpdate)
+	require.Empty(t, condition)
+}
+
+func TestPortworxUpdateCondition(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// Create the mock servers that can be used to mock SDK calls
+	mockClusterServer := mock.NewMockOpenStorageClusterServer(mockCtrl)
+	mockNodeServer := mock.NewMockOpenStorageNodeServer(mockCtrl)
+
+	// Start a sdk server that implements the mock servers
+	sdkServerIP := "127.0.0.1"
+	sdkServerPort := 21883
+	mockSdk := mock.NewSdkServer(mock.SdkServers{
+		Cluster: mockClusterServer,
+		Node:    mockNodeServer,
+	})
+	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
+	require.NoError(t, err)
+	defer mockSdk.Stop()
+
+	setupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer restoreEtcHosts(t)
+
+	// Create fake k8s client with fake service that will point the client
+	// to the mock sdk server address
+	k8sClient := testutil.FakeK8sClient(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pxutil.PortworxServiceName,
+			Namespace: "kube-test",
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: sdkServerIP,
+			Ports: []v1.ServicePort{
+				{
+					Name: pxutil.PortworxSDKPortName,
+					Port: int32(sdkServerPort),
+				},
+			},
+		},
+	})
+
+	// Create driver object with the fake k8s client
+	driver := portworx{
+		k8sClient: k8sClient,
+		recorder:  record.NewFakeRecorder(10),
+	}
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Status: corev1.StorageClusterStatus{
+			Phase: string(corev1.ClusterStateRunning),
+			Conditions: []corev1.ClusterCondition{{
+				Source: pxutil.PortworxComponentName,
+				Type:   corev1.ClusterConditionTypeRuntimeState,
+				Status: corev1.ClusterConditionStatusOnline,
+			}},
+		},
+	}
+	hash := "v1"
+
+	// Create fake k8s nodes and pods
+	k8sNode1 := createK8sNode("k8s-node-1", 1)
+	k8sNode2 := createK8sNode("k8s-node-2", 1)
+	labels := driver.GetSelectorLabels()
+	labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+	pod1 := createStoragePod(cluster, "px-pod-1", k8sNode1.Name, labels)
+	pod1.Status = v1.PodStatus{
+		Conditions: []v1.PodCondition{{
+			Type:   v1.PodReady,
+			Status: "True",
+		}},
+	}
+	pod2 := createStoragePod(cluster, "px-pod-2", k8sNode2.Name, labels)
+	pod2.Status = pod1.Status
+	err = k8sClient.Create(context.TODO(), k8sNode1)
+	require.NoError(t, err)
+	err = k8sClient.Create(context.TODO(), k8sNode2)
+	require.NoError(t, err)
+	err = k8sClient.Create(context.TODO(), pod1)
+	require.NoError(t, err)
+	err = k8sClient.Create(context.TODO(), pod2)
+	require.NoError(t, err)
+
+	// Upgrade not triggered
+	expectedClusterResp := &api.SdkClusterInspectCurrentResponse{
+		Cluster: &api.StorageCluster{
+			Id:     "cluster-id",
+			Name:   "cluster-name",
+			Status: api.Status_STATUS_OK,
+		},
+	}
+	mockClusterServer.EXPECT().
+		InspectCurrent(gomock.Any(), &api.SdkClusterInspectCurrentRequest{}).
+		Return(expectedClusterResp, nil).
+		Times(5)
+	node1 := &api.StorageNode{
+		Id:                "node-1",
+		SchedulerNodeName: k8sNode1.Name,
+		Status:            api.Status_STATUS_OK,
+	}
+	node2 := &api.StorageNode{
+		Id:                "node-2",
+		SchedulerNodeName: k8sNode2.Name,
+		Status:            api.Status_STATUS_OK,
+	}
+	expectedNodeEnumerateResp := &api.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*api.StorageNode{node1, node2},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	err = driver.UpdateStorageClusterStatus(cluster, hash)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
+	condition := util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeInstall)
+	require.Empty(t, condition)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusOnline, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeUpdate)
+	require.Empty(t, condition)
+
+	nodeStatusList := &corev1.StorageNodeList{}
+	err = testutil.List(k8sClient, nodeStatusList)
+	require.NoError(t, err)
+	require.Len(t, nodeStatusList.Items, 2)
+
+	storageNode := &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode1.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+	require.Equal(t, hash, storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode2.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+	require.Equal(t, hash, storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
+
+	// Upgrade hash to v2, bounce pod1:
+	// pod1 v2 not ready, storageNode1 v1 Upgrading, node1 Online
+	// pod2 v1 ready, storageNode2 v1 Online, node2 Online
+	hash = "v2"
+	pod1.Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+	pod1.Status.Conditions[0].Status = "False"
+	err = testutil.Update(k8sClient, pod1)
+	require.NoError(t, err)
+
+	expectedNodeEnumerateResp = &api.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*api.StorageNode{node1, node2},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	err = driver.UpdateStorageClusterStatus(cluster, hash)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeInstall)
+	require.Empty(t, condition)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusOnline, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeUpdate)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusInProgress, condition.Status)
+	require.Equal(t, "Portworx update in progress, 2 nodes remaining", condition.Message)
+
+	nodeStatusList = &corev1.StorageNodeList{}
+	err = testutil.List(k8sClient, nodeStatusList)
+	require.NoError(t, err)
+	require.Len(t, nodeStatusList.Items, 2)
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode1.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeUpdateStatus), storageNode.Status.Phase)
+	require.Equal(t, "v1", storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode2.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+	require.Equal(t, "v1", storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
+
+	// Upgrade hash to v3, pod1 v2 is ready, bounce pod2, node2 is unavailable from sdk server
+	// pod1 v2 ready, storageNode1 v2 Online, node1 Online
+	// pod2 v3 not ready, storageNode2 v1 Upgrading, node2 unavailable
+	hash = "v3"
+	pod1.Status.Conditions[0].Status = "True"
+	err = testutil.Update(k8sClient, pod1)
+	require.NoError(t, err)
+	pod2.Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+	pod2.Status.Conditions[0].Status = "False"
+	err = testutil.Update(k8sClient, pod2)
+	require.NoError(t, err)
+
+	expectedNodeEnumerateResp = &api.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*api.StorageNode{node1},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	err = driver.UpdateStorageClusterStatus(cluster, hash)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeInstall)
+	require.Empty(t, condition)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusOnline, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeUpdate)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusInProgress, condition.Status)
+	require.Equal(t, "Portworx update in progress, 2 nodes remaining", condition.Message)
+
+	nodeStatusList = &corev1.StorageNodeList{}
+	err = testutil.List(k8sClient, nodeStatusList)
+	require.NoError(t, err)
+	require.Len(t, nodeStatusList.Items, 2)
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode1.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+	require.Equal(t, "v2", storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode2.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeUpdateStatus), storageNode.Status.Phase)
+	require.Equal(t, "v1", storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
+
+	// pod2 v3 is ready
+	// pod1 v2 ready, storageNode1 v2 Online, node1 Online
+	// pod2 v3 ready, storageNode2 v3 Online, node2 Online
+	pod2.Status.Conditions[0].Status = "True"
+	err = testutil.Update(k8sClient, pod2)
+	require.NoError(t, err)
+
+	expectedNodeEnumerateResp = &api.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*api.StorageNode{node1, node2},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	err = driver.UpdateStorageClusterStatus(cluster, hash)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeInstall)
+	require.Empty(t, condition)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusOnline, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeUpdate)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusInProgress, condition.Status)
+	require.Equal(t, "Portworx update in progress, 1 nodes remaining", condition.Message)
+
+	nodeStatusList = &corev1.StorageNodeList{}
+	err = testutil.List(k8sClient, nodeStatusList)
+	require.NoError(t, err)
+	require.Len(t, nodeStatusList.Items, 2)
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode1.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+	require.Equal(t, "v2", storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode2.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+	require.Equal(t, "v3", storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
+
+	// all pods upgraded to v3 and ready, upgrade completed
+	// pod1 v3 ready, storageNode1 v3 Online, node1 Online
+	// pod2 v3 ready, storageNode2 v3 Online, node2 Online
+	pod1.Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+	err = testutil.Update(k8sClient, pod1)
+	require.NoError(t, err)
+
+	expectedNodeEnumerateResp = &api.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*api.StorageNode{node1, node2},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	err = driver.UpdateStorageClusterStatus(cluster, hash)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeInstall)
+	require.Empty(t, condition)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeRuntimeState)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusOnline, condition.Status)
+	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypeUpdate)
+	require.NotEmpty(t, condition)
+	require.Equal(t, corev1.ClusterConditionStatusCompleted, condition.Status)
+	require.Equal(t, "Portworx update completed", condition.Message)
+
+	nodeStatusList = &corev1.StorageNodeList{}
+	err = testutil.List(k8sClient, nodeStatusList)
+	require.NoError(t, err)
+	require.Len(t, nodeStatusList.Items, 2)
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode1.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+	require.Equal(t, "v3", storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
+
+	storageNode = &corev1.StorageNode{}
+	err = testutil.Get(k8sClient, storageNode, k8sNode2.Name, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, string(corev1.NodeOnlineStatus), storageNode.Status.Phase)
+	require.Equal(t, "v3", storageNode.Labels[util.DefaultStorageClusterUniqueLabelKey])
 }
 
 func TestUpdateClusterStatusForNodes(t *testing.T) {
@@ -3042,7 +3600,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Times(1)
 
 	// Status None
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList := &corev1.StorageNodeList{}
@@ -3094,7 +3652,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3110,7 +3668,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3126,7 +3684,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3142,7 +3700,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3158,7 +3716,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3174,7 +3732,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3190,7 +3748,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3206,7 +3764,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3222,7 +3780,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3238,7 +3796,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3254,7 +3812,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3270,7 +3828,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3286,7 +3844,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3302,7 +3860,7 @@ func TestUpdateClusterStatusForNodes(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3400,7 +3958,7 @@ func TestUpdateClusterStatusForNodeVersions(t *testing.T) {
 		AnyTimes()
 
 	// Status None
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList := &corev1.StorageNodeList{}
@@ -3421,7 +3979,7 @@ func TestUpdateClusterStatusForNodeVersions(t *testing.T) {
 	// If the PX image does not have a tag then don't update the version
 	cluster.Spec.Image = "test/image"
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3433,7 +3991,7 @@ func TestUpdateClusterStatusForNodeVersions(t *testing.T) {
 	err = k8sClient.Delete(context.TODO(), nodeStatus)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatus = &corev1.StorageNode{}
@@ -3461,7 +4019,7 @@ func TestUpdateClusterStatusWithoutPortworxService(t *testing.T) {
 	}
 
 	// TestCase: No storage nodes and portworx pods exist
-	err := driver.UpdateStorageClusterStatus(cluster)
+	err := driver.UpdateStorageClusterStatus(cluster, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
 
@@ -3486,7 +4044,7 @@ func TestUpdateClusterStatusWithoutPortworxService(t *testing.T) {
 	err = k8sClient.Create(context.TODO(), pod1)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.Contains(t, err.Error(), "not found")
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -3512,7 +4070,7 @@ func TestUpdateClusterStatusWithoutPortworxService(t *testing.T) {
 	err = k8sClient.Create(context.TODO(), storageNode2)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.Contains(t, err.Error(), "not found")
 
 	// Delete extra nodes that do not have corresponding pods
@@ -3550,7 +4108,7 @@ func TestUpdateClusterStatusServiceWithoutClusterIP(t *testing.T) {
 	}
 
 	// TestCase: No storage nodes and portworx pods exist
-	err := driver.UpdateStorageClusterStatus(cluster)
+	err := driver.UpdateStorageClusterStatus(cluster, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to get endpoint")
 
@@ -3583,7 +4141,7 @@ func TestUpdateClusterStatusServiceWithoutClusterIP(t *testing.T) {
 	err = k8sClient.Create(context.TODO(), storageNode)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.Contains(t, err.Error(), "failed to get endpoint")
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -3641,7 +4199,7 @@ func TestUpdateClusterStatusServiceGrpcServerError(t *testing.T) {
 	err = k8sClient.Create(context.TODO(), storageNode)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error connecting to GRPC server")
 
@@ -3655,7 +4213,7 @@ func TestUpdateClusterStatusServiceGrpcServerError(t *testing.T) {
 	// grpc connection timeout
 	cluster.Status.Phase = string(corev1.ClusterStateInit)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -3747,7 +4305,7 @@ func TestUpdateClusterStatusInspectClusterFailure(t *testing.T) {
 		Return(nil, fmt.Errorf("InspectCurrent error")).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "InspectCurrent error")
 
@@ -3769,7 +4327,7 @@ func TestUpdateClusterStatusInspectClusterFailure(t *testing.T) {
 	err = k8sClient.Status().Update(context.TODO(), storageNode)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to inspect cluster")
 
@@ -3794,7 +4352,7 @@ func TestUpdateClusterStatusInspectClusterFailure(t *testing.T) {
 	err = k8sClient.Status().Update(context.TODO(), storageNode)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "empty ClusterInspect response")
 
@@ -3897,7 +4455,7 @@ func TestUpdateClusterStatusEnumerateNodesFailure(t *testing.T) {
 		Return(nil, fmt.Errorf("node Enumerate error")).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "node Enumerate error")
 
@@ -3919,7 +4477,7 @@ func TestUpdateClusterStatusEnumerateNodesFailure(t *testing.T) {
 	err = k8sClient.Status().Update(context.TODO(), storageNode)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to enumerate nodes")
 
@@ -3944,7 +4502,7 @@ func TestUpdateClusterStatusEnumerateNodesFailure(t *testing.T) {
 	err = k8sClient.Status().Update(context.TODO(), storageNode)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -3966,7 +4524,7 @@ func TestUpdateClusterStatusEnumerateNodesFailure(t *testing.T) {
 	err = k8sClient.Status().Update(context.TODO(), storageNode)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -3987,7 +4545,7 @@ func TestUpdateClusterStatusEnumerateNodesFailure(t *testing.T) {
 	err = k8sClient.Delete(context.TODO(), pod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList := &corev1.StorageNodeList{}
@@ -4002,7 +4560,7 @@ func TestUpdateClusterStatusEnumerateNodesFailure(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList = &corev1.StorageNodeList{}
@@ -4091,7 +4649,7 @@ func TestUpdateClusterStatusShouldUpdateStatusIfChanged(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	require.Equal(t, string(corev1.ClusterStateDegraded), cluster.Status.Phase)
@@ -4119,7 +4677,7 @@ func TestUpdateClusterStatusShouldUpdateStatusIfChanged(t *testing.T) {
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	require.Equal(t, string(corev1.ClusterStateRunning), cluster.Status.Phase)
@@ -4215,7 +4773,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes := &corev1.StorageNodeList{}
@@ -4243,7 +4801,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 	err = k8sClient.Status().Update(context.TODO(), &storageNodes.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -4269,7 +4827,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 	err = k8sClient.Status().Update(context.TODO(), &storageNodes.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -4286,7 +4844,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 		Times(1)
 
 	time.Sleep(time.Second)
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -4320,7 +4878,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 	err = k8sClient.Create(context.TODO(), pod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -4339,7 +4897,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 	err = k8sClient.Update(context.TODO(), &storageNodes.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -4359,7 +4917,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 	err = k8sClient.Update(context.TODO(), &storageNodes.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -4378,7 +4936,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 	err = k8sClient.Update(context.TODO(), &storageNodes.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -4392,7 +4950,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 	err = k8sClient.Update(context.TODO(), &storageNodes.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -4406,7 +4964,7 @@ func TestUpdateClusterStatusShouldUpdateNodePhaseBasedOnConditions(t *testing.T)
 	err = k8sClient.Update(context.TODO(), &storageNodes.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodes = &corev1.StorageNodeList{}
@@ -4506,7 +5064,7 @@ func TestUpdateClusterStatusWithoutSchedulerNodeName(t *testing.T) {
 		),
 	)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList := &corev1.StorageNodeList{}
@@ -4533,7 +5091,7 @@ func TestUpdateClusterStatusWithoutSchedulerNodeName(t *testing.T) {
 		),
 	)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList = &corev1.StorageNodeList{}
@@ -4563,7 +5121,7 @@ func TestUpdateClusterStatusWithoutSchedulerNodeName(t *testing.T) {
 		),
 	)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList = &corev1.StorageNodeList{}
@@ -4593,7 +5151,7 @@ func TestUpdateClusterStatusWithoutSchedulerNodeName(t *testing.T) {
 		),
 	)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList = &corev1.StorageNodeList{}
@@ -4618,7 +5176,7 @@ func TestUpdateClusterStatusWithoutSchedulerNodeName(t *testing.T) {
 		),
 	)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList = &corev1.StorageNodeList{}
@@ -4711,7 +5269,7 @@ func TestUpdateClusterStatusShouldDeleteStorageNodeForNonExistingNodes(t *testin
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList := &corev1.StorageNodeList{}
@@ -4733,7 +5291,7 @@ func TestUpdateClusterStatusShouldDeleteStorageNodeForNonExistingNodes(t *testin
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList = &corev1.StorageNodeList{}
@@ -4827,7 +5385,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 		Return(nodeEnumerateRespWithAllNodes, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList := &corev1.StorageNodeList{}
@@ -4865,7 +5423,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err = k8sClient.Create(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -4886,7 +5444,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err = k8sClient.Update(context.TODO(), &storageNodeList.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -4912,7 +5470,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err = k8sClient.Update(context.TODO(), &storageNodeList.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -4932,7 +5490,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -4950,7 +5508,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -4966,7 +5524,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -4984,7 +5542,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5000,7 +5558,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5017,7 +5575,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 		Return(nodeEnumerateRespWithAllNodes, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5034,7 +5592,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExists(t *testing.T) 
 	err = k8sClient.Create(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5129,7 +5687,7 @@ func TestUpdateClusterStatusShouldDeleteStorageNodeIfSchedulerNodeNameNotPresent
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList := &corev1.StorageNodeList{}
@@ -5154,7 +5712,7 @@ func TestUpdateClusterStatusShouldDeleteStorageNodeIfSchedulerNodeNameNotPresent
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList = &corev1.StorageNodeList{}
@@ -5177,7 +5735,7 @@ func TestUpdateClusterStatusShouldDeleteStorageNodeIfSchedulerNodeNameNotPresent
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	nodeStatusList = &corev1.StorageNodeList{}
@@ -5274,7 +5832,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 		Return(nodeEnumerateRespWithAllNodes, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList := &corev1.StorageNodeList{}
@@ -5315,7 +5873,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err = k8sClient.Create(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5336,7 +5894,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err = k8sClient.Update(context.TODO(), &storageNodeList.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5362,7 +5920,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err = k8sClient.Update(context.TODO(), &storageNodeList.Items[0])
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5382,7 +5940,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5400,7 +5958,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5416,7 +5974,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5434,7 +5992,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5450,7 +6008,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err = k8sClient.Update(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5467,7 +6025,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 		Return(nodeEnumerateRespWithAllNodes, nil).
 		Times(1)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -5484,7 +6042,7 @@ func TestUpdateClusterStatusShouldNotDeleteStorageNodeIfPodExistsAndScheduleName
 	err = k8sClient.Create(context.TODO(), nodeOnePod)
 	require.NoError(t, err)
 
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	storageNodeList = &corev1.StorageNodeList{}
@@ -7762,7 +8320,7 @@ func TestUpdateStorageNodeKVDB(t *testing.T) {
 		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
 		Return(expectedNodeEnumerateResp, nil).
 		Times(3)
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	// check if both storage nodes exist and have the KVDB condition
@@ -7788,7 +8346,7 @@ func TestUpdateStorageNodeKVDB(t *testing.T) {
 	cm.Data[pxEntriesKey] = `[{"IP":"10.0.1.2","ID":"node-three","Index":0,"State":3,"Type":0,"Version":"v2","peerport":"9018","clientport":"9019","Domain":"portworx-1.internal.kvdb","DataDirType":"KvdbDevice"},{"IP":"10.0.2.2","ID":"node-four","Index":2,"State":0,"Type":2,"Version":"v2","peerport":"9018","clientport":"9019","Domain":"portworx-3.internal.kvdb","DataDirType":"KvdbDevice"}]`
 	err = driver.k8sClient.Update(context.TODO(), cm)
 	require.NoError(t, err)
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 	// check if both storage nodes exist and DONT have the KVDB condition
 	for _, n := range []string{"node-one", "node-two"} {
@@ -7859,7 +8417,7 @@ func TestUpdateStorageNodeKVDB(t *testing.T) {
 			kvdbNodeStateTest.state, kvdbNodeStateTest.nodeType)
 		err = driver.k8sClient.Update(context.TODO(), cm)
 		require.NoError(t, err)
-		err = driver.UpdateStorageClusterStatus(cluster)
+		err = driver.UpdateStorageClusterStatus(cluster, "")
 		require.NoError(t, err)
 
 		var (
@@ -7890,7 +8448,7 @@ func TestUpdateStorageNodeKVDB(t *testing.T) {
 	// TEST 5: config map not found
 	err = driver.k8sClient.Delete(context.TODO(), cm)
 	require.NoError(t, err)
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 }
 
@@ -8005,7 +8563,7 @@ func TestUpdateStorageNodeKVDBWhenOverwriteClusterID(t *testing.T) {
 		EnumerateWithFilters(gomock.Any(), &api.SdkNodeEnumerateWithFiltersRequest{}).
 		Return(expectedNodeEnumerateResp, nil).
 		Times(1)
-	err = driver.UpdateStorageClusterStatus(cluster)
+	err = driver.UpdateStorageClusterStatus(cluster, "")
 	require.NoError(t, err)
 
 	// check if both storage nodes exist and have the KVDB condition
@@ -8933,6 +9491,31 @@ func createK8sNode(nodeName string, allowedPods int) *v1.Node {
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourcePods: resource.MustParse(strconv.Itoa(allowedPods)),
 			},
+		},
+	}
+}
+
+func createStoragePod(
+	cluster *corev1.StorageCluster,
+	podName, nodeName string,
+	labels map[string]string,
+) *v1.Pod {
+	clusterRef := metav1.NewControllerRef(cluster, corev1.SchemeGroupVersion.WithKind("StorageCluster"))
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            podName,
+			Namespace:       cluster.Namespace,
+			Labels:          labels,
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Spec: v1.PodSpec{
+			NodeName: nodeName,
+			Containers: []v1.Container{{
+				Name: "portworx",
+				Args: []string{
+					"-c", "px-cluster",
+				},
+			}},
 		},
 	}
 }

--- a/drivers/storage/storage.go
+++ b/drivers/storage/storage.go
@@ -67,7 +67,7 @@ type ClusterPluginInterface interface {
 	// cluster spec if they are not set
 	SetDefaultsOnStorageCluster(*corev1.StorageCluster) error
 	// UpdateStorageClusterStatus update the status of storage cluster
-	UpdateStorageClusterStatus(*corev1.StorageCluster) error
+	UpdateStorageClusterStatus(*corev1.StorageCluster, string) error
 	// DeleteStorage is going to uninstall and delete the storage service based on
 	// StorageClusterDeleteStrategy. DeleteStorage should provide idempotent behavior
 	// and subsequent calls should result in the same result.

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -705,8 +705,8 @@ const (
 	ClusterConditionTypePreflight ClusterConditionType = "Preflight"
 	// ClusterConditionTypeInstall indicates the phase for a component install operation on the cluster
 	ClusterConditionTypeInstall ClusterConditionType = "Install"
-	// ClusterConditionTypeUpgrade indicates the phase for a component upgrade operation on the cluster
-	ClusterConditionTypeUpgrade ClusterConditionType = "Upgrade"
+	// ClusterConditionTypeUpdate indicates the phase for a component update operation on the cluster
+	ClusterConditionTypeUpdate ClusterConditionType = "Update"
 	// ClusterConditionTypeDelete indicates the phase for a component delete operation on the cluster
 	ClusterConditionTypeDelete ClusterConditionType = "Delete"
 	// ClusterConditionTypeMigration indicates the phase for a component migration operation on the cluster

--- a/pkg/apis/core/v1/storagenode.go
+++ b/pkg/apis/core/v1/storagenode.go
@@ -125,14 +125,16 @@ type NodeConditionStatus string
 
 // These are valid statuses of different node conditions.
 const (
-	// NodeSucceeded means the node condition status is succeeded
+	// NodeSucceededStatus means the node condition status is succeeded
 	NodeSucceededStatus NodeConditionStatus = "Succeeded"
-	// NodeFailed means the node condition status is failed
+	// NodeFailedStatus means the node condition status is failed
 	NodeFailedStatus NodeConditionStatus = "Failed"
 	// NodeOnlineStatus means the node condition is online and healthy
 	NodeOnlineStatus NodeConditionStatus = "Online"
 	// NodeInitStatus means the node condition is in initializing state
 	NodeInitStatus NodeConditionStatus = "Initializing"
+	// NodeUpdateStatus means the node condition is in updating state
+	NodeUpdateStatus NodeConditionStatus = "Updating"
 	// NodeNotInQuorumStatus means the node is not in quorum
 	NodeNotInQuorumStatus NodeConditionStatus = "NotInQuorum"
 	// NodeMaintenanceStatus means the node condition is in maintenance state

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -432,7 +432,7 @@ func TestWaitForMigrationApproval(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -1097,7 +1097,7 @@ func TestFailureDuringStorkInstallation(t *testing.T) {
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
@@ -1237,7 +1237,7 @@ func TestStoragePodsShouldNotBeScheduledIfDisabled(t *testing.T) {
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
@@ -1397,12 +1397,12 @@ func TestStoragePodGetsScheduled(t *testing.T) {
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).
 		Do(func(c *corev1.StorageCluster) {
 			hash := computeHash(&c.Spec, nil)
-			expectedPodTemplate.Labels[defaultStorageClusterUniqueLabelKey] = hash
+			expectedPodTemplate.Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
 		})
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).
 		Return(expectedPodSpec, nil).
@@ -1511,12 +1511,12 @@ func TestStoragePodGetsScheduledK8s1_24(t *testing.T) {
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).
 		Do(func(c *corev1.StorageCluster) {
 			hash := computeHash(&c.Spec, nil)
-			expectedPodTemplate.Labels[defaultStorageClusterUniqueLabelKey] = hash
+			expectedPodTemplate.Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
 		})
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).
 		Return(expectedPodSpec, nil).
@@ -1592,7 +1592,7 @@ func TestStorageNodeGetsCreated(t *testing.T) {
 	driver.EXPECT().GetSelectorLabels().Return(storageLabels).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
@@ -1908,14 +1908,14 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).
 		Do(func(c *corev1.StorageCluster) {
 			hash := computeHash(&c.Spec, nil)
-			expectedPodTemplates[0].Labels[defaultStorageClusterUniqueLabelKey] = hash
-			expectedPodTemplates[1].Labels[defaultStorageClusterUniqueLabelKey] = hash
-			expectedPodTemplates[2].Labels[defaultStorageClusterUniqueLabelKey] = hash
+			expectedPodTemplates[0].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+			expectedPodTemplates[1].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+			expectedPodTemplates[2].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
 		})
 	gomock.InOrder(
 		driver.EXPECT().GetStoragePodSpec(gomock.Any(), "k8s-node-1").
@@ -2021,7 +2021,7 @@ func TestFailedStoragePodsGetRemoved(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
@@ -2035,7 +2035,7 @@ func TestFailedStoragePodsGetRemoved(t *testing.T) {
 	k8sNode3 := createK8sNode("k8s-node-3", 10)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 
 	// Running pod should not get deleted if nothing has changed
 	runningPod := createStoragePod(cluster, "running-pod", k8sNode1.Name, storageLabels)
@@ -2124,7 +2124,7 @@ func TestExtraStoragePodsGetRemoved(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
@@ -2136,7 +2136,7 @@ func TestExtraStoragePodsGetRemoved(t *testing.T) {
 	k8sNode := createK8sNode("k8s-node", 10)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	affinity := &v1.Affinity{
 		NodeAffinity: &v1.NodeAffinity{
 			RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
@@ -2252,7 +2252,7 @@ func TestStoragePodsAreRemovedIfDisabled(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -2263,7 +2263,7 @@ func TestStoragePodsAreRemovedIfDisabled(t *testing.T) {
 	k8sNode := createK8sNode("k8s-node", 10)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	runningPod := createStoragePod(cluster, "running-pod", k8sNode.Name, storageLabels)
 
 	err = k8sClient.Create(context.TODO(), k8sNode)
@@ -2348,7 +2348,7 @@ func TestStoragePodFailureDueToNodeSelectorNotMatch(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -2367,7 +2367,7 @@ func TestStoragePodFailureDueToNodeSelectorNotMatch(t *testing.T) {
 	k8sNode3 := createK8sNode("k8s-node-3", 10)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	runningPod := createStoragePod(cluster, "running-pod", k8sNode3.Name, storageLabels)
 
 	err = k8sClient.Create(context.TODO(), k8sNode1)
@@ -2445,7 +2445,7 @@ func TestStoragePodSchedulingWithTolerations(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).Times(3)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).Times(3)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).Times(3)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).Times(3)
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -2477,7 +2477,7 @@ func TestStoragePodSchedulingWithTolerations(t *testing.T) {
 	k8sNode3 := createK8sNode("k8s-node-3", 10)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	runningPod1 := createStoragePod(cluster, "running-pod-1", k8sNode1.Name, storageLabels)
 	runningPod2 := createStoragePod(cluster, "running-pod-2", k8sNode2.Name, storageLabels)
 	runningPod3 := createStoragePod(cluster, "running-pod-3", k8sNode3.Name, storageLabels)
@@ -2690,7 +2690,7 @@ func TestFailureDuringCreateDeletePods(t *testing.T) {
 	k8sNode3 := createK8sNode("k8s-node-3", 10)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	failedPod := createStoragePod(cluster, "failed-pod", k8sNode1.Name, storageLabels)
 	failedPod.Status = v1.PodStatus{
 		Phase: v1.PodFailed,
@@ -2758,7 +2758,7 @@ func TestTimeoutFailureDuringCreatePods(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil)
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil)
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
@@ -2812,8 +2812,8 @@ func TestUpdateClusterStatusFromDriver(t *testing.T) {
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	driver.EXPECT().
-		UpdateStorageClusterStatus(gomock.Any()).
-		Do(func(c *corev1.StorageCluster) {
+		UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).
+		Do(func(c *corev1.StorageCluster, hash string) {
 			c.Status.Phase = string(corev1.ClusterStateRunning)
 			util.UpdateStorageClusterCondition(cluster, &corev1.ClusterCondition{
 				Source: pxutil.PortworxComponentName,
@@ -2874,8 +2874,8 @@ func TestUpdateClusterStatusErrorFromDriver(t *testing.T) {
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	driver.EXPECT().
-		UpdateStorageClusterStatus(gomock.Any()).
-		Do(func(c *corev1.StorageCluster) {
+		UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).
+		Do(func(c *corev1.StorageCluster, hash string) {
 			c.Status.Phase = string(corev1.ClusterStateDegraded)
 		}).
 		Return(fmt.Errorf("update status error"))
@@ -2989,7 +2989,7 @@ func TestUpdateDriverWithInstanceInformation(t *testing.T) {
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().UpdateDriver(expectedDriverInfo).Return(nil)
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
@@ -3130,7 +3130,7 @@ func TestGarbageCollection(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	request := reconcile.Request{
@@ -3565,7 +3565,7 @@ func TestDeleteStorageClusterShouldDeleteStork(t *testing.T) {
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	request := reconcile.Request{
@@ -3773,7 +3773,7 @@ func TestRollingUpdateWithMinReadySeconds(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	k8sNode := createK8sNode("k8s-node", 10)
@@ -3801,8 +3801,8 @@ func TestRollingUpdateWithMinReadySeconds(t *testing.T) {
 
 	// Verify that the revision hash matches that of the new pod
 	require.Len(t, podControl.Templates, 1)
-	require.Equal(t, revisions.Items[0].Labels[defaultStorageClusterUniqueLabelKey],
-		podControl.Templates[0].Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, revisions.Items[0].Labels[util.DefaultStorageClusterUniqueLabelKey],
+		podControl.Templates[0].Labels[util.DefaultStorageClusterUniqueLabelKey])
 
 	// Test case: Changing the cluster spec -
 	// A new revision should be created for the new cluster spec
@@ -3879,7 +3879,7 @@ func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	k8sNode := createK8sNode("k8s-node", 10)
@@ -3907,8 +3907,8 @@ func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 
 	// Verify that the revision hash matches that of the new pod
 	require.Len(t, podControl.Templates, 1)
-	require.Equal(t, revisions.Items[0].Labels[defaultStorageClusterUniqueLabelKey],
-		podControl.Templates[0].Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, revisions.Items[0].Labels[util.DefaultStorageClusterUniqueLabelKey],
+		podControl.Templates[0].Labels[util.DefaultStorageClusterUniqueLabelKey])
 
 	// Test case: Changing the cluster spec -
 	// A new revision should be created for the new cluster spec
@@ -3988,8 +3988,8 @@ func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 			revision2 = &revisions.Items[i]
 		}
 	}
-	require.Equal(t, revision2.Labels[defaultStorageClusterUniqueLabelKey],
-		podControl.Templates[0].Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, revision2.Labels[util.DefaultStorageClusterUniqueLabelKey],
+		podControl.Templates[0].Labels[util.DefaultStorageClusterUniqueLabelKey])
 }
 
 // When any storage node is unhealthy, we should not upgrade storage pod as it may cause
@@ -4037,13 +4037,13 @@ func TestUpdateStorageClusterBasedOnStorageNodeStatuses(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(storageNodes, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
 	rev1Hash, err := createRevision(k8sClient, cluster, driverName)
 	require.NoError(t, err)
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 
 	// Kubernetes node with enough resources to create new pods
 	for i := 0; i < 3; i++ {
@@ -4249,7 +4249,7 @@ func TestUpdateStorageClusterWithOpenshiftUpgrade(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	k8sNode := createK8sNode("k8s-node", 10)
@@ -4277,8 +4277,8 @@ func TestUpdateStorageClusterWithOpenshiftUpgrade(t *testing.T) {
 
 	// Verify that the revision hash matches that of the new pod
 	require.Len(t, podControl.Templates, 1)
-	require.Equal(t, revisions.Items[0].Labels[defaultStorageClusterUniqueLabelKey],
-		podControl.Templates[0].Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, revisions.Items[0].Labels[util.DefaultStorageClusterUniqueLabelKey],
+		podControl.Templates[0].Labels[util.DefaultStorageClusterUniqueLabelKey])
 
 	// TestCase: Changing the cluster spec -
 	// A new revision should be created for the new cluster spec
@@ -4386,7 +4386,7 @@ func TestUpdateStorageClusterShouldNotExceedMaxUnavailable(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	k8sNode1 := createK8sNode("k8s-node-1", 10)
@@ -4405,7 +4405,7 @@ func TestUpdateStorageClusterShouldNotExceedMaxUnavailable(t *testing.T) {
 	// Pods that are already running on the k8s nodes with same hash
 	rev1Hash, err := createRevision(k8sClient, cluster, driverName)
 	require.NoError(t, err)
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod1 := createStoragePod(cluster, "old-pod-1", k8sNode1.Name, storageLabels)
 	oldPod1.Status.Conditions = []v1.PodCondition{
 		{
@@ -4596,7 +4596,7 @@ func TestUpdateStorageClusterWithPercentageMaxUnavailable(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	k8sNode1 := createK8sNode("k8s-node-1", 10)
@@ -4615,7 +4615,7 @@ func TestUpdateStorageClusterWithPercentageMaxUnavailable(t *testing.T) {
 	// Pods that are already running on the k8s nodes with same hash
 	rev1Hash, err := createRevision(k8sClient, cluster, driverName)
 	require.NoError(t, err)
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod1 := createStoragePod(cluster, "old-pod-1", k8sNode1.Name, storageLabels)
 	oldPod1.Status.Conditions = []v1.PodCondition{
 		{
@@ -4825,7 +4825,7 @@ func TestUpdateStorageClusterWhenDriverReportsPodNotUpdated(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(false).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -4838,7 +4838,7 @@ func TestUpdateStorageClusterWhenDriverReportsPodNotUpdated(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	storagePod := createStoragePod(cluster, "storage-pod", k8sNode.Name, storageLabels)
 	storagePod.Status.Conditions = []v1.PodCondition{
 		{
@@ -4893,7 +4893,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItDoesNotHaveAnyHash(t *testing.T
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	k8sNode := createK8sNode("k8s-node", 10)
@@ -4955,7 +4955,7 @@ func TestUpdateStorageClusterImagePullSecret(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -4968,7 +4968,7 @@ func TestUpdateStorageClusterImagePullSecret(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	storagePod := createStoragePod(cluster, "storage-pod", k8sNode.Name, storageLabels)
 	storagePod.Status.Conditions = []v1.PodCondition{
 		{
@@ -5064,7 +5064,7 @@ func TestUpdateStorageClusterCustomImageRegistry(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -5077,7 +5077,7 @@ func TestUpdateStorageClusterCustomImageRegistry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	storagePod := createStoragePod(cluster, "storage-pod", k8sNode.Name, storageLabels)
 	storagePod.Status.Conditions = []v1.PodCondition{
 		{
@@ -5171,7 +5171,7 @@ func TestUpdateStorageClusterKvdbSpec(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -5184,7 +5184,7 @@ func TestUpdateStorageClusterKvdbSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -5291,7 +5291,7 @@ func TestUpdateStorageClusterResourceRequirements(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -5304,7 +5304,7 @@ func TestUpdateStorageClusterResourceRequirements(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -5407,7 +5407,7 @@ func TestUpdateStorageClusterCloudStorageSpec(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -5420,7 +5420,7 @@ func TestUpdateStorageClusterCloudStorageSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -5680,7 +5680,7 @@ func TestUpdateStorageClusterStorageSpec(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -5693,7 +5693,7 @@ func TestUpdateStorageClusterStorageSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -5906,7 +5906,7 @@ func TestUpdateStorageClusterNetworkSpec(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -5919,7 +5919,7 @@ func TestUpdateStorageClusterNetworkSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -5999,7 +5999,7 @@ func TestUpdateStorageClusterEnvVariables(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -6012,7 +6012,7 @@ func TestUpdateStorageClusterEnvVariables(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -6094,7 +6094,7 @@ func TestUpdateStorageClusterRuntimeOptions(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -6107,7 +6107,7 @@ func TestUpdateStorageClusterRuntimeOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -6186,7 +6186,7 @@ func TestUpdateStorageClusterVolumes(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -6199,7 +6199,7 @@ func TestUpdateStorageClusterVolumes(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -6398,7 +6398,7 @@ func TestUpdateStorageClusterVolumes(t *testing.T) {
 	require.NoError(t, err)
 	history, err := getRevision(k8sClient, cluster, driverName)
 	require.NoError(t, err)
-	storageLabels[defaultStorageClusterUniqueLabelKey] = history.Labels[defaultStorageClusterUniqueLabelKey]
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = history.Labels[util.DefaultStorageClusterUniqueLabelKey]
 	oldPod.Labels = storageLabels
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
@@ -6449,7 +6449,7 @@ func TestUpdateStorageClusterSecretsProvider(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -6462,7 +6462,7 @@ func TestUpdateStorageClusterSecretsProvider(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -6540,7 +6540,7 @@ func TestUpdateStorageClusterStartPort(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -6553,7 +6553,7 @@ func TestUpdateStorageClusterStartPort(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -6634,7 +6634,7 @@ func TestUpdateStorageClusterCSISpec(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -6647,7 +6647,7 @@ func TestUpdateStorageClusterCSISpec(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -6809,7 +6809,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -6826,7 +6826,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -6955,7 +6955,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs := &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -6978,7 +6978,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs = &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -7000,7 +7000,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs = &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -7022,7 +7022,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs = &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -7044,7 +7044,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs = &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -7066,7 +7066,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs = &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -7091,7 +7091,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs = &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -7113,7 +7113,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs = &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -7138,7 +7138,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs = &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -7165,7 +7165,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 	revs = &appsv1.ControllerRevisionList{}
 	err = k8sClient.List(context.TODO(), revs, &client.ListOptions{})
 	require.NoError(t, err)
-	oldPod.Labels[defaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[defaultStorageClusterUniqueLabelKey]
+	oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey] = latestRevision(revs).Labels[util.DefaultStorageClusterUniqueLabelKey]
 	err = k8sClient.Update(context.TODO(), oldPod)
 	require.NoError(t, err)
 
@@ -7276,7 +7276,7 @@ func TestUpdateStorageClusterK8sNodeChanges(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -7293,7 +7293,7 @@ func TestUpdateStorageClusterK8sNodeChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -7371,7 +7371,7 @@ func TestUpdateStorageClusterShouldNotRestartPodsForSomeOptions(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -7384,7 +7384,7 @@ func TestUpdateStorageClusterShouldNotRestartPodsForSomeOptions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -7539,7 +7539,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItsHistoryHasInvalidSpec(t *testi
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -7554,7 +7554,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItsHistoryHasInvalidSpec(t *testi
 	err = k8sClient.Create(context.TODO(), k8sNode)
 	require.NoError(t, err)
 
-	storageLabels[defaultStorageClusterUniqueLabelKey] = invalidRevision.Labels[defaultStorageClusterUniqueLabelKey]
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = invalidRevision.Labels[util.DefaultStorageClusterUniqueLabelKey]
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -7622,7 +7622,7 @@ func TestUpdateStorageClusterSecurity(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -7635,7 +7635,7 @@ func TestUpdateStorageClusterSecurity(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	oldPod.Status.Conditions = []v1.PodCondition{
 		{
@@ -7933,7 +7933,7 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// This will create a revision which we will map to our pre-created pods
@@ -7946,7 +7946,7 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pods that are already running on the k8s nodes with same hash
-	storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 	knownAnnotationKey := constants.AnnotationPodSafeToEvict
 	oldPod.Annotations = map[string]string{
@@ -8133,7 +8133,7 @@ func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	k8sNode := createK8sNode("k8s-node", 10)
@@ -8162,7 +8162,7 @@ func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
 	// Create some duplicate revisions that will be deduplicated later.
 	dupHistory1 := firstRevision.DeepCopy()
 	dupHistory1.Name = historyName(cluster.Name, "00001")
-	dupHistory1.Labels[defaultStorageClusterUniqueLabelKey] = "00001"
+	dupHistory1.Labels[util.DefaultStorageClusterUniqueLabelKey] = "00001"
 	dupHistory1.Revision = firstRevision.Revision + 1
 	dupHistory1.ResourceVersion = ""
 	err = k8sClient.Create(context.TODO(), dupHistory1)
@@ -8170,7 +8170,7 @@ func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
 
 	dupHistory2 := firstRevision.DeepCopy()
 	dupHistory2.Name = historyName(cluster.Name, "00002")
-	dupHistory2.Labels[defaultStorageClusterUniqueLabelKey] = "00002"
+	dupHistory2.Labels[util.DefaultStorageClusterUniqueLabelKey] = "00002"
 	dupHistory2.Revision = firstRevision.Revision + 2
 	dupHistory2.ResourceVersion = ""
 	err = k8sClient.Create(context.TODO(), dupHistory2)
@@ -8179,8 +8179,8 @@ func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
 	// The created pod should have the hash of first revision
 	oldPod, err := k8scontroller.GetPodFromTemplate(&podControl.Templates[0], cluster, clusterRef)
 	require.NoError(t, err)
-	require.Equal(t, firstRevision.Labels[defaultStorageClusterUniqueLabelKey],
-		oldPod.Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, firstRevision.Labels[util.DefaultStorageClusterUniqueLabelKey],
+		oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey])
 	oldPod.Name = oldPod.GenerateName + "1"
 	oldPod.Namespace = cluster.Namespace
 	oldPod.Spec.NodeName = k8sNode.Name
@@ -8249,8 +8249,8 @@ func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
 	updatedPod := &v1.Pod{}
 	err = testutil.Get(k8sClient, updatedPod, oldPod.Name, oldPod.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, dupHistory2.Labels[defaultStorageClusterUniqueLabelKey],
-		updatedPod.Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, dupHistory2.Labels[util.DefaultStorageClusterUniqueLabelKey],
+		updatedPod.Labels[util.DefaultStorageClusterUniqueLabelKey])
 }
 
 func TestUpdateClusterShouldHandleHashCollisions(t *testing.T) {
@@ -8286,7 +8286,7 @@ func TestUpdateClusterShouldHandleHashCollisions(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	// TestCase: Simulate that the cluster got deleted while constructing history.
@@ -8457,7 +8457,7 @@ func TestUpdateClusterShouldDedupRevisionsAnywhereInHistory(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	k8sNode := createK8sNode("k8s-node", 10)
@@ -8486,7 +8486,7 @@ func TestUpdateClusterShouldDedupRevisionsAnywhereInHistory(t *testing.T) {
 	// Create some duplicate revisions that will be deduplicated later.
 	dupHistory1 := firstRevision.DeepCopy()
 	dupHistory1.Name = historyName(cluster.Name, "00001")
-	dupHistory1.Labels[defaultStorageClusterUniqueLabelKey] = "00001"
+	dupHistory1.Labels[util.DefaultStorageClusterUniqueLabelKey] = "00001"
 	dupHistory1.Revision = firstRevision.Revision + 1
 	dupHistory1.ResourceVersion = ""
 	err = k8sClient.Create(context.TODO(), dupHistory1)
@@ -8495,8 +8495,8 @@ func TestUpdateClusterShouldDedupRevisionsAnywhereInHistory(t *testing.T) {
 	// The created pod should have the hash of first revision
 	oldPod, err := k8scontroller.GetPodFromTemplate(&podControl.Templates[0], cluster, clusterRef)
 	require.NoError(t, err)
-	require.Equal(t, firstRevision.Labels[defaultStorageClusterUniqueLabelKey],
-		oldPod.Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, firstRevision.Labels[util.DefaultStorageClusterUniqueLabelKey],
+		oldPod.Labels[util.DefaultStorageClusterUniqueLabelKey])
 	oldPod.Name = oldPod.GenerateName + "1"
 	oldPod.Namespace = cluster.Namespace
 	oldPod.Spec.NodeName = k8sNode.Name
@@ -8530,7 +8530,7 @@ func TestUpdateClusterShouldDedupRevisionsAnywhereInHistory(t *testing.T) {
 	// revisions should be removed and pod's hash should be updated to latest.
 	dupHistory2 := firstRevision.DeepCopy()
 	dupHistory2.Name = historyName(cluster.Name, "00002")
-	dupHistory2.Labels[defaultStorageClusterUniqueLabelKey] = "00002"
+	dupHistory2.Labels[util.DefaultStorageClusterUniqueLabelKey] = "00002"
 	dupHistory2.Revision = revisions.Items[2].Revision + 1
 	dupHistory2.ResourceVersion = ""
 	err = k8sClient.Create(context.TODO(), dupHistory2)
@@ -8569,8 +8569,8 @@ func TestUpdateClusterShouldDedupRevisionsAnywhereInHistory(t *testing.T) {
 	updatedPod := &v1.Pod{}
 	err = testutil.Get(k8sClient, updatedPod, oldPod.Name, oldPod.Namespace)
 	require.NoError(t, err)
-	require.Equal(t, dupHistory2.Labels[defaultStorageClusterUniqueLabelKey],
-		updatedPod.Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, dupHistory2.Labels[util.DefaultStorageClusterUniqueLabelKey],
+		updatedPod.Labels[util.DefaultStorageClusterUniqueLabelKey])
 }
 
 func TestHistoryCleanup(t *testing.T) {
@@ -8605,7 +8605,7 @@ func TestHistoryCleanup(t *testing.T) {
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 	k8sNode1 := createK8sNode("k8s-node-1", 10)
@@ -8645,8 +8645,8 @@ func TestHistoryCleanup(t *testing.T) {
 	// Ensure that the older revision gets deleted as it is not used.
 	runningPod1, err := k8scontroller.GetPodFromTemplate(&podControl.Templates[3], cluster, clusterRef)
 	require.NoError(t, err)
-	require.Equal(t, latestRevision(revisions).Labels[defaultStorageClusterUniqueLabelKey],
-		runningPod1.Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, latestRevision(revisions).Labels[util.DefaultStorageClusterUniqueLabelKey],
+		runningPod1.Labels[util.DefaultStorageClusterUniqueLabelKey])
 	runningPod1.Name = runningPod1.GenerateName + "1"
 	runningPod1.Namespace = cluster.Namespace
 	runningPod1.Spec.NodeName = k8sNode1.Name
@@ -8678,8 +8678,8 @@ func TestHistoryCleanup(t *testing.T) {
 
 	runningPod2, err := k8scontroller.GetPodFromTemplate(&podControl.Templates[0], cluster, clusterRef)
 	require.NoError(t, err)
-	require.Equal(t, latestRevision(revisions).Labels[defaultStorageClusterUniqueLabelKey],
-		runningPod2.Labels[defaultStorageClusterUniqueLabelKey])
+	require.Equal(t, latestRevision(revisions).Labels[util.DefaultStorageClusterUniqueLabelKey],
+		runningPod2.Labels[util.DefaultStorageClusterUniqueLabelKey])
 	runningPod2.Name = runningPod2.GenerateName + "2"
 	runningPod2.Namespace = cluster.Namespace
 	runningPod2.Spec.NodeName = k8sNode2.Name
@@ -8985,7 +8985,7 @@ func TestDoesTelemetryMatch(t *testing.T) {
 		driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
 		driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
 		driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
-		driver.EXPECT().UpdateStorageClusterStatus(gomock.Any()).Return(nil).AnyTimes()
+		driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 		driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 		condition := &corev1.ClusterCondition{
@@ -9004,7 +9004,7 @@ func TestDoesTelemetryMatch(t *testing.T) {
 		require.NoError(t, err)
 
 		// Pods that are already running on the k8s nodes with same hash
-		storageLabels[defaultStorageClusterUniqueLabelKey] = rev1Hash
+		storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 		oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
 		oldPod.Status.Conditions = []v1.PodCondition{
 			{
@@ -9292,7 +9292,7 @@ func createRevision(
 	if err := k8sClient.Create(context.TODO(), history); err != nil {
 		return "", err
 	}
-	return history.Labels[defaultStorageClusterUniqueLabelKey], nil
+	return history.Labels[util.DefaultStorageClusterUniqueLabelKey], nil
 }
 
 func deleteRevision(
@@ -9307,7 +9307,7 @@ func deleteRevision(
 	if err := k8sClient.Delete(context.TODO(), history); err != nil {
 		return "", err
 	}
-	return history.Labels[defaultStorageClusterUniqueLabelKey], nil
+	return history.Labels[util.DefaultStorageClusterUniqueLabelKey], nil
 }
 
 func getRevision(
@@ -9326,9 +9326,9 @@ func getRevision(
 			Name:      historyName(cluster.Name, hash),
 			Namespace: cluster.Namespace,
 			Labels: map[string]string{
-				constants.LabelKeyClusterName:       cluster.Name,
-				constants.LabelKeyDriverName:        driverName,
-				defaultStorageClusterUniqueLabelKey: hash,
+				constants.LabelKeyClusterName:            cluster.Name,
+				constants.LabelKeyDriverName:             driverName,
+				util.DefaultStorageClusterUniqueLabelKey: hash,
 			},
 			Annotations:     cluster.Annotations,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(cluster, controllerKind)},

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -68,20 +68,19 @@ const (
 	// ControllerName is the name of the controller
 	ControllerName = "storagecluster-controller"
 	// ComponentName is the component name of the storage cluster
-	ComponentName                       = "storage"
-	slowStartInitialBatchSize           = 1
-	validateCRDInterval                 = 5 * time.Second
-	validateCRDTimeout                  = 1 * time.Minute
-	deleteFinalizerName                 = constants.OperatorPrefix + "/delete"
-	nodeNameIndex                       = "nodeName"
-	defaultStorageClusterUniqueLabelKey = apps.ControllerRevisionHashLabelKey
-	defaultRevisionHistoryLimit         = 10
-	defaultMaxUnavailablePods           = 1
-	failureDomainZoneKey                = v1.LabelZoneFailureDomainStable
-	crdBasePath                         = "/crds"
-	deprecatedCRDBasePath               = "/crds/deprecated"
-	storageClusterCRDFile               = "core_v1_storagecluster_crd.yaml"
-	minSupportedK8sVersion              = "1.21.0"
+	ComponentName               = "storage"
+	slowStartInitialBatchSize   = 1
+	validateCRDInterval         = 5 * time.Second
+	validateCRDTimeout          = 1 * time.Minute
+	deleteFinalizerName         = constants.OperatorPrefix + "/delete"
+	nodeNameIndex               = "nodeName"
+	defaultRevisionHistoryLimit = 10
+	defaultMaxUnavailablePods   = 1
+	failureDomainZoneKey        = v1.LabelZoneFailureDomainStable
+	crdBasePath                 = "/crds"
+	deprecatedCRDBasePath       = "/crds/deprecated"
+	storageClusterCRDFile       = "core_v1_storagecluster_crd.yaml"
+	minSupportedK8sVersion      = "1.21.0"
 )
 
 var _ reconcile.Reconciler = &Controller{}
@@ -623,7 +622,7 @@ func (c *Controller) syncStorageCluster(
 		return fmt.Errorf("failed to construct revisions of StorageCluster %v/%v: %v",
 			cluster.Namespace, cluster.Name, err)
 	}
-	hash := cur.Labels[defaultStorageClusterUniqueLabelKey]
+	hash := cur.Labels[util.DefaultStorageClusterUniqueLabelKey]
 
 	// TODO: Don't process a storage cluster until all its previous creations and
 	// deletions have been processed.
@@ -647,7 +646,7 @@ func (c *Controller) syncStorageCluster(
 	}
 
 	// Update status of the cluster
-	return c.updateStorageClusterStatus(cluster)
+	return c.updateStorageClusterStatus(cluster, hash)
 }
 
 func (c *Controller) deleteStorageCluster(
@@ -797,9 +796,10 @@ func (c *Controller) removeMigrationLabels() error {
 
 func (c *Controller) updateStorageClusterStatus(
 	cluster *corev1.StorageCluster,
+	clusterHash string,
 ) error {
 	toUpdate := cluster.DeepCopy()
-	if err := c.Driver.UpdateStorageClusterStatus(toUpdate); err != nil {
+	if err := c.Driver.UpdateStorageClusterStatus(toUpdate, clusterHash); err != nil {
 		k8s.WarningEvent(c.recorder, cluster, util.FailedSyncReason, err.Error())
 	}
 	return k8s.UpdateStorageClusterStatus(c.client, toUpdate)
@@ -1213,7 +1213,7 @@ func (c *Controller) CreatePodTemplate(
 		}
 	}
 	if len(hash) > 0 {
-		newTemplate.Labels[defaultStorageClusterUniqueLabelKey] = hash
+		newTemplate.Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
 	}
 	return newTemplate, nil
 }
@@ -1283,6 +1283,7 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 	}
 
 	if err := c.Driver.SetDefaultsOnStorageCluster(toUpdate); err != nil {
+		// TODO: investigate update failure
 		return err
 	}
 

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -376,6 +376,7 @@ func (c *Controller) syncStorage(
 			}
 
 			if updateNeeded {
+				// TODO: get latest pod to update
 				if err := c.client.Update(context.TODO(), podCopy); err != nil {
 					return err
 				}

--- a/pkg/mock/storagedriver.mock.go
+++ b/pkg/mock/storagedriver.mock.go
@@ -228,17 +228,17 @@ func (mr *MockDriverMockRecorder) UpdateDriver(arg0 interface{}) *gomock.Call {
 }
 
 // UpdateStorageClusterStatus mocks base method.
-func (m *MockDriver) UpdateStorageClusterStatus(arg0 *v1.StorageCluster) error {
+func (m *MockDriver) UpdateStorageClusterStatus(arg0 *v1.StorageCluster, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStorageClusterStatus", arg0)
+	ret := m.ctrl.Call(m, "UpdateStorageClusterStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateStorageClusterStatus indicates an expected call of UpdateStorageClusterStatus.
-func (mr *MockDriverMockRecorder) UpdateStorageClusterStatus(arg0 interface{}) *gomock.Call {
+func (mr *MockDriverMockRecorder) UpdateStorageClusterStatus(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStorageClusterStatus", reflect.TypeOf((*MockDriver)(nil).UpdateStorageClusterStatus), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStorageClusterStatus", reflect.TypeOf((*MockDriver)(nil).UpdateStorageClusterStatus), arg0, arg1)
 }
 
 // Validate mocks base method.

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
+	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,6 +69,8 @@ const (
 	StoragelessNodeValue = "storageless"
 	// StoragePartitioningEnvKey is the storage spec environment variable used to set storage/storageless node type
 	StoragePartitioningEnvKey = "ENABLE_ASG_STORAGE_PARTITIONING"
+	// DefaultStorageClusterUniqueLabelKey is the controller revision hash of storage cluster
+	DefaultStorageClusterUniqueLabelKey = apps.ControllerRevisionHashLabelKey
 )
 
 var (

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -469,7 +469,7 @@ func TestUpdateStorageClusterCondition(t *testing.T) {
 	// TestCase: add second condition
 	expectedCondition2 := &corev1.ClusterCondition{
 		Source: portworxComponentName,
-		Type:   corev1.ClusterConditionTypeUpgrade,
+		Type:   corev1.ClusterConditionTypeUpdate,
 		Status: corev1.ClusterConditionStatusInProgress,
 	}
 	UpdateStorageClusterCondition(cluster, expectedCondition2)
@@ -483,7 +483,7 @@ func TestUpdateStorageClusterCondition(t *testing.T) {
 	timestamp = metav1.NewTime(time.Now().Truncate(time.Second))
 	expectedCondition2 = &corev1.ClusterCondition{
 		Source:  portworxComponentName,
-		Type:    corev1.ClusterConditionTypeUpgrade,
+		Type:    corev1.ClusterConditionTypeUpdate,
 		Status:  corev1.ClusterConditionStatusFailed,
 		Message: "upgrade failed",
 	}
@@ -499,7 +499,7 @@ func TestUpdateStorageClusterCondition(t *testing.T) {
 	timestamp = metav1.NewTime(time.Now().Add(time.Second).Truncate(time.Second))
 	expectedCondition2 = &corev1.ClusterCondition{
 		Source:             portworxComponentName,
-		Type:               corev1.ClusterConditionTypeUpgrade,
+		Type:               corev1.ClusterConditionTypeUpdate,
 		Status:             corev1.ClusterConditionStatusCompleted,
 		LastTransitionTime: timestamp,
 	}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* Add `Updating` status to StorageNode `NodeState` condition
* Compare px pod has with StorageNode hash to check if StorageNode is updated

**Which issue(s) this PR fixes** (optional)
Closes # PWX-28655

**Special notes for your reviewer**:
install in progress
```
    - lastTransitionTime: "2023-02-28T23:11:53Z"
      message: Portworx installation completed on 0/4 nodes, 4 nodes remaining
      source: Portworx
      status: InProgress
      type: Install
```
```
    - lastTransitionTime: "2023-02-28T23:16:08Z"
      message: Portworx installation completed on 1/4 nodes, 3 nodes remaining
      source: Portworx
      status: InProgress
      type: Install
```
```
    - lastTransitionTime: "2023-02-28T23:17:52Z"
      message: Portworx installation completed on 4 nodes
      source: Portworx
      status: Completed
      type: Install
```
update:
```
    - lastTransitionTime: "2023-02-28T23:20:58Z"
      message: Portworx update in progress, 4 nodes remaining
      source: Portworx
      status: InProgress
      type: Update
kube-system   operator-dev-test-jliao-2-1   317e9787-e726-4529-827e-525edfdb70e1   Online      2.13.0-bc68491   10m
kube-system   operator-dev-test-jliao-2-2   883d3299-12c5-4f44-a3b4-8897471c372e   Online      2.13.0-bc68491   10m
kube-system   operator-dev-test-jliao-2-3   f27af465-b23e-4562-b9f3-ee8fd2d006b2   Updating   2.13.0-bc68491   10m
kube-system   operator-dev-test-jliao-2-4   c954c685-0724-48e2-993e-e3be548efe34   Online      2.13.0-bc68491   10m
```
```
    - lastTransitionTime: "2023-02-28T23:30:00Z"
      message: Portworx update in progress, 2 nodes remaining
      source: Portworx
      status: InProgress
      type: Update
```
```
    - lastTransitionTime: "2023-02-28T23:38:14Z"
      message: Portworx update completed
      source: Portworx
      status: Completed
      type: Update
```