### PR TITLE
[PWX-26954] Enable telemetry by default on PX 2.12+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifndef DOCKER_HUB_REGISTRY_IMG
     $(warning DOCKER_HUB_REGISTRY_IMG not defined, using '$(DOCKER_HUB_REGISTRY_IMG)' instead)
 endif
 ifndef BASE_REGISTRY_IMG
-    BASE_REGISTRY_IMG := docker.io/portworx/px-operator-registry:1.10.3
+    BASE_REGISTRY_IMG := docker.io/portworx/px-operator-registry:1.10.4
     $(warning BASE_REGISTRY_IMG not defined, using '$(BASE_REGISTRY_IMG)' instead)
 endif
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.7-1049.1675784874
+FROM registry.access.redhat.com/ubi8-minimal:8.7-1085
 
 RUN microdnf update
 RUN microdnf --enablerepo=rhel-7-server-rpms \

--- a/test/integration_test/utils/px_operator.go
+++ b/test/integration_test/utils/px_operator.go
@@ -26,6 +26,8 @@ var (
 	PxOperatorVer1_8, _ = version.NewVersion("1.8-")
 	// PxOperatorVer1_8_1 portworx-operator 1.8.1 minimum version
 	PxOperatorVer1_8_1, _ = version.NewVersion("1.8.1-")
+	// PxOperatorVer1_11 portworx-operator 1.11 minimum version
+	PxOperatorVer1_11, _ = version.NewVersion("1.11-")
 )
 
 // TODO: Install portworx-operator in test automation


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* Enable telemetry by default on PX 2.12+ (ccm-go) if custom proxy not specified or cluster is not air-gapped
* Update telemetry regression test

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
telemetry regression test: telemetry is enabled by default https://jenkins.pwx.dev.purestorage.com/view/Newstack%20Dashboard/job/Operator/job/operator-integration-basic-master/207/console
