### PR TITLE
[pwx-28659] Get live StorageCluster to update and tolerant revision conflict errors

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -1165,6 +1165,45 @@ func TestFailureDuringDriverPreInstall(t *testing.T) {
 	require.Contains(t, actualEvent, "preinstall error")
 }
 
+func TestStorageClusterFailedSyncObjectModified(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	driverName := "mock-driver"
+	cluster := createStorageCluster()
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient := testutil.FakeK8sClient(cluster)
+	podControl := &k8scontroller.FakePodControl{}
+	recorder := record.NewFakeRecorder(10)
+	controller := Controller{
+		client:            k8sClient,
+		Driver:            driver,
+		podControl:        podControl,
+		recorder:          recorder,
+		kubernetesVersion: k8sVersion,
+		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+	}
+
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
+	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil)
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).Return(fmt.Errorf(k8s.UpdateRevisionConflictErr))
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return(driverName).AnyTimes()
+
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+	// When failed to sync StorageCluster due to object modified, don't raise an event
+	result, err := controller.Reconcile(context.TODO(), request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+	require.Len(t, recorder.Events, 0)
+}
+
 func TestStoragePodsShouldNotBeScheduledIfDisabled(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -40,7 +40,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -236,10 +235,9 @@ func (c *Controller) Reconcile(_ context.Context, request reconcile.Request) (re
 
 	if err := c.validate(cluster); err != nil {
 		k8s.WarningEvent(c.recorder, cluster, util.FailedValidationReason, err.Error())
-		if updateErr := c.updateLiveStorageClusterState(cluster, corev1.ClusterStateDegraded); updateErr != nil {
+		if updateErr := util.UpdateLiveStorageClusterLifecycle(c.client, cluster, corev1.ClusterStateDegraded); updateErr != nil {
 			logrus.Errorf("Failed to update StorageCluster status. %v", updateErr)
 		}
-
 		return reconcile.Result{}, err
 	}
 
@@ -255,8 +253,14 @@ func (c *Controller) Reconcile(_ context.Context, request reconcile.Request) (re
 	}
 
 	if err := c.syncStorageCluster(cluster); err != nil {
+		// Ignore object revision conflict errors, as StorageCluster can be edited in different places,
+		// the next reconcile loop should be able to resolve the issue
+		if strings.Contains(err.Error(), k8s.UpdateRevisionConflictErr) {
+			logrus.Warnf("failed to sync StorageCluster %s/%s: %v", cluster.Namespace, cluster.Name, err)
+			return reconcile.Result{}, nil
+		}
 		k8s.WarningEvent(c.recorder, cluster, util.FailedSyncReason, err.Error())
-		if updateErr := c.updateLiveStorageClusterState(cluster, corev1.ClusterStateDegraded); updateErr != nil {
+		if updateErr := util.UpdateLiveStorageClusterLifecycle(c.client, cluster, corev1.ClusterStateDegraded); updateErr != nil {
 			logrus.Errorf("Failed to update StorageCluster status. %v", updateErr)
 		}
 		return reconcile.Result{}, err
@@ -458,12 +462,12 @@ func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
 	// Update the cluster only if anything has changed
 	if !reflect.DeepEqual(cluster, toUpdate) {
 		toUpdate.DeepCopyInto(cluster)
-		if err := c.client.Update(context.TODO(), cluster); err != nil {
+		if err := k8s.UpdateStorageCluster(c.client, cluster); err != nil {
 			return err
 		}
 
 		cluster.Status = *toUpdate.Status.DeepCopy()
-		if err := c.client.Status().Update(context.TODO(), cluster); err != nil {
+		if err := k8s.UpdateStorageClusterStatus(c.client, cluster); err != nil {
 			return err
 		}
 	}
@@ -590,7 +594,7 @@ func (c *Controller) syncStorageCluster(
 	if cluster.DeletionTimestamp != nil {
 		logrus.Infof("Storage cluster %v/%v has been marked for deletion",
 			cluster.Namespace, cluster.Name)
-		if err := c.updateLiveStorageClusterState(cluster, corev1.ClusterStateUninstall); err != nil {
+		if err := util.UpdateLiveStorageClusterLifecycle(c.client, cluster, corev1.ClusterStateUninstall); err != nil {
 			logrus.Errorf("Failed to update StorageCluster status. %v", err)
 			return err
 		}
@@ -720,7 +724,7 @@ func (c *Controller) deleteStorageCluster(
 
 			newFinalizers := removeDeleteFinalizer(toDelete.Finalizers)
 			toDelete.Finalizers = newFinalizers
-			if err := c.client.Update(context.TODO(), toDelete); err != nil && !errors.IsNotFound(err) {
+			if err := k8s.UpdateStorageCluster(c.client, toDelete); err != nil && !errors.IsNotFound(err) {
 				return err
 			}
 		}
@@ -798,26 +802,6 @@ func (c *Controller) updateStorageClusterStatus(
 	if err := c.Driver.UpdateStorageClusterStatus(toUpdate); err != nil {
 		k8s.WarningEvent(c.recorder, cluster, util.FailedSyncReason, err.Error())
 	}
-	return k8s.UpdateStorageClusterStatus(c.client, toUpdate)
-}
-
-func (c *Controller) updateLiveStorageClusterState(
-	cluster *corev1.StorageCluster,
-	clusterState corev1.ClusterState,
-) error {
-	toUpdate := &corev1.StorageCluster{}
-	err := c.client.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      cluster.Name,
-			Namespace: cluster.Namespace,
-		},
-		toUpdate,
-	)
-	if err != nil {
-		return err
-	}
-	toUpdate.Status.Phase = string(clusterState)
 	return k8s.UpdateStorageClusterStatus(c.client, toUpdate)
 }
 
@@ -1307,12 +1291,14 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 	// Update the cluster only if anything has changed
 	if !reflect.DeepEqual(cluster, toUpdate) {
 		toUpdate.DeepCopyInto(cluster)
-		if err := c.client.Update(context.TODO(), cluster); err != nil {
+		if err := k8s.UpdateStorageCluster(c.client, cluster); err != nil {
 			return err
 		}
 
+		// NOTE: race condition can happen when updating status right after spec,
+		// revision got from live cluster can become stale, so ignoring the error in syncStorageCluster
 		cluster.Status = *toUpdate.Status.DeepCopy()
-		if err := c.client.Status().Update(context.TODO(), cluster); err != nil {
+		if err := k8s.UpdateStorageClusterStatus(c.client, cluster); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 
 	storageapi "github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/operator/drivers/storage/portworx/util"
@@ -642,7 +643,11 @@ func (c *Controller) syncStoragePod(
 		pod.Labels[defaultStorageClusterUniqueLabelKey] = hash
 		if err := c.client.Update(context.TODO(), pod); err != nil {
 			errMsg := fmt.Sprintf("Unable to update storage pod: %v", err)
-			k8s.WarningEvent(c.recorder, cluster, operatorutil.FailedStoragePodReason, errMsg)
+			if strings.Contains(err.Error(), k8s.UpdateRevisionConflictErr) {
+				logrus.Warnf(errMsg)
+			} else {
+				k8s.WarningEvent(c.recorder, cluster, operatorutil.FailedStoragePodReason, errMsg)
+			}
 		}
 	}
 

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -108,6 +108,10 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if err := c.syncStorageNode(storagenode); err != nil {
+		if strings.Contains(err.Error(), k8s.UpdateRevisionConflictErr) {
+			logrus.Warnf("failed to sync StorageNode %s/%s: %v", storagenode.Namespace, storagenode.Name, err)
+			return reconcile.Result{}, nil
+		}
 		k8s.WarningEvent(c.recorder, storagenode, util.FailedSyncReason, err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -44,6 +44,9 @@ const (
 	NodeRoleLabelControlPlane = "node-role.kubernetes.io/control-plane"
 	NodeRoleLabelInfra        = "node-role.kubernetes.io/infra"
 	NodeRoleLabelWorker       = "node-role.kubernetes.io/worker"
+
+	// UpdateRevisionConflictErr contains controller-runtime update error message when updating stale objects
+	UpdateRevisionConflictErr = "the object has been modified; please apply your changes to the latest version and try again"
 )
 
 var (
@@ -1220,8 +1223,31 @@ func DeleteDaemonSet(
 	return k8sClient.Update(context.TODO(), ds)
 }
 
-// UpdateStorageClusterStatus updates the status of given StorageCluster object
-// on the latest copy
+// UpdateStorageCluster updates given StorageCluster object on the latest copy
+func UpdateStorageCluster(
+	k8sClient client.Client,
+	cluster *corev1.StorageCluster,
+) error {
+	existingCluster := &corev1.StorageCluster{}
+	if err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+		existingCluster,
+	); err != nil {
+		return err
+	}
+
+	cluster.ResourceVersion = existingCluster.ResourceVersion
+	if !reflect.DeepEqual(cluster, existingCluster) {
+		return k8sClient.Update(context.TODO(), cluster)
+	}
+	return nil
+}
+
+// UpdateStorageClusterStatus updates the status of given StorageCluster object on the latest copy
 func UpdateStorageClusterStatus(
 	k8sClient client.Client,
 	cluster *corev1.StorageCluster,
@@ -1239,7 +1265,10 @@ func UpdateStorageClusterStatus(
 	}
 
 	cluster.ResourceVersion = existingCluster.ResourceVersion
-	return k8sClient.Status().Update(context.TODO(), cluster)
+	if !reflect.DeepEqual(cluster.Status, existingCluster.Status) {
+		return k8sClient.Status().Update(context.TODO(), cluster)
+	}
+	return nil
 }
 
 // CreateOrUpdateStorageNode creates a StorageNode if not present, else updates it

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -15,6 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
@@ -532,6 +533,31 @@ func UpdateStorageClusterCondition(
 		indexSorted++
 	}
 	cluster.Status.Conditions = sortedConditions
+}
+
+// UpdateLiveStorageClusterLifecycle updates live storage cluster phase only to report cluster lifecycle
+func UpdateLiveStorageClusterLifecycle(
+	k8sClient client.Client,
+	cluster *corev1.StorageCluster,
+	clusterState corev1.ClusterState,
+) error {
+	cluster.Status.Phase = string(clusterState)
+	toUpdate := &corev1.StorageCluster{}
+	if err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+		toUpdate,
+	); err != nil {
+		return err
+	} else if toUpdate.Status.Phase == string(clusterState) {
+		return nil
+	}
+
+	toUpdate.Status.Phase = string(clusterState)
+	return k8sClient.Status().Update(context.TODO(), toUpdate)
 }
 
 // GetStorageClusterCondition returns the condition based on source and type


### PR DESCRIPTION
…

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* During fresh install objects created by operator could be modified by k8s, causing operator failing to update them and raising error "the object has been modified; please apply your changes to the latest version and try again"
* Tolerant error above in operator reconcile loops
* Do a get before updating stc and update the object revision to avoid hitting revision conflicts
* Fixed the issue stc status showing Degraded during fresh install


**Which issue(s) this PR fixes** (optional)
Closes # PWX-28659

**Special notes for your reviewer**:

