### PR TITLE
[pwx-26954] Disable telemetry if it's enabled with custom proxy

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -600,7 +600,7 @@ func (t *telemetry) createCCMGoConfigMapRegisterProxy(
 		configParameterRegisterCloudSupportPort: fmt.Sprint(cloudSupportPort),
 	}
 
-	proxy := pxutil.GetPxProxyEnvVarValue(cluster)
+	_, proxy := pxutil.GetPxProxyEnvVarValue(cluster)
 	if proxy != "" && t.usePxProxy {
 		address, port, err := pxutil.SplitPxProxyHostPort(proxy)
 		if err != nil {
@@ -649,7 +649,7 @@ func (t *telemetry) createCCMGoConfigMapTelemetryPhonehomeProxy(
 		configParameterRestCloudSupportPort: fmt.Sprint(cloudSupportPort),
 	}
 
-	proxy := pxutil.GetPxProxyEnvVarValue(cluster)
+	_, proxy := pxutil.GetPxProxyEnvVarValue(cluster)
 	if proxy != "" && t.usePxProxy {
 		address, port, err := pxutil.SplitPxProxyHostPort(proxy)
 		if err != nil {
@@ -700,7 +700,7 @@ func (t *telemetry) createCCMGoConfigMapCollectorProxyV2(
 		configParameterComponentSN:          "portworx-metrics-node",
 	}
 
-	proxy := pxutil.GetPxProxyEnvVarValue(cluster)
+	_, proxy := pxutil.GetPxProxyEnvVarValue(cluster)
 	if proxy != "" && t.usePxProxy {
 		address, port, err := pxutil.SplitPxProxyHostPort(proxy)
 		if err != nil {

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -735,7 +735,7 @@ func (t *telemetry) reconcileCCMJavaProxyConfigMap(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	proxy := pxutil.GetPxProxyEnvVarValue(cluster)
+	_, proxy := pxutil.GetPxProxyEnvVarValue(cluster)
 	// Delete the existing config map if portworx proxy is empty
 	if proxy == "" {
 		return k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef)

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -4964,6 +4965,24 @@ func setupEtcHosts(t *testing.T, ip string, hostnames ...string) {
 	require.NoError(t, err)
 	assert.Equal(t, bb.Len(), n, "short write")
 	fd.Close()
+
+	// waiting for dns can be resolved
+	for i := 0; i < 60; i++ {
+		var ips []net.IP
+		ips, err = net.LookupIP(hostnames[0])
+		if err != nil || !strings.Contains(fmt.Sprintf("%v", ips), ip) {
+			logrus.WithFields(logrus.Fields{
+				"error": err,
+				"ips":   ips,
+				"ip":    ip,
+				"hosts": hostnames,
+			}).Warnf("failed to set /etc/hosts, retrying")
+			time.Sleep(1 * time.Second)
+			continue
+		}
+		break
+	}
+	require.NoError(t, err)
 }
 
 func restoreEtcHosts(t *testing.T) {
@@ -13735,18 +13754,30 @@ func TestSetTelemetryDefaults(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, cluster.Spec.Monitoring)
 
-	// TestCase: telemetry should not be enabled by default if cluster UUID is not ready
+	// TestCase: telemetry should be disabled if using custom proxy on ccm-go
 	cluster.Spec.Image = "portworx/oci-monitor:2.12.0"
+	cluster.Spec.Env = []v1.EnvVar{{
+		Name:  pxutil.EnvKeyPortworxHTTPSProxy,
+		Value: "test-proxy",
+	}}
+	cluster.Spec.Monitoring = &corev1.MonitoringSpec{
+		Telemetry: &corev1.TelemetrySpec{
+			Enabled: true,
+		},
+	}
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
-	require.Nil(t, cluster.Spec.Monitoring)
+	require.NotNil(t, cluster.Spec.Monitoring)
+	require.NotNil(t, cluster.Spec.Monitoring.Telemetry)
+	require.False(t, cluster.Spec.Monitoring.Telemetry.Enabled)
+	require.Empty(t, cluster.Spec.Monitoring.Telemetry.Image)
 
 	// TestCase: telemetry should not be enabled by default if proxy is configured
+	cluster.Spec.Monitoring = nil
 	cluster.Spec.Env = []v1.EnvVar{{
 		Name:  pxutil.EnvKeyPortworxHTTPProxy,
 		Value: "test-proxy",
 	}}
-	cluster.Status.ClusterUID = "test-uuid"
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 	require.Nil(t, cluster.Spec.Monitoring)
@@ -13764,13 +13795,20 @@ func TestSetTelemetryDefaults(t *testing.T) {
 	require.NotNil(t, cluster.Spec.Monitoring.Telemetry)
 	require.False(t, cluster.Spec.Monitoring.Telemetry.Enabled)
 
-	// TestCase: telemetry should not be enabled by default if prod register endpoint is unreachable
-	setupEtcHosts(t, "1.2.3.4", "register.cloud-support.purestorage.com")
+	// TestCase: telemetry should not be enabled by default if uuid is not ready
 	cluster.Spec.Monitoring = nil
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 	require.Nil(t, cluster.Spec.Monitoring)
-	restoreEtcHosts(t)
+
+	// TestCase: telemetry should not be enabled by default if prod register endpoint is unreachable
+	cluster.Status.ClusterUID = "cluster-uid"
+	setupEtcHosts(t, "127.0.0.1", "register.cloud-support.purestorage.com")
+	defer restoreEtcHosts(t)
+	cluster.Spec.Monitoring = nil
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	require.Nil(t, cluster.Spec.Monitoring)
 
 	// TestCase: telemetry should be enabled by default if staging register endpoint is reachable
 	cluster.Spec.Env = nil

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1509,7 +1509,7 @@ func (t *template) getTelemetryVolumeInfoList() []volumeInfo {
 			configVolume,
 		}
 
-		if pxutil.GetPxProxyEnvVarValue(t.cluster) != "" {
+		if _, proxy := pxutil.GetPxProxyEnvVarValue(t.cluster); proxy != "" {
 			volumeInfoList = append(volumeInfoList, volumeInfo{
 				name:      "ccm-proxy-config",
 				mountPath: component.TelemetryCCMProxyFilePath,

--- a/drivers/storage/portworx/manifest/remote.go
+++ b/drivers/storage/portworx/manifest/remote.go
@@ -65,7 +65,8 @@ func (m *remote) downloadVersionManifest(
 	params.Add("kbver", m.k8sVersion.String())
 	u.RawQuery = params.Encode()
 
-	body, err := getManifestFromURL(u.String(), pxutil.GetPxProxyEnvVarValue(m.cluster))
+	_, proxy := pxutil.GetPxProxyEnvVarValue(m.cluster)
+	body, err := getManifestFromURL(u.String(), proxy)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -1307,8 +1307,11 @@ func setTelemetryDefaults(
 	// TODO: pwx-29521 uuid is checked here to avoid unit tests sending requests to arcus endpoint
 	if !pxutil.IsCCMGoSupported(pxVersion) ||
 		(toUpdate.Spec.Monitoring != nil && toUpdate.Spec.Monitoring.Telemetry != nil) ||
-		toUpdate.Status.ClusterUID == "" ||
-		pxutil.GetPxProxyEnvVarValue(toUpdate) != "" {
+		toUpdate.Status.ClusterUID == "" {
+		return nil
+	}
+	if _, proxy := pxutil.GetPxProxyEnvVarValue(toUpdate); proxy != "" {
+		// Don't enable telemetry if either of http or https proxy is specified
 		return nil
 	}
 	canAccess, err := component.CanAccessArcusRegisterEndpoint(toUpdate)

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -637,16 +637,26 @@ func GetClusterEnvVarValue(ctx context.Context, cluster *corev1.StorageCluster, 
 
 // GetPxProxyEnvVarValue returns the PX_HTTP(S)_PROXY environment variable value for a cluster.
 // Note: we only expect one proxy for the telemetry CCM container but we prefer https over http if both are specified
-func GetPxProxyEnvVarValue(cluster *corev1.StorageCluster) string {
+func GetPxProxyEnvVarValue(cluster *corev1.StorageCluster) (string, string) {
 	httpProxy := ""
 	for _, env := range cluster.Spec.Env {
-		if env.Name == EnvKeyPortworxHTTPSProxy {
-			return env.Value
-		} else if env.Name == EnvKeyPortworxHTTPProxy {
-			httpProxy = env.Value
+		key, val := env.Name, env.Value
+		if key == EnvKeyPortworxHTTPSProxy {
+			// If http proxy is specified in https env var, treat it as a http proxy endpoint
+			if strings.HasPrefix(val, "http://") {
+				logrus.Warnf("using endpoint %s from environment variable %s as a http proxy endpoint instead",
+					val, EnvKeyPortworxHTTPSProxy)
+				return EnvKeyPortworxHTTPProxy, val
+			}
+			return EnvKeyPortworxHTTPSProxy, val
+		} else if key == EnvKeyPortworxHTTPProxy {
+			httpProxy = val
 		}
 	}
-	return httpProxy
+	if httpProxy != "" {
+		return EnvKeyPortworxHTTPProxy, httpProxy
+	}
+	return "", ""
 }
 
 // SplitPxProxyHostPort trims protocol prefix then splits the proxy address of the form "host:port"
@@ -1111,10 +1121,18 @@ func ValidateTelemetry(cluster *corev1.StorageCluster) error {
 		// PX version is lower than 2.8
 		return fmt.Errorf("telemetry is not supported on Portworx version: %s", pxVersion)
 	} else if IsCCMGoSupported(pxVersion) {
-		if proxy := GetPxProxyEnvVarValue(cluster); proxy != "" {
-			// CCM Go is supported but custom proxy is enabled
+		proxyType, proxy := GetPxProxyEnvVarValue(cluster)
+		if proxy == "" {
+			return nil
+		} else if proxyType == EnvKeyPortworxHTTPProxy {
+			// CCM Go is enabled with http proxy, but it cannot be split into host and port
+			if _, _, err := SplitPxProxyHostPort(proxy); err != nil {
+				return fmt.Errorf("telemetry is not supported with proxy in a format of: %s", proxy)
+			}
+		} else if proxyType == EnvKeyPortworxHTTPSProxy {
+			// CCM Go is enabled with https proxy
 			// TODO: remove when custom proxy is supported
-			return fmt.Errorf("telemetry is not supported with custom proxy: %s", proxy)
+			return fmt.Errorf("telemetry is not supported with secure proxy: %s", proxy)
 		}
 	}
 

--- a/drivers/storage/portworx/util/util_test.go
+++ b/drivers/storage/portworx/util/util_test.go
@@ -366,6 +366,9 @@ func TestSplitPxProxyHostPort(t *testing.T) {
 
 	_, _, err = SplitPxProxyHostPort(":1234")
 	require.Error(t, err)
+
+	_, _, err = SplitPxProxyHostPort("user:password@host:1234")
+	require.Error(t, err)
 }
 
 func createClusterWithAuth() *corev1.StorageCluster {

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -9206,6 +9206,85 @@ func TestStorageClusterStateDuringValidation(t *testing.T) {
 	require.False(t, pxutil.IsFreshInstall(updatedCluster))
 }
 
+func TestStorageClusterValidateTelemetry(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/oci-monitor:2.7.0",
+			Monitoring: &corev1.MonitoringSpec{
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient := testutil.FakeK8sClient(cluster)
+	recorder := record.NewFakeRecorder(10)
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+
+	controller := Controller{
+		client:            k8sClient,
+		Driver:            driver,
+		recorder:          recorder,
+		kubernetesVersion: k8sVersion,
+	}
+
+	driver.EXPECT().Validate().Return(nil).AnyTimes()
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return("mock-driver").AnyTimes()
+	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+
+	// TestCase: raise warning when telemetry is enabled but px version is too low
+	_, err := controller.Reconcile(context.TODO(), request)
+	require.NoError(t, err)
+
+	require.Len(t, recorder.Events, 1)
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v telemetry will be disabled: telemetry is not supported on Portworx version",
+			v1.EventTypeWarning, util.FailedValidationReason))
+
+	// TestCase: raise warning when telemetry is enabled with custom proxy and ccm-go
+	currentCluster := &corev1.StorageCluster{}
+	err = testutil.Get(k8sClient, currentCluster, cluster.Name, cluster.Namespace)
+	require.NoError(t, err)
+
+	currentCluster.Spec.Image = "portworx/oci-monitor:2.12.0"
+	currentCluster.Spec.Env = []v1.EnvVar{{
+		Name:  pxutil.EnvKeyPortworxHTTPSProxy,
+		Value: "test-proxy",
+	}}
+	err = testutil.Update(k8sClient, currentCluster)
+	require.NoError(t, err)
+
+	_, err = controller.Reconcile(context.TODO(), request)
+	require.NoError(t, err)
+
+	require.Len(t, recorder.Events, 1)
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v telemetry will be disabled: telemetry is not supported with custom proxy",
+			v1.EventTypeWarning, util.FailedValidationReason))
+}
+
 func replaceOldPod(
 	oldPod *v1.Pod,
 	cluster *corev1.StorageCluster,

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -303,6 +303,11 @@ func (c *Controller) validate(cluster *corev1.StorageCluster) error {
 	if err := c.Driver.Validate(); err != nil {
 		return err
 	}
+	if err := pxutil.ValidateTelemetry(cluster); err != nil {
+		// Raise warning only and don't block anything
+		msg := fmt.Sprintf("telemetry will be disabled: %v", err)
+		k8s.WarningEvent(c.recorder, cluster, util.FailedValidationReason, msg)
+	}
 
 	return nil
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* Fresh install, telemetry will be enabled if
    * PX is 2.12+, so ccm-go is supported
    * telemetry is not disabled explicitly in the spec
    * no PX_HTTP_PROXY or PX_HTTPS_PROXY is specified in stc spec
    * no air-gapped, operator can reach to the registration endpoint
* Upgrade case:
    * if fresh install conditions above are met during upgrade, telemetry will be enabled by default
    * if already using telemetry enabled with proxy:
        * using PX_HTTP_PROXY in format of host:port or http://host:port, telemetry will be still enabled. this is the basic http proxy we have verified already, can be turn off at anytime
        * using http proxy but with auth, e.g. http://user:pass@host:port , telemetry will be disabled as this format is not supported yet
        * using PX_HTTPS_PROXY , telemetry will be disabled with any secure proxy. If http endpoint if provided, will be considered as PX_HTTP_PROXY

**Which issue(s) this PR fixes** (optional)
Closes # PWX-26954

**Special notes for your reviewer**:

