### PR TITLE
[PWX-29531] Fix SecurityContextConstraints to be compatible with open…

### DIFF
--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -3,7 +3,6 @@ package component
 import (
 	"context"
 	"fmt"
-
 	"github.com/hashicorp/go-version"
 	ocp_secv1 "github.com/openshift/api/security/v1"
 	"github.com/sirupsen/logrus"
@@ -14,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -85,18 +85,32 @@ func (s *scc) Reconcile(cluster *opcorev1.StorageCluster) error {
 	// Note SCC does not belong to namespace hence we don't set owner reference to StorageCluster.
 	// By design cross-namespace owner reference is invalid.
 	for _, scc := range s.getSCCs(cluster) {
+		existingScc := ocp_secv1.SecurityContextConstraints{}
 		err := s.k8sClient.Get(context.TODO(),
 			types.NamespacedName{
 				Name: scc.Name,
 			},
-			&ocp_secv1.SecurityContextConstraints{})
+			&existingScc)
 
 		if errors.IsNotFound(err) {
 			err = s.k8sClient.Create(context.TODO(), &scc)
-		}
-
-		if err != nil {
-			return fmt.Errorf("failed to create %s security context constraints: %s", scc.Name, err)
+			if err != nil {
+				return fmt.Errorf("failed to create %s security context constraints: %s", scc.Name, err)
+			}
+		} else if err == nil {
+			resourceVersion := existingScc.ResourceVersion
+			pxutil.CleanupObject(&scc)
+			pxutil.CleanupObject(&existingScc)
+			logrus.Infof("Updating %s security context constraints", scc.Name)
+			if !reflect.DeepEqual(scc, existingScc) {
+				scc.ResourceVersion = resourceVersion
+				err = s.k8sClient.Update(context.TODO(), &scc)
+				if err != nil {
+					return fmt.Errorf("failed to update %s security context constraints: %s", scc.Name, err)
+				}
+			}
+		} else {
+			return fmt.Errorf("failed to get %s security context constraints: %s", scc.Name, err)
 		}
 	}
 	return nil
@@ -170,6 +184,7 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, PVCServiceAccountName),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CollectorServiceAccountName),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-node-wiper"),
+				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"),
 			},
 		},
 	}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12836,6 +12836,15 @@ func TestSCC(t *testing.T) {
 	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedSCC, scc)
+
+	// Update SCC
+	scc.AllowHostNetwork = false
+	err = k8sClient.Update(context.TODO(), scc)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NoError(t, err)
 }
 
 func TestPodSecurityPoliciesEnabled(t *testing.T) {

--- a/drivers/storage/portworx/testspec/portworxSCC.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC.yaml
@@ -35,5 +35,6 @@ users:
 - system:serviceaccount:kube-test:portworx-pvc-controller
 - system:serviceaccount:kube-test:px-metrics-collector
 - system:serviceaccount:kube-test:px-node-wiper
+- system:serviceaccount:kube-test:px-prometheus
 volumes:
 - '*'

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1276,6 +1276,18 @@ func CountStorageNodes(
 	return storageNodesCount, nil
 }
 
+func CleanupObject(obj client.Object) {
+	obj.SetGenerateName("")
+	obj.SetUID("")
+	obj.SetResourceVersion("")
+	obj.SetGeneration(0)
+	obj.SetSelfLink("")
+	obj.SetCreationTimestamp(metav1.Time{})
+	obj.SetFinalizers(nil)
+	obj.SetOwnerReferences(nil)
+	obj.SetManagedFields(nil)
+}
+
 // IsFreshInstall checks whether it's a fresh Portworx install
 func IsFreshInstall(cluster *corev1.StorageCluster) bool {
 	// To handle failures during fresh install e.g. validation falures,

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -411,7 +411,7 @@ func (d *DryRun) simulateK8sNode() error {
 		}
 
 		for _, node := range nodeList.Items {
-			d.cleanupObject(&node)
+			pxutil.CleanupObject(&node)
 			err = d.mockClient.Create(context.TODO(), &node)
 			if err != nil {
 				return err
@@ -420,18 +420,6 @@ func (d *DryRun) simulateK8sNode() error {
 	}
 
 	return nil
-}
-
-func (d *DryRun) cleanupObject(obj client.Object) {
-	obj.SetGenerateName("")
-	obj.SetUID("")
-	obj.SetResourceVersion("")
-	obj.SetGeneration(0)
-	obj.SetSelfLink("")
-	obj.SetCreationTimestamp(metav1.Time{})
-	obj.SetFinalizers(nil)
-	obj.SetOwnerReferences(nil)
-	obj.SetManagedFields(nil)
 }
 
 func (d *DryRun) validateObjects(dsObjs, operatorObjs []client.Object, h *migration.Handler) error {
@@ -590,7 +578,7 @@ func (d *DryRun) getStorageCluster(storageClusterFile string) (*corev1.StorageCl
 		}
 		if len(clusterList.Items) > 0 {
 			cluster := &clusterList.Items[0]
-			d.cleanupObject(cluster)
+			pxutil.CleanupObject(cluster)
 			return cluster, nil
 		}
 	}


### PR DESCRIPTION
…shift

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Add px-prometheus to portworx scc (which uses runAsAny) to bypass the MustRunAsRange restrictions of runAsUser and runAsGroup.

**Which issue(s) this PR fixes** (optional)
Ticket: https://portworx.atlassian.net/browse/PWX-29531

**Test**:
Tested with portworx fresh installation on openshift.
Tested with upgrading portworx operator with SCC change and verify openshift SCC is gone.
Tested tuning prometheus spec to add PVC.

