### PR TITLE
PWX-26175-r2: Fixing license extension tests

### DIFF
--- a/test/integration_test/bluegreen_test.go
+++ b/test/integration_test/bluegreen_test.go
@@ -305,14 +305,22 @@ var bgTestCases = []types.TestCase{
 				logrus.Infof("Attempt volume creation on %s", lastPOD.Spec.NodeName)
 				err = runInPortworxPod(&lastPOD, nil, &stdout, &stderr,
 					"/opt/pwx/bin/pxctl", "volume", "create", "--repl", "1", "--size", "3", tmpVolName)
-				require.NoError(t, err)
 				require.Contains(t, stdout.String(), "Volume successfully created")
+				require.NoError(t, err)
 
 				logrus.Infof("Attempt volume snapshot on %s", lastPOD.Spec.NodeName)
 				err = runInPortworxPod(&lastPOD, nil, &stdout, &stderr,
 					"/opt/pwx/bin/pxctl", "volume", "snapshot", "create", "--name", "snap"+tmpSuffix, tmpVolName)
-				require.NoError(t, err)
 				require.Contains(t, stdout.String(), "Volume snap successful")
+				require.NoError(t, err)
+
+				logrus.Infof("Cleaning up volume / snapshot on %s", lastPOD.Spec.NodeName)
+				err = runInPortworxPod(&lastPOD, nil, &stdout, &stderr,
+					"/bin/sh", "-c", "/opt/pwx/bin/pxctl v delete --force snap"+tmpSuffix+
+						"; /opt/pwx/bin/pxctl v delete --force "+tmpVolName)
+				require.Contains(t, stdout.String(), "Volume snap"+tmpSuffix+" successfully deleted")
+				require.Contains(t, stdout.String(), "Volume "+tmpVolName+" successfully deleted")
+				require.NoError(t, err)
 			}
 		},
 		// ShouldSkip: func(tc *types.TestCase) bool { return true },


### PR DESCRIPTION
Adding cleanup of test volume/snapshot

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The tests include decommission of the px-nodes
* however, the test will sporadically fail, if the volume/snapshot has been created on the node we're attempting to decommission
* as a fix, we'll clean up the test volume/snapshot, so decommission should not complain about "destroying unique volumes"


**Which issue(s) this PR fixes** (optional)
Closes #  PWX-26175 (part 2)

**Special notes for your reviewer**:

This is a re-post of [now closed] https://github.com/libopenstorage/operator/pull/981