### PR TITLE
Add portworx-restricted scc

### DIFF
--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -320,7 +320,7 @@ func (c *csi) createClusterRole(
 			{
 				APIGroups:     []string{"security.openshift.io"},
 				Resources:     []string{"securitycontextconstraints"},
-				ResourceNames: []string{PxSCCName},
+				ResourceNames: []string{PxRestrictedSCCName},
 				Verbs:         []string{"use"},
 			},
 			{

--- a/drivers/storage/portworx/component/lighthouse.go
+++ b/drivers/storage/portworx/component/lighthouse.go
@@ -204,7 +204,7 @@ func (c *lighthouse) createClusterRole() error {
 				{
 					APIGroups:     []string{"security.openshift.io"},
 					Resources:     []string{"securitycontextconstraints"},
-					ResourceNames: []string{PxSCCName, "anyuid"},
+					ResourceNames: []string{PxRestrictedSCCName, "anyuid"},
 					Verbs:         []string{"use"},
 				},
 				{

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -238,7 +238,7 @@ func (c *pvcController) createClusterRole() error {
 				{
 					APIGroups:     []string{"security.openshift.io"},
 					Resources:     []string{"securitycontextconstraints"},
-					ResourceNames: []string{PxSCCName},
+					ResourceNames: []string{PxRestrictedSCCName},
 					Verbs:         []string{"use"},
 				},
 				{

--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -27,6 +27,8 @@ const (
 	SCCComponentName = "scc"
 	// PxSCCName name of portworx securityContextConstraints
 	PxSCCName = "portworx"
+	// PxRestrictedSCCName name of portworx-restricted securityContextConstraints
+	PxRestrictedSCCName = "portworx-restricted"
 	// PxNodeWiperServiceAccountName name of portworx node wiper service account
 	PxNodeWiperServiceAccountName = "px-node-wiper"
 )
@@ -217,12 +219,53 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 			Groups:  nil,
 			Users: []string{
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, pxutil.PortworxServiceAccountName(cluster)),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CSIServiceAccountName),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, LhServiceAccountName),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, PVCServiceAccountName),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CollectorServiceAccountName),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-node-wiper"),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"),
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: PxRestrictedSCCName,
+			},
+			AllowHostDirVolumePlugin: false,
+			AllowHostIPC:             false,
+			AllowHostNetwork:         false,
+			AllowHostPID:             false,
+			AllowHostPorts:           false,
+			AllowPrivilegeEscalation: boolPtr(true),
+			AllowPrivilegedContainer: false,
+			FSGroup: ocp_secv1.FSGroupStrategyOptions{
+				Type: ocp_secv1.FSGroupStrategyMustRunAs,
+			},
+			ReadOnlyRootFilesystem: false,
+			RequiredDropCapabilities: []corev1.Capability{
+				"KILL",
+				"MKNOD",
+				"SETUID",
+				"SETGID",
+			},
+			RunAsUser: ocp_secv1.RunAsUserStrategyOptions{
+				Type: ocp_secv1.RunAsUserStrategyMustRunAsRange,
+			},
+			SELinuxContext: ocp_secv1.SELinuxContextStrategyOptions{
+				Type: ocp_secv1.SELinuxStrategyMustRunAs,
+			},
+			SupplementalGroups: ocp_secv1.SupplementalGroupsStrategyOptions{
+				Type: ocp_secv1.SupplementalGroupsStrategyRunAsAny,
+			},
+			Volumes: []ocp_secv1.FSType{
+				ocp_secv1.FSTypeConfigMap,
+				ocp_secv1.FSTypeDownwardAPI,
+				ocp_secv1.FSTypeEmptyDir,
+				ocp_secv1.FSTypePersistentVolumeClaim,
+				ocp_secv1.FSProjected,
+				ocp_secv1.FSTypeSecret,
+			},
+			Users: []string{
+				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CSIServiceAccountName),
+				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, LhServiceAccountName),
+				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, PVCServiceAccountName),
 			},
 		},
 	}

--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -220,6 +220,7 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 			Users: []string{
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, pxutil.PortworxServiceAccountName(cluster)),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CollectorServiceAccountName),
+				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, ServiceAccountNameTelemetry),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-node-wiper"),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"),
 			},
@@ -228,9 +229,9 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 			ObjectMeta: metav1.ObjectMeta{
 				Name: PxRestrictedSCCName,
 			},
-			AllowHostDirVolumePlugin: false,
+			AllowHostDirVolumePlugin: true,
 			AllowHostIPC:             false,
-			AllowHostNetwork:         false,
+			AllowHostNetwork:         true,
 			AllowHostPID:             false,
 			AllowHostPorts:           false,
 			AllowPrivilegeEscalation: boolPtr(true),
@@ -258,10 +259,12 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 				ocp_secv1.FSTypeConfigMap,
 				ocp_secv1.FSTypeDownwardAPI,
 				ocp_secv1.FSTypeEmptyDir,
+				ocp_secv1.FSTypeHostPath,
 				ocp_secv1.FSTypePersistentVolumeClaim,
 				ocp_secv1.FSProjected,
 				ocp_secv1.FSTypeSecret,
 			},
+			Groups: nil,
 			Users: []string{
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CSIServiceAccountName),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, LhServiceAccountName),

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12900,6 +12900,11 @@ func TestSCC(t *testing.T) {
 	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
 	require.NotNil(t, err)
 
+	expectedPxRestrictedSCC := testutil.GetExpectedSCC(t, "portworxRestrictedSCC.yaml")
+	pxRestrictedSCC := &ocp_secv1.SecurityContextConstraints{}
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NotNil(t, err)
+
 	// Install with SCC enabled
 	crd := testutil.GetExpectedCRDV1(t, "sccCrd.yaml")
 	err = k8sClient.Create(context.TODO(), crd)
@@ -12911,13 +12916,25 @@ func TestSCC(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedSCC, scc)
 
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedSCC, scc)
+
 	// Update SCC
 	scc.AllowHostNetwork = false
 	err = k8sClient.Update(context.TODO(), scc)
 	require.NoError(t, err)
+
+	pxRestrictedSCC.AllowHostNetwork = true
+	err = k8sClient.Update(context.TODO(), pxRestrictedSCC)
+	require.NoError(t, err)
+
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NoError(t, err)
+
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
 	require.NoError(t, err)
 
 	// Update SCC priority

--- a/drivers/storage/portworx/testspec/csiClusterRole_k8s_1.11.yaml
+++ b/drivers/storage/portworx/testspec/csiClusterRole_k8s_1.11.yaml
@@ -53,7 +53,7 @@ rules:
   verbs: ["*"]
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
-  resourceNames: ["portworx"]
+  resourceNames: ["portworx-restricted"]
   verbs: ["use"]
 - apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]

--- a/drivers/storage/portworx/testspec/csiClusterRole_k8s_1.13.yaml
+++ b/drivers/storage/portworx/testspec/csiClusterRole_k8s_1.13.yaml
@@ -60,7 +60,7 @@ rules:
   verbs: ["*"]
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
-  resourceNames: ["portworx"]
+  resourceNames: ["portworx-restricted"]
   verbs: ["use"]
 - apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]

--- a/drivers/storage/portworx/testspec/csiClusterRole_k8s_1.14.yaml
+++ b/drivers/storage/portworx/testspec/csiClusterRole_k8s_1.14.yaml
@@ -56,7 +56,7 @@ rules:
   verbs: ["*"]
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
-  resourceNames: ["portworx"]
+  resourceNames: ["portworx-restricted"]
   verbs: ["use"]
 - apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]

--- a/drivers/storage/portworx/testspec/lighthouseClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/lighthouseClusterRole.yaml
@@ -30,7 +30,7 @@ rules:
     verbs: ["*"]
   - apiGroups: ["security.openshift.io"]
     resources: ["securitycontextconstraints"]
-    resourceNames: ["portworx", "anyuid"]
+    resourceNames: ["portworx-restricted", "anyuid"]
     verbs: ["use"]
   - apiGroups: ["policy"]
     resources: ["podsecuritypolicies"]

--- a/drivers/storage/portworx/testspec/portworxRestrictedSCC.yaml
+++ b/drivers/storage/portworx/testspec/portworxRestrictedSCC.yaml
@@ -1,0 +1,39 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+kind: SecurityContextConstraints
+metadata:
+  name: portworx-restricted
+  resourceVersion: "1"
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:kube-test:px-csi
+  - system:serviceaccount:kube-test:px-lighthouse
+  - system:serviceaccount:kube-test:portworx-pvc-controller
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret

--- a/drivers/storage/portworx/testspec/portworxSCC.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC.yaml
@@ -29,9 +29,6 @@ supplementalGroups:
   type: RunAsAny
 users:
 - system:serviceaccount:kube-test:portworx
-- system:serviceaccount:kube-test:px-csi
-- system:serviceaccount:kube-test:px-lighthouse
-- system:serviceaccount:kube-test:portworx-pvc-controller
 - system:serviceaccount:kube-test:px-metrics-collector
 - system:serviceaccount:kube-test:px-node-wiper
 - system:serviceaccount:kube-test:px-prometheus

--- a/drivers/storage/portworx/testspec/portworxSCC.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC.yaml
@@ -30,6 +30,7 @@ supplementalGroups:
 users:
 - system:serviceaccount:kube-test:portworx
 - system:serviceaccount:kube-test:px-metrics-collector
+- system:serviceaccount:kube-test:px-telemetry
 - system:serviceaccount:kube-test:px-node-wiper
 - system:serviceaccount:kube-test:px-prometheus
 volumes:

--- a/drivers/storage/portworx/testspec/pvcControllerClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerClusterRole.yaml
@@ -44,7 +44,7 @@ rules:
   verbs: ["get", "list", "watch", "create", "update"]
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
-  resourceNames: ["portworx"]
+  resourceNames: ["portworx-restricted"]
   verbs: ["use"]
 - apiGroups: ["policy"]
   resources: ["podsecuritypolicies"]


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Add a scc portworx-restricted, and use it for stork, csi, pvc controller, lighthouse.

**Which issue(s) this PR fixes** (optional)
Ticket: https://portworx.atlassian.net/browse/PWX-27673

**Test**:
Upgrade operator with my test image, and delete one pod of each kind, and verify the pod is back to running state. Confirmed "Updating security context constraints" only show 1 time.

