### PR TITLE
[PWX-29064] Add integ test for custom prometheus params

### DIFF
--- a/drivers/storage/portworx/component/podsecuritypolicies.go
+++ b/drivers/storage/portworx/component/podsecuritypolicies.go
@@ -42,7 +42,7 @@ func (p *podsecuritypolicies) Initialize(k8sClient client.Client, k8sVersion ver
 }
 
 func (p *podsecuritypolicies) IsPausedForMigration(cluster *corev1.StorageCluster) bool {
-	return false
+	return !p.k8sVersion.LessThan(k8sutil.K8sVer1_25)
 }
 
 func (p *podsecuritypolicies) IsEnabled(cluster *corev1.StorageCluster) bool {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
1. Test automation on new feature prometheus configurations(resources, PV, replica, retention, volume, volumeMounts)
2. Stop cleaning PodSecurityPolicies for k8s version 1.25+

**Which issue(s) this PR fixes** (optional)
Ticket: https://portworx.atlassian.net/browse/PWX-29064

**Special notes for your reviewer**:
Test:
Passed on local k8s cluster:
<img width="684" alt="Screen Shot 2023-03-30 at 3 32 14 PM" src="https://user-images.githubusercontent.com/122411280/228978179-0685ebe3-8ad4-4f5c-9dfe-3c4e892b06b5.png">


