### PR TITLE
PWX-29409: Ignore zones with no nodes

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -221,7 +221,8 @@ func (p *portworx) getDefaultStorageNodesDisaggregatedMode(
 	prevValue := uint64(math.MaxUint64)
 	for key, value := range nodeTypeZoneMap {
 		totalNodes += value
-		if value < minValue {
+		// Let's not count zones with no nodes
+		if value < minValue && value != 0 {
 			minValue = value
 		}
 		if prevValue != math.MaxUint64 && prevValue != value {

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -9250,13 +9250,13 @@ func TestStorageClusterDefaultsMaxStorageNodesPerZoneDisaggregatedMode(t *testin
 	testStoragelessNodesDisaggregatedMode(t, 7, 5, 0)
 	testStoragelessNodesDisaggregatedMode(t, 1, 5, 7, 5)
 	testStoragelessNodesDisaggregatedMode(t, 3, 5, 5, 5)
-	testStoragelessNodesDisaggregatedMode(t, 0, 5, 8, 8)
-	testStoragelessNodesDisaggregatedMode(t, 0, 7, 8, 8)
-	testStoragelessNodesDisaggregatedMode(t, 0, 7, 0, 8)
+	testStoragelessNodesDisaggregatedMode(t, 3, 5, 8, 8)
+	testStoragelessNodesDisaggregatedMode(t, 1, 7, 8, 8)
+	testStoragelessNodesDisaggregatedMode(t, 1, 7, 0, 8)
 	testStoragelessNodesDisaggregatedMode(t, 7, 1, 0, 0)
 	testStoragelessNodesDisaggregatedMode(t, 0, 8, 8, 8)
 	testStoragelessNodesDisaggregatedMode(t, 0, 6, 6, 6, 6)
-	testStoragelessNodesDisaggregatedMode(t, 0, 6, 5, 6, 6)
+	testStoragelessNodesDisaggregatedMode(t, 1, 6, 5, 6, 6)
 	testStoragelessNodesDisaggregatedMode(t, 5, 1, 1, 1, 1)
 	testStoragelessNodesDisaggregatedMode(t, 5, 1, 1, 1, 0)
 	testStoragelessNodesDisaggregatedMode(t, 5, 1, 0, 0, 0)
@@ -9304,6 +9304,51 @@ func testStoragelessNodesDisaggregatedMode(t *testing.T, expectedValue uint32, s
 	} else {
 		require.Equal(t, expectedValue, *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
 	}
+}
+
+func TestDisaggregatedMissingLabels(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{
+		GitVersion: "v1.21.0",
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+
+	driver := portworx{}
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Monitoring: &corev1.MonitoringSpec{Telemetry: &corev1.TelemetrySpec{}},
+		},
+	}
+
+	totalNodes := uint32(6)
+	zones := uint32(1)
+	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+	cluster.Spec.CloudStorage.MaxStorageNodesPerZone = nil
+	k8sClient := getK8sClientWithNodesDisaggregated(t, totalNodes, zones, cluster, 0)
+	// Create a node without any of the node-type or topology labels
+	k8sNode := createK8sNode("Extra-node", 10)
+	err := k8sClient.Create(context.TODO(), k8sNode)
+	require.NoError(t, err)
+	recorder := record.NewFakeRecorder(10)
+
+	err = driver.Init(k8sClient, runtime.NewScheme(), recorder)
+	require.NoError(t, err)
+
+	driver.zoneToInstancesMap, err = cloudprovider.GetZoneMap(driver.k8sClient, "", "")
+	require.NoError(t, err)
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	require.NotNil(t, cluster.Spec.CloudStorage)
+	require.NotNil(t, cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
+	require.Equal(t, uint32(6), *cluster.Spec.CloudStorage.MaxStorageNodesPerZone)
 }
 
 func TestStorageClusterDefaultsMaxStorageNodesPerZone(t *testing.T) {


### PR DESCRIPTION
  In disaggregated mode, there could be zones in which no storage nodes
  might be present. Such a zone would make the maxSNPZ value to be 0.
  CHanging the behavior to ignore 0 nodes in a zone for maxSNPZ
  calculation.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests


-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Testing:
1. Added unit test
2. Manually test on a cluster of 4 nodes. 3 were labelled storage and were labelled to be in a `zone`. The 4th one did not have any zone label or storage/storageless label. Before the fix, maxSNPZ was not set (defaults to 0). After the fix, it was set to 3
```
$kn get stc px-with-fix-7bbc65af-8132-463f-a3fc-9b0dc48546de -oyaml| grep max
    maxStorageNodesPerZone: 3
      maxUnavailable: 1
```
