### PR TITLE
update: add registry.k8s.io to common docker registry

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -102,7 +102,7 @@ func AddDefaultRegistryToImage(image string) string {
 	}
 
 	for k := range commonDockerRegistries {
-		if strings.HasPrefix(image, k) || strings.HasPrefix(image, "gcr.io") || strings.HasPrefix(image, "k8s.gcr.io") {
+		if strings.HasPrefix(image, k) || strings.HasPrefix(image, "gcr.io") || strings.HasPrefix(image, "k8s.gcr.io") || strings.HasPrefix(image, "registry.k8s.io") {
 			return image
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
k8s.gcr.io is deprecated

**Which issue(s) this PR fixes** (optional)
Closes #[PWX-29428](https://portworx.atlassian.net/browse/PWX-29428)



[PWX-29428]: https://portworx.atlassian.net/browse/PWX-29428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ