### PR TITLE
PWX-28826: Handle pre-flight check for DMthin 

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -174,11 +174,9 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 
 	var storageNodes []*corev1.StorageNode
 
-	/*
-		Wait for pre-flight checks to complete.  All the pre-flight pods are running.
-		However the checks being performed may not have completed.  Keep checking the
-		updated StorageNodes for completion check below
-	*/
+	//	Wait for pre-flight checks to complete.  All the pre-flight pods are running.
+	//	However the checks being performed may not have completed.  Keep checking the
+	//	updated StorageNodes for completion check below
 	for {
 		time.Sleep(5 * time.Second)
 		storageNodes, err = p.storageNodesList(cluster)
@@ -189,10 +187,8 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 
 		done := true
 		for _, node := range storageNodes {
-			/*
-				We add a check entry to signal when the pre-check is done.
-				So if length of checks > 0 the checks are all done.
-			*/
+			//	We add a check entry to signal when the pre-check is done.
+			//	So if length of checks > 0 the checks are all done.
 			if len(node.Status.Checks) == 0 {
 				done = false
 				break

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -226,12 +226,12 @@ func (u *preFlightPortworx) ProcessPreFlightResults(recorder record.EventRecorde
 				if check.Type != "status" {
 					msg := fmt.Sprintf("%s pre-flight check ", check.Type)
 					if check.Success {
-						msg = msg + "passed: "
+						msg = msg + "passed: " + check.Reason
+						k8sutil.InfoEvent(recorder, u.cluster, util.FailedPreFlight, msg)
 					} else {
-						msg = msg + "failed: "
+						msg = msg + "failed: " + check.Reason
+						k8sutil.WarningEvent(recorder, u.cluster, util.FailedPreFlight, msg)
 					}
-					msg = msg + check.Reason
-					k8sutil.WarningEvent(recorder, u.cluster, util.FailedPreFlight, msg)
 				}
 			}
 			passed = false

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -498,7 +498,7 @@ func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
 		}
 
 		// XXX - Sleep to avoid race cond check NOTE: in setStorageClusterDefaults()
-		time.Sleep(60 * time.Second)
+		time.Sleep(30 * time.Second)
 
 		cluster.Status = *toUpdate.Status.DeepCopy()
 		if err := k8s.UpdateStorageClusterStatus(c.client, cluster); err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:
Modify operator to execute a pre-flight on each node in the cluster.  This pre-flight will actually be executed by oci-monitor and px-runc installed on the host.   The pre-flight will determine if DMthin can be enabled on the cluster.   We do this by having operator launch a daemonset using the storage config with an extra pre-flight option.  This will cause oci-monitor to run in pre-flight mode which executes checks via px-runc on each node.   The results of the check are passed to oci-monitor via a json file. They are read  in and added to the StorageNode obj and passed to operator.  Once the checks are done this pre-flight daemonset is deleted by the operator.   The operator processes the checks returned in the StorageNode obj to determine if the existing storage config can be modified to enable DMthin (add: -T dmthin param).   If the checks fail then the storage config is not updated and the cluster starts with the original stc.

**Which issue(s) this PR fixes** (optional)
Closes #  
PWX-28826

**Special notes for your reviewer**:
px-runc side is in this PR: https://github.com/portworx/porx/pull/11018
px-installer side is in this PR: https://github.com/portworx/px-installer/pull/1679