### PR TITLE
PWX-29409: Ignore zones with no nodes

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1214,7 +1214,8 @@ func getDefaultStorageNodesDisaggregatedMode(
 	prevValue := uint64(math.MaxUint64)
 	for key, value := range nodeTypeZoneMap {
 		totalNodes += value
-		if value < minValue {
+		// Let's not count zones with no nodes
+		if value < minValue && value != 0 {
 			minValue = value
 		}
 		if prevValue != math.MaxUint64 && prevValue != value {


### PR DESCRIPTION
  In disaggregated mode, there could be zones in which no storage nodes
  might be present. Such a zone would make the maxSNPZ value to be 0.
  CHanging the behavior to ignore 0 nodes in a zone for maxSNPZ
  calculation.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

