### PR TITLE
PWX-29714 Controller to reconcile PortworxDiag objects

### DIFF
--- a/pkg/apis/portworx/v1/portworxdiag.go
+++ b/pkg/apis/portworx/v1/portworxdiag.go
@@ -4,13 +4,6 @@ import (
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// PortworxDiagResourceName is name for "portworxdiag" resource.
-	PortworxDiagResourceName = "portworxdiag"
-	// PortworxDiagResourcePlural is plural for "portworxdiag" resource.
-	PortworxDiagResourcePlural = "portworxdiags"
-)
-
 // PortworxDiagSpec is the spec used to define a portworx diag.
 type PortworxDiagSpec struct {
 	// Configuration for diags collection of the main Portworx component.

--- a/pkg/controller/portworxdiag/controller_test.go
+++ b/pkg/controller/portworxdiag/controller_test.go
@@ -1,0 +1,200 @@
+package portworxdiag
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	portworxv1 "github.com/libopenstorage/operator/pkg/apis/portworx/v1"
+	"github.com/libopenstorage/operator/pkg/mock"
+	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	fakeextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kversion "k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakek8sclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/libopenstorage/operator/pkg/client/clientset/versioned/scheme"
+	testutil "github.com/libopenstorage/operator/pkg/util/test"
+)
+
+func TestInit(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	k8sClient := testutil.FakeK8sClient()
+	coreops.SetInstance(coreops.New(fakeClient))
+	recorder := record.NewFakeRecorder(10)
+
+	mgr := mock.NewMockManager(mockCtrl)
+	mgr.EXPECT().GetClient().Return(k8sClient).AnyTimes()
+	mgr.EXPECT().GetScheme().Return(scheme.Scheme).AnyTimes()
+	mgr.EXPECT().GetEventRecorderFor(gomock.Any()).Return(recorder).AnyTimes()
+	mgr.EXPECT().SetFields(gomock.Any()).Return(nil).AnyTimes()
+	mgr.EXPECT().Add(gomock.Any()).Return(nil).AnyTimes()
+	mgr.EXPECT().GetLogger().Return(log.Log.WithName("test")).AnyTimes()
+
+	controller := Controller{
+		client:   k8sClient,
+		recorder: recorder,
+	}
+	err := controller.Init(mgr)
+	require.NoError(t, err)
+
+	ctrl := mock.NewMockController(mockCtrl)
+	controller.ctrl = ctrl
+	ctrl.EXPECT().Watch(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	err = controller.StartWatch()
+	require.NoError(t, err)
+}
+
+func TestRegisterCRD(t *testing.T) {
+	fakeClient := fakek8sclient.NewSimpleClientset()
+	fakeClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &kversion.Info{
+		GitVersion: "v1.23.0",
+	}
+	fakeExtClient := fakeextclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(fakeClient))
+	apiextensionsops.SetInstance(apiextensionsops.New(fakeExtClient))
+	group := portworxv1.SchemeGroupVersion.Group
+	portworxDiagCRDName := "portworxdiags" + "." + group
+
+	// When the CRDs are created, just updated their status so the validation
+	// does not get stuck until timeout.
+	go func() {
+		err := testutil.ActivateCRDWhenCreated(fakeExtClient, portworxDiagCRDName)
+		require.NoError(t, err)
+	}()
+
+	controller := Controller{}
+
+	// Should fail if the CRD specs are not found
+	err := controller.RegisterCRD()
+	require.Error(t, err)
+
+	// Set the correct crd path
+	crdBaseDir = func() string {
+		return "../../../deploy/crds"
+	}
+	defer func() {
+		crdBaseDir = getCRDBasePath
+	}()
+
+	err = controller.RegisterCRD()
+	require.NoError(t, err)
+
+	crds, err := fakeExtClient.ApiextensionsV1().
+		CustomResourceDefinitions().
+		List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, crds.Items, 1)
+
+	pdCRD, err := fakeExtClient.ApiextensionsV1().
+		CustomResourceDefinitions().
+		Get(context.TODO(), portworxDiagCRDName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, portworxDiagCRDName, pdCRD.Name)
+	require.Equal(t, portworxv1.SchemeGroupVersion.Group, pdCRD.Spec.Group)
+	require.Len(t, pdCRD.Spec.Versions, 1)
+	require.Equal(t, portworxv1.SchemeGroupVersion.Version, pdCRD.Spec.Versions[0].Name)
+	require.True(t, pdCRD.Spec.Versions[0].Served)
+	require.True(t, pdCRD.Spec.Versions[0].Storage)
+	subresource := &apiextensionsv1.CustomResourceSubresources{
+		Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+	}
+	require.Equal(t, subresource, pdCRD.Spec.Versions[0].Subresources)
+	require.NotEmpty(t, pdCRD.Spec.Versions[0].Schema.OpenAPIV3Schema.Properties)
+	require.Equal(t, apiextensionsv1.NamespaceScoped, pdCRD.Spec.Scope)
+	require.Equal(t, "portworxdiag", pdCRD.Spec.Names.Singular)
+	require.Equal(t, "portworxdiags", pdCRD.Spec.Names.Plural)
+	require.Equal(t, reflect.TypeOf(portworxv1.PortworxDiag{}).Name(), pdCRD.Spec.Names.Kind)
+	require.Equal(t, reflect.TypeOf(portworxv1.PortworxDiagList{}).Name(), pdCRD.Spec.Names.ListKind)
+	require.Equal(t, []string{"pxdiag"}, pdCRD.Spec.Names.ShortNames)
+
+	// If CRDs are already present, then should update it
+	pdCRD.ResourceVersion = "1000"
+	_, err = fakeExtClient.ApiextensionsV1().
+		CustomResourceDefinitions().
+		Update(context.TODO(), pdCRD, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// The fake client overwrites the status in Update call which real client
+	// does not. This will keep the CRD activated so validation does not get stuck.
+	go func() {
+		err := keepCRDActivated(fakeExtClient, portworxDiagCRDName)
+		require.NoError(t, err)
+	}()
+
+	// If CRDs are already present, then should not fail
+	err = controller.RegisterCRD()
+	require.NoError(t, err)
+
+	crds, err = fakeExtClient.ApiextensionsV1().
+		CustomResourceDefinitions().
+		List(context.TODO(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, crds.Items, 1)
+	require.Equal(t, portworxDiagCRDName, crds.Items[0].Name)
+
+	pdCRD, err = fakeExtClient.ApiextensionsV1().
+		CustomResourceDefinitions().
+		Get(context.TODO(), portworxDiagCRDName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, "1000", pdCRD.ResourceVersion)
+}
+
+func TestReconcileOfDeletedDiag(t *testing.T) {
+	k8sClient := testutil.FakeK8sClient()
+	recorder := record.NewFakeRecorder(1)
+	controller := Controller{
+		client:   k8sClient,
+		recorder: recorder,
+	}
+
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "does-not-exist",
+			Namespace: "test-ns",
+		},
+	}
+	result, err := controller.Reconcile(context.TODO(), request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+	require.Len(t, recorder.Events, 0)
+}
+
+func keepCRDActivated(fakeClient *fakeextclient.Clientset, crdName string) error {
+	return wait.Poll(1*time.Second, 1*time.Minute, func() (bool, error) {
+		crd, err := fakeClient.ApiextensionsV1().
+			CustomResourceDefinitions().
+			Get(context.TODO(), crdName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(crd.Status.Conditions) == 0 {
+			crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{{
+				Type:   apiextensionsv1.Established,
+				Status: apiextensionsv1.ConditionTrue,
+			}}
+			_, err = fakeClient.ApiextensionsV1().
+				CustomResourceDefinitions().
+				UpdateStatus(context.TODO(), crd, metav1.UpdateOptions{})
+			if err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+		return false, nil
+	})
+}

--- a/pkg/controller/portworxdiag/portworxdiag.go
+++ b/pkg/controller/portworxdiag/portworxdiag.go
@@ -1,0 +1,141 @@
+package portworxdiag
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/libopenstorage/operator/drivers/storage"
+	portworxv1 "github.com/libopenstorage/operator/pkg/apis/portworx/v1"
+	"github.com/libopenstorage/operator/pkg/util"
+	"github.com/libopenstorage/operator/pkg/util/k8s"
+)
+
+const (
+	// ControllerName is the name of the controller
+	ControllerName      = "portworxdiag-controller"
+	validateCRDInterval = 5 * time.Second
+	validateCRDTimeout  = 1 * time.Minute
+	crdBasePath         = "/crds"
+	portworxDiagCRDFile = "portworx.io_portworxdiags.yaml"
+)
+
+var _ reconcile.Reconciler = &Controller{}
+
+var (
+	crdBaseDir = getCRDBasePath
+)
+
+// Controller reconciles a StorageCluster object
+type Controller struct {
+	client   client.Client
+	scheme   *runtime.Scheme
+	recorder record.EventRecorder
+	Driver   storage.Driver
+	ctrl     controller.Controller
+}
+
+// Init initialize the portworx diag controller.
+func (c *Controller) Init(mgr manager.Manager) error {
+	c.client = mgr.GetClient()
+	c.scheme = mgr.GetScheme()
+	c.recorder = mgr.GetEventRecorderFor(ControllerName)
+
+	var err error
+	// Create a new controller
+	c.ctrl, err = controller.New(ControllerName, mgr, controller.Options{Reconciler: c})
+	return err
+}
+
+// StartWatch starts the watch on the PortworxDiag object type.
+func (c *Controller) StartWatch() error {
+	if c.ctrl == nil {
+		return fmt.Errorf("controller not initialized to start a watch")
+	}
+
+	return c.ctrl.Watch(
+		&source.Kind{Type: &portworxv1.PortworxDiag{}},
+		&handler.EnqueueRequestForObject{},
+	)
+}
+
+func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := logrus.WithFields(map[string]interface{}{
+		"Request.Namespace": req.Namespace,
+		"Request.Name":      req.Name,
+	})
+	log.Infof("Reconciling PortworxDiag")
+
+	// Fetch the StorageCluster instance
+	diag := &portworxv1.PortworxDiag{}
+	err := c.client.Get(context.TODO(), req.NamespacedName, diag)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	if err := c.syncPortworxDiag(diag); err != nil {
+		// Ignore object revision conflict errors, as PortworxDiag could have been edited.
+		// The next reconcile loop should be able to resolve the issue.
+		if strings.Contains(err.Error(), k8s.UpdateRevisionConflictErr) {
+			logrus.Warnf("failed to sync PortworxDiag %s: %v", req, err)
+			return reconcile.Result{}, nil
+		}
+
+		k8s.WarningEvent(c.recorder, diag, util.FailedSyncReason, err.Error())
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) syncPortworxDiag(diag *portworxv1.PortworxDiag) error {
+	// TODO: Create diag pods with appropriate parameters to trigger the diag collection.
+	return nil
+}
+
+// RegisterCRD registers and validates CRDs
+func (c *Controller) RegisterCRD() error {
+	crd, err := k8s.GetCRDFromFile(portworxDiagCRDFile, crdBaseDir())
+	if err != nil {
+		return err
+	}
+	latestCRD, err := apiextensionsops.Instance().GetCRD(crd.Name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		if err = apiextensionsops.Instance().RegisterCRD(crd); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	} else {
+		crd.ResourceVersion = latestCRD.ResourceVersion
+		if _, err := apiextensionsops.Instance().UpdateCRD(crd); err != nil {
+			return err
+		}
+	}
+
+	resource := fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, crd.Spec.Group)
+	return apiextensionsops.Instance().ValidateCRD(resource, validateCRDTimeout, validateCRDInterval)
+}
+
+func getCRDBasePath() string {
+	return crdBasePath
+}

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/operator/pkg/apis"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/mock"
 	"github.com/libopenstorage/operator/pkg/util"
@@ -143,7 +144,7 @@ func MockDriver(mockCtrl *gomock.Controller) *mock.MockDriver {
 // adds the CRDs defined in this repository to the scheme
 func FakeK8sClient(initObjects ...runtime.Object) client.Client {
 	s := scheme.Scheme
-	if err := corev1.AddToScheme(s); err != nil {
+	if err := apis.AddToScheme(s); err != nil {
 		logrus.Error(err)
 	}
 	if err := monitoringv1.AddToScheme(s); err != nil {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

- The PR contains just the skeleton of the diags controller without much business logic.
- Register the PortworxDiag CRD if not already registered.
- Added a feature flag to enable diags controller. We will set this to true by default when we are ready to release this feature.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-29714

**Special notes for your reviewer**:

