### PR TITLE
Use reconcile loop to check pre-flight status.  Timeout after 15m.

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -532,7 +532,7 @@ func TestSetDefaultsOnStorageClusterOnEKS(t *testing.T) {
 	_, ok := cluster.Annotations[pxutil.AnnotationIsEKS]
 	require.False(t, ok)
 	_, ok = cluster.Annotations[pxutil.AnnotationPreflightCheck]
-	require.True(t, ok)
+	require.False(t, ok)
 	require.NotNil(t, cluster.Spec.Storage)
 	require.Nil(t, cluster.Spec.CloudStorage)
 

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -420,7 +420,11 @@ func bringUpStorageCluster(cluster *corev1.StorageCluster) (bool, error) {
 		return true, nil
 	} else if check == "false" {
 		condition := util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypePreflight)
-		if condition != nil && condition.Status == corev1.ClusterConditionStatusCompleted {
+		if condition != nil {
+			if condition.Status == corev1.ClusterConditionStatusCompleted {
+				return true, nil
+			}
+		} else {
 			return true, nil
 		}
 	}

--- a/pkg/preflight/utils.go
+++ b/pkg/preflight/utils.go
@@ -11,9 +11,7 @@ func IsEKS() bool {
 
 // RequiresCheck returns whether a preflight check is needed based on the platform
 func RequiresCheck() bool {
-	return true
-	// TODO: add other scenarios here
-	//return IsEKS()
+	return Instance().ProviderName() == string(cloudops.AWS)
 }
 
 // RunningOnCloud checks whether portworx is running on cloud

--- a/test/integration_test/utils/storagecluster.go
+++ b/test/integration_test/utils/storagecluster.go
@@ -72,6 +72,12 @@ func ConstructStorageCluster(cluster *corev1.StorageCluster, specGenURL string, 
 		}
 	}
 
+	// XXX - Skip preflight for now when executing integration tests.  Cause automatically setting DMthin required meta-data device.
+	if cluster.Annotations == nil {
+		cluster.Annotations = make(map[string]string)
+	}
+	cluster.Annotations["portworx.io/preflight-check"] = "false"
+
 	// Add EKS annotation
 	if IsEks {
 		if cluster.Annotations == nil {

--- a/test/integration_test/utils/storagecluster.go
+++ b/test/integration_test/utils/storagecluster.go
@@ -72,12 +72,6 @@ func ConstructStorageCluster(cluster *corev1.StorageCluster, specGenURL string, 
 		}
 	}
 
-	// XXX - Skip preflight for now when executing integration tests.  Cause automatically setting DMthin required meta-data device.
-	if cluster.Annotations == nil {
-		cluster.Annotations = make(map[string]string)
-	}
-	cluster.Annotations["portworx.io/preflight-check"] = "false"
-
 	// Add EKS annotation
 	if IsEks {
 		if cluster.Annotations == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
When executing pre-flight check we would wait for the checks to complete blocking the reconcile loop.   This prevented any other state change from being processed.  So this change corrected that.  Use cluster conditions to determine if we are still executing a pre-flight.  If so check the status each time though the loop.   Add a 15 min timeout based on the time the DS has been running.    

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Adding this as a separate PR to PWX-28826 branch so the changes can be clearly viewed.      This PR is separate https://github.com/libopenstorage/operator/pull/1014 which has been approved however it has the blocking code.  This merge will correct that.   
