### PR TITLE
PWX-30729_pt2: RKE2 fix

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1545,6 +1545,11 @@ func (t *template) getK3sVolumeInfoList() []volumeInfo {
 			hostPath:  "/run/k3s/containerd/containerd.sock",
 			mountPath: "/run/containerd/containerd.sock",
 		},
+		{
+			name:      "containerddir-rke2",
+			hostPath:  "/var/lib/rancher/rke2/agent/containerd",
+			mountPath: "/var/lib/rancher/rke2/agent/containerd",
+		},
 	}
 }
 

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1546,9 +1546,9 @@ func (t *template) getK3sVolumeInfoList() []volumeInfo {
 			mountPath: "/run/containerd/containerd.sock",
 		},
 		{
-			name:      "containerddir-rke2",
-			hostPath:  "/var/lib/rancher/rke2/agent/containerd",
-			mountPath: "/var/lib/rancher/rke2/agent/containerd",
+			name:      "containerddir-k3s",
+			hostPath:  "/var/lib/rancher",
+			mountPath: "/var/lib/rancher",
 		},
 	}
 }

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -178,6 +178,6 @@ spec:
         - name: containerd-k3s
           hostPath:
             path: /run/k3s/containerd/containerd.sock
-        - name: containerddir-rke2
+        - name: containerddir-k3s
           hostPath:
-            path: /var/lib/rancher/rke2/agent/containerd
+            path: /var/lib/rancher

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -100,6 +100,8 @@ spec:
               mountPath: /var/run/dbus
             - name: containerd-k3s
               mountPath: /run/containerd/containerd.sock
+            - name: containerddir-rke2
+              mountPath: /var/lib/rancher/rke2/agent/containerd
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.3
           imagePullPolicy: Always
@@ -176,3 +178,6 @@ spec:
         - name: containerd-k3s
           hostPath:
             path: /run/k3s/containerd/containerd.sock
+        - name: containerddir-rke2
+          hostPath:
+            path: /var/lib/rancher/rke2/agent/containerd

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -100,8 +100,8 @@ spec:
               mountPath: /var/run/dbus
             - name: containerd-k3s
               mountPath: /run/containerd/containerd.sock
-            - name: containerddir-rke2
-              mountPath: /var/lib/rancher/rke2/agent/containerd
+            - name: containerddir-k3s
+              mountPath: /var/lib/rancher
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.3
           imagePullPolicy: Always


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

**What this PR does / why we need it**:

The px-3.0.0/master OCI-Mon are using upgraded client APIs for ContainerD
* the new client APIs require `/var/lib/containerd` mount (already fixed)
* specifically on RKE2 distros, we'll also need to add `/var/lib/rancher/rke2/agent/containerd` mount

**Which issue(s) this PR fixes** (optional)
Closes # PWX-30729 (part 2)

**Special notes for your reviewer**:

NOTE, this fix is mirroring our DaemonSet update @ https://github.com/portworx/px-installer/pull/1721