### PR TITLE
PWX-30623_pt2: IKS + containerd fix

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -110,6 +110,7 @@ func newTemplate(
 		return nil, err
 	}
 
+	t.isK3s = isK3sClusterExt(ext)
 	t.runOnMaster = t.isK3s || pxutil.RunOnMaster(cluster)
 	t.pxVersion = pxutil.GetPortworxVersion(cluster)
 	deprecatedCSIDriverName := pxutil.UseDeprecatedCSIDriverName(cluster)
@@ -126,7 +127,6 @@ func newTemplate(
 		t.csiConfig = csiGenerator.GetBasicCSIConfiguration()
 	}
 
-	t.isK3s = isK3sClusterExt(ext)
 	t.isPKS = pxutil.IsPKS(cluster)
 	t.isIKS = pxutil.IsIKS(cluster) || isIKSClusterExt(ext)
 	t.isOpenshift = pxutil.IsOpenshift(cluster)


### PR DESCRIPTION
* adding /var/data/cripersistentstorage mount for IKS clusters  (new containerd requirement)

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The px-3.0.0 has updated containerd API version, which now requires extra mounts
* we have already addressed this for generic installs, but
* \[**ISSUE**\] for IKS platform specifically, we must add a new `/var/data/cripersistentstorage` mount

Additionally:
* apart from the "usual" way to identify IKS platform via `portworx.io/is-iks: true` annotation...
*  \[**NEW**\] we are also adding an automatic detection via the Kubernetes version extension (i.e. `Server Version: v1.25.8+IKS`)
   - that way, the IKS platform will be automatically recognized, even in cases when customer forget to specify `is-iks` annotation

**Which issue(s) this PR fixes** (optional)
Closes # PWX-30623  (part 2)

**Special notes for your reviewer**:

This fix corresponds to the WebSVC fix @ https://github.com/portworx/px-installer/pull/1726