### PR TITLE
PWX-30857_pt2: PKS fix

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1710,6 +1710,10 @@ func getDefaultVolumeInfoList(pxVersion *version.Version) []volumeInfo {
 			name:      "containerdvardir",
 			hostPath:  "/var/lib/containerd",
 			mountPath: "/var/lib/containerd",
+			pks: &pksVolumeInfo{
+				hostPath:  "/var/vcap/store/containerd",
+				mountPath: "/var/vcap/store/containerd",
+			},
 		},
 		{
 			name:      "criosock",

--- a/drivers/storage/portworx/testspec/pks.yaml
+++ b/drivers/storage/portworx/testspec/pks.yaml
@@ -80,7 +80,7 @@ spec:
             - name: containerddir
               mountPath: /run/containerd
             - name: containerdvardir
-              mountPath: /var/lib/containerd
+              mountPath: /var/vcap/store/containerd
             - name: etcpwx
               mountPath: /etc/pwx
             - name: optpwx
@@ -122,7 +122,7 @@ spec:
             path: /run/containerd
         - name: containerdvardir
           hostPath:
-            path: /var/lib/containerd
+            path: /var/vcap/store/containerd
         - name: etcpwx
           hostPath:
             path: /var/vcap/store/etc/pwx

--- a/drivers/storage/portworx/testspec/pks_2.9.1.yaml
+++ b/drivers/storage/portworx/testspec/pks_2.9.1.yaml
@@ -67,7 +67,7 @@ spec:
             - name: containerddir
               mountPath: /run/containerd
             - name: containerdvardir
-              mountPath: /var/lib/containerd
+              mountPath: /var/vcap/store/containerd
             - name: etcpwx
               mountPath: /etc/pwx
             - name: optpwx
@@ -112,7 +112,7 @@ spec:
             path: /run/containerd
         - name: containerdvardir
           hostPath:
-            path: /var/lib/containerd
+            path: /var/vcap/store/containerd
         - name: etcpwx
           hostPath:
             path: /var/vcap/store/etc/pwx

--- a/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
+++ b/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
@@ -65,7 +65,7 @@ spec:
             - name: containerddir
               mountPath: /run/containerd
             - name: containerdvardir
-              mountPath: /var/lib/containerd
+              mountPath: /var/vcap/store/containerd
             - name: criosock
               mountPath: /var/run/crio
             - name: crioconf
@@ -130,7 +130,7 @@ spec:
             path: /run/containerd
         - name: containerdvardir
           hostPath:
-            path: /var/lib/containerd
+            path: /var/vcap/store/containerd
         - name: etcpwx
           hostPath:
             path: /var/vcap/store/etc/pwx


### PR DESCRIPTION
* the PKS distro uses `/var/vcap/store/containerd` mount instead of `/var/lib/containerd`

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This PR corrects the mounts for the PKS distro using `containerd` container runtimes, and px-3.0.0 

**Which issue(s) this PR fixes** (optional)
Closes # PWX-30857 (part 2)

**Special notes for your reviewer**:

NOTE: the equivalent WebSVC fix (part 1) is @ https://github.com/portworx/px-installer/pull/1734