### PR TITLE
PWX-29131: container image -url parsing fix

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3018,7 +3018,7 @@ func TestLighthouseWithoutImageTag(t *testing.T) {
 		Spec: corev1.StorageClusterSpec{
 			UserInterface: &corev1.UserInterfaceSpec{
 				Enabled: true,
-				Image:   "portworx/px-lighthouse",
+				Image:   "portworx/px-lighthouse:latest",
 			},
 		},
 	}
@@ -3032,13 +3032,13 @@ func TestLighthouseWithoutImageTag(t *testing.T) {
 	err = testutil.Get(k8sClient, lhDeployment, component.LhDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	image := k8sutil.GetImageFromDeployment(lhDeployment, component.LhContainerName)
-	require.Equal(t, "docker.io/portworx/px-lighthouse", image)
+	require.Equal(t, "docker.io/portworx/px-lighthouse:latest", image)
 	image = k8sutil.GetImageFromDeployment(lhDeployment, component.LhConfigInitContainerName)
-	require.Equal(t, "docker.io/portworx/lh-config-sync", image)
+	require.Equal(t, "docker.io/portworx/lh-config-sync:latest", image)
 	image = k8sutil.GetImageFromDeployment(lhDeployment, component.LhConfigSyncContainerName)
-	require.Equal(t, "docker.io/portworx/lh-config-sync", image)
+	require.Equal(t, "docker.io/portworx/lh-config-sync:latest", image)
 	image = k8sutil.GetImageFromDeployment(lhDeployment, component.LhStorkConnectorContainerName)
-	require.Equal(t, "docker.io/portworx/lh-stork-connector", image)
+	require.Equal(t, "docker.io/portworx/lh-stork-connector:latest", image)
 }
 
 func TestLighthouseSidecarsOverrideWithEnv(t *testing.T) {
@@ -3057,7 +3057,7 @@ func TestLighthouseSidecarsOverrideWithEnv(t *testing.T) {
 		Spec: corev1.StorageClusterSpec{
 			UserInterface: &corev1.UserInterfaceSpec{
 				Enabled: true,
-				Image:   "portworx/px-lighthouse",
+				Image:   "portworx/px-lighthouse:latest",
 				Env: []v1.EnvVar{
 					{
 						Name:  component.EnvKeyLhConfigSyncImage,
@@ -3081,7 +3081,7 @@ func TestLighthouseSidecarsOverrideWithEnv(t *testing.T) {
 	err = testutil.Get(k8sClient, lhDeployment, component.LhDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
 	image := k8sutil.GetImageFromDeployment(lhDeployment, component.LhContainerName)
-	require.Equal(t, "docker.io/portworx/px-lighthouse", image)
+	require.Equal(t, "docker.io/portworx/px-lighthouse:latest", image)
 	image = k8sutil.GetImageFromDeployment(lhDeployment, component.LhConfigInitContainerName)
 	require.Equal(t, "docker.io/test/config-sync:t1", image)
 	image = k8sutil.GetImageFromDeployment(lhDeployment, component.LhConfigSyncContainerName)
@@ -7883,7 +7883,7 @@ func TestCompleteInstallWithCustomRegistryChange(t *testing.T) {
 			},
 			PxRepo: &corev1.PxRepoSpec{
 				Enabled: true,
-				Image:   "testImage",
+				Image:   "testImage:latest",
 			},
 		},
 		Status: corev1.StorageClusterStatus{ClusterUID: "test-uid"},
@@ -8756,7 +8756,7 @@ func TestCompleteInstallWithCustomRepoRegistryChange(t *testing.T) {
 			},
 			PxRepo: &corev1.PxRepoSpec{
 				Enabled: true,
-				Image:   "pxRepoImage",
+				Image:   "pxRepoImage:latest",
 			},
 		},
 		Status: corev1.StorageClusterStatus{

--- a/pkg/cloudprovider/azure.go
+++ b/pkg/cloudprovider/azure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/libopenstorage/cloudops"
 )
 
+//lint:file-ignore U1000 Ignore unused code
 type azure struct {
 	defaultProvider
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,8 +3,10 @@ package util
 import (
 	"context"
 	"fmt"
+	"net"
 	"path"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -97,6 +99,9 @@ var (
 		"topology.kubernetes.io/region",
 		"topology.kubernetes.io/zone",
 	}
+
+	// hostnameWithDomainRe regex matches hostname with a DNS domain
+	hostnameWithDomainRe = regexp.MustCompile(`^(?i)[a-z0-9-]+(\.[a-z0-9-]+)+\.?$`)
 )
 
 // AddDefaultRegistryToImage adds default registry to image.
@@ -105,10 +110,41 @@ func AddDefaultRegistryToImage(image string) string {
 		return ""
 	}
 
-	for k := range commonDockerRegistries {
-		if strings.HasPrefix(image, k) || strings.HasPrefix(image, "gcr.io") || strings.HasPrefix(image, "k8s.gcr.io") {
+	// check if image has version-tag included, add ":latest" if missing
+	if strings.Count(image, ":") < 1 {
+		image = image + ":latest"
+	}
+
+	parts := strings.Split(image, "/")
+
+	// no separate parts, always add registry-server
+	if len(parts) <= 0 {
+		return DefaultImageRegistry + "/" + image
+	}
+
+	hn := parts[0]
+
+	// if host:port and not IPv6, reset to host
+	if hn[len(hn)-1] != ']' && strings.Count(hn, ":") > 0 {
+		var err error
+		hn, _, err = net.SplitHostPort(parts[0])
+		if err != nil || hn == "" {
+			logrus.WithError(err).Errorf("got error splitting %s in image-url %s", parts[0], image)
 			return image
 		}
+	}
+
+	// check if 1st part is IP address
+	ip := net.ParseIP(strings.Trim(hn, "[]"))
+	if ip != nil {
+		logrus.Tracef("image-url starts w/ IP: %s", image)
+		return image
+	}
+
+	// check if 1st part is a hostname+domain
+	if hostnameWithDomainRe.MatchString(hn) {
+		logrus.Tracef("image-url starts w/ host+domain: %s", image)
+		return image
 	}
 
 	return DefaultImageRegistry + "/" + image
@@ -151,7 +187,7 @@ func GetImageURN(cluster *corev1.StorageCluster, image string) string {
 
 	registryAndRepo = strings.TrimRight(registryAndRepo, "/")
 	if registryAndRepo == "" {
-		// no registry/repository specifed, return image
+		// no registry/repository specified, return image
 		return AddDefaultRegistryToImage(image)
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -117,11 +117,6 @@ func AddDefaultRegistryToImage(image string) string {
 
 	parts := strings.Split(image, "/")
 
-	// no separate parts, always add registry-server
-	if len(parts) <= 0 {
-		return DefaultImageRegistry + "/" + image
-	}
-
 	hn := parts[0]
 
 	// if host:port and not IPv6, reset to host

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -6,6 +6,7 @@ import (
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -548,4 +549,37 @@ func fakeK8sClient(initObjects ...runtime.Object) client.Client {
 		logrus.Error(err)
 	}
 	return fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(initObjects...).Build()
+}
+
+func TestAddDefaultRegistryToImage(t *testing.T) {
+	data := []struct {
+		in       string
+		expected string
+	}{
+		{"foo", "docker.io/foo:latest"},
+		{"foo:bar", "docker.io/foo:bar"},
+		{"foo/bar", "docker.io/foo/bar:latest"},
+		{"docker.io/foo/bar:1", "docker.io/foo/bar:1"},
+		{"gcr.io/foo/bar:1", "gcr.io/foo/bar:1"},
+		{"k8s.gcr.io/foo/bar:1", "k8s.gcr.io/foo/bar:1"},
+		{"portworx/oci-monitor:1.2.3", "docker.io/portworx/oci-monitor:1.2.3"},
+		{"docker.io/portworx/oci-monitor:1.2.3", "docker.io/portworx/oci-monitor:1.2.3"},
+		{"regserv.acme.org/portworx/oci-monitor:1.2.3", "regserv.acme.org/portworx/oci-monitor:1.2.3"},
+		{"regserv.acme.org:5443/portworx/oci-monitor:1.2.3", "regserv.acme.org:5443/portworx/oci-monitor:1.2.3"},
+		{"192.168.1.2/foo/bar:1.2.3", "192.168.1.2/foo/bar:1.2.3"},
+		{"192.168.1.2:5433/foo/bar:1.2.3", "192.168.1.2:5433/foo/bar:1.2.3"},
+		{"[2001:db8:3333:4444:5555:6666:7777:8888]/foo/bar:1.2.3", "[2001:db8:3333:4444:5555:6666:7777:8888]/foo/bar:1.2.3"},
+		{"[2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:5443/foo/bar:1.2.3", "[2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF]:5443/foo/bar:1.2.3"},
+		{"[::1]/foo/bar:1.2.3", "[::1]/foo/bar:1.2.3"},
+		// few invalid URLs..
+		{"", ""},
+		{":123", ":123"},
+		{":foo", ":foo"},
+		{"::1/foo/bar:1.2.3", "::1/foo/bar:1.2.3"},
+	}
+
+	for i, td := range data {
+		res := AddDefaultRegistryToImage(td.in)
+		assert.Equal(t, td.expected, res, "Unexpected #%d / %v", i+1, td)
+	}
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -28,7 +28,7 @@ func TestImageURN(t *testing.T) {
 
 	// TestCase: Empty repo and registry
 	out = getImageURN("", "", "test/image")
-	require.Equal(t, "docker.io/test/image", out)
+	require.Equal(t, "docker.io/test/image:latest", out)
 
 	// TestCase: Registry without repo but image with repo
 	out = getImageURN("", "registry.io", "test/image")
@@ -123,7 +123,7 @@ func TestImageURNPreserved(t *testing.T) {
 
 	// Ensure original behaviour remains
 	out = getImageURNPreserved("", "", "test/image")
-	require.Equal(t, "docker.io/test/image", out)
+	require.Equal(t, "docker.io/test/image:latest", out)
 
 	// Ensure original behaviour remains
 	out = getImageURNPreserved("", "registry.io", "test/image")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The `AddDefaultRegistryToImage()` is used to parse all image-URL's specified in `px-versions` CM, but it had issues:
* most URLs will be prefixed w/ `docker.io`  (unless form well-known repos) -- so private registry-servers cannot be used
* no support for IPs (IPv4, IPv6)

As a fix, we'll...
* prefix the URL w/ `docker.io` only if URL does not start w/ hostname or IP
* additionally, append `:latest` if no image-tag was provided

**Which issue(s) this PR fixes** (optional)
Closes # PWX-29131

**Special notes for your reviewer**:

See JIRA-ticket for PX-specific test info