### PR TITLE
PTX-17408 Validate against new StorageCluster Status design for PX Operator 23.5+

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -130,8 +130,9 @@ var TestSpecPath = "testspec"
 
 var (
 	pxVer2_12, _                      = version.NewVersion("2.12.0-")
-	opVer1_10, _                      = version.NewVersion("1.10.0-")
 	opVer1_9_1, _                     = version.NewVersion("1.9.1-")
+	opVer1_10, _                      = version.NewVersion("1.10.0-")
+	opVer23_5, _                      = version.NewVersion("23.5.0-")
 	minOpVersionForKubeSchedConfig, _ = version.NewVersion("1.10.2-")
 )
 
@@ -4010,9 +4011,8 @@ func validateAllStorageNodesInState(namespace string, status corev1.NodeConditio
 func ValidateStorageClusterIsOnline(cluster *corev1.StorageCluster, timeout, interval time.Duration) (*corev1.StorageCluster, error) {
 	state := string(corev1.ClusterConditionStatusOnline)
 	var conditions []corev1.ClusterCondition
-	masterOpVersion, _ := version.NewVersion(PxOperatorMasterVersion)
 	opVersion, _ := GetPxOperatorVersion()
-	if opVersion.GreaterThanOrEqual(masterOpVersion) {
+	if opVersion.GreaterThanOrEqual(opVer23_5) {
 		state = string(corev1.ClusterStateRunning)
 		conditions = append(conditions, corev1.ClusterCondition{
 			Source: "Portworx",


### PR DESCRIPTION
Validate against new StorageCluster Status design for PX Operator 23.5+

NOTE: This is required to run PX Operator 23.5.0+ which has the new Status design

