### PR TITLE
PWX-29505_pt1: adding new images in versions-CM

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -3978,6 +3978,15 @@ spec:
                   pxRepo:
                     type: string
                     description: Desired image for pxRepo.
+                  kubeScheduler:
+                    type: string
+                    description: Desired image for kubernetes scheduler.
+                  kubeControllerManager:
+                    type: string
+                    description: Desired image for kubernetes controller manager.
+                  pause:
+                    type: string
+                    description: Desired image for pause image.
               conditions:
                 type: array
                 description: Contains details for the current condition of this cluster.

--- a/drivers/storage/portworx/component/alertmanager.go
+++ b/drivers/storage/portworx/component/alertmanager.go
@@ -163,10 +163,7 @@ func (c *alertManager) createAlertManagerInstance(
 	ownerRef *metav1.OwnerReference,
 ) error {
 	replicas := int32(3)
-	alertManagerImageName := util.GetImageURN(
-		cluster,
-		cluster.Status.DesiredImages.AlertManager,
-	)
+	imageName := util.GetImageURN(cluster, cluster.Status.DesiredImages.AlertManager)
 
 	alertManagerInst := &monitoringv1.Alertmanager{
 		ObjectMeta: metav1.ObjectMeta{
@@ -176,7 +173,7 @@ func (c *alertManager) createAlertManagerInstance(
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 		},
 		Spec: monitoringv1.AlertmanagerSpec{
-			Image:    &alertManagerImageName,
+			Image:    &imageName,
 			Replicas: &replicas,
 		},
 	}

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -186,7 +186,11 @@ func (c *portworxAPI) createDaemonSet(
 		existingImageName = existingDaemonSet.Spec.Template.Spec.Containers[0].Image
 	}
 
-	imageName := util.GetImageURN(cluster, pxutil.ImageNamePause)
+	imageName := pxutil.ImageNamePause
+	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.Pause != "" {
+		imageName = cluster.Status.DesiredImages.Pause
+	}
+	imageName = util.GetImageURN(cluster, imageName)
 	serviceAccount := pxutil.PortworxServiceAccountName(cluster)
 	existingServiceAccount := existingDaemonSet.Spec.Template.Spec.ServiceAccountName
 

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -295,14 +295,15 @@ func (c *pvcController) createDeployment(
 		return err
 	}
 
-	kubeControllerImage := "gcr.io/google_containers/kube-controller-manager-amd64"
+	imageName := "gcr.io/google_containers/kube-controller-manager-amd64"
 	if k8sutil.IsNewKubernetesRegistry(&c.k8sVersion) {
-		kubeControllerImage = k8sutil.DefaultK8SRegistryPath + "/kube-controller-manager-amd64"
+		imageName = k8sutil.DefaultK8SRegistryPath + "/kube-controller-manager-amd64"
 	}
-	imageName := util.GetImageURN(
-		cluster,
-		kubeControllerImage+":v"+c.k8sVersion.String(),
-	)
+	imageName = imageName + ":v" + c.k8sVersion.String()
+	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.KubeControllerManager != "" {
+		imageName = cluster.Status.DesiredImages.KubeControllerManager
+	}
+	imageName = util.GetImageURN(cluster, imageName)
 
 	command := []string{
 		"kube-controller-manager",

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -644,6 +644,9 @@ func TestPortworxAPIDaemonSetAlwaysDeploys(t *testing.T) {
 			Name:      "px-cluster",
 			Namespace: "kube-test",
 		},
+		Status: corev1.StorageClusterStatus{
+			DesiredImages: &corev1.ComponentImages{},
+		},
 	}
 
 	err = driver.PreInstall(cluster)
@@ -677,6 +680,13 @@ func TestPortworxAPIDaemonSetAlwaysDeploys(t *testing.T) {
 	err = testutil.Get(k8sClient, ds, component.PxAPIDaemonSetName, cluster.Namespace)
 	require.NoError(t, err)
 	require.Equal(t, "registry.k8s.io/pause:3.1", ds.Spec.Template.Spec.Containers[0].Image)
+
+	cluster.Status.DesiredImages.Pause = "private.repo.org/foo/bar:1.2.3"
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, ds, component.PxAPIDaemonSetName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, "private.repo.org/foo/bar:1.2.3", ds.Spec.Template.Spec.Containers[0].Image)
 
 	// Case: If the daemon set was marked as deleted, the it should be recreated,
 	// even if it is already present

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -59,6 +59,7 @@ var (
 )
 
 // Release is a single release object with images for different components
+// -note: please keep in sync w/ `storagecluster.ComponentImages` structure
 type Release struct {
 	Stork                      string `yaml:"stork,omitempty"`
 	Lighthouse                 string `yaml:"lighthouse,omitempty"`
@@ -83,6 +84,9 @@ type Release struct {
 	LogUploader                string `yaml:"logUploader,omitempty"`
 	TelemetryProxy             string `yaml:"telemetryProxy,omitempty"` // Use a new field for easy backward compatibility
 	PxRepo                     string `yaml:"pxRepo,omitempty"`
+	KubeScheduler              string `yaml:"kubeScheduler,omitempty"`
+	KubeControllerManager      string `yaml:"kubeControllerManager,omitempty"`
+	Pause                      string `yaml:"pause,omitempty"`
 }
 
 // Version is the response structure from a versions source

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -550,6 +550,21 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			}
 		}
 
+		// set misc image defaults
+		imagesData := []struct {
+			desiredImage *string
+			releaseImage string
+		}{
+			{&toUpdate.Status.DesiredImages.KubeControllerManager, release.Components.KubeControllerManager},
+			{&toUpdate.Status.DesiredImages.KubeScheduler, release.Components.KubeScheduler},
+			{&toUpdate.Status.DesiredImages.Pause, release.Components.Pause},
+		}
+		for _, v := range imagesData {
+			if *v.desiredImage == "" {
+				*v.desiredImage = v.releaseImage
+			}
+		}
+
 		// Reset the component update strategy if it is 'Once', so that we don't
 		// upgrade components again during next reconcile loop
 		if toUpdate.Spec.AutoUpdateComponents != nil &&

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -634,6 +634,8 @@ type StorageClusterStatus struct {
 }
 
 // ComponentImages is a collection of all the images managed by the operator
+// -note: please keep in sync w/ `manifest.Release` structure
+// -WARN: the ComponentImages are annotated w/ `json:` while `manifest.Release` uses `yaml:`
 type ComponentImages struct {
 	Stork                      string `json:"stork,omitempty"`
 	UserInterface              string `json:"userInterface,omitempty"`
@@ -657,6 +659,9 @@ type ComponentImages struct {
 	LogUploader                string `json:"logUploader,omitempty"`
 	TelemetryProxy             string `json:"telemetryProxy,omitempty"`
 	PxRepo                     string `json:"pxRepo,omitempty"`
+	KubeScheduler              string `json:"kubeScheduler,omitempty"`
+	KubeControllerManager      string `json:"kubeControllerManager,omitempty"`
+	Pause                      string `json:"pause,omitempty"`
 }
 
 // Storage represents cluster storage details

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -879,10 +879,11 @@ func (c *Controller) createStorkSchedDeployment(
 	} else {
 		kubeSchedImage = kubeSchedImage + ":v" + c.kubernetesVersion.String()
 	}
-	imageName := util.GetImageURN(
-		cluster,
-		kubeSchedImage,
-	)
+	imageName := kubeSchedImage
+	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.KubeScheduler != "" {
+		imageName = cluster.Status.DesiredImages.KubeScheduler
+	}
+	imageName = util.GetImageURN(cluster, imageName)
 
 	var command []string
 	if c.kubernetesVersion.GreaterThanOrEqual(k8sMinVersionForKubeSchedulerConfiguration) {

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -1271,6 +1271,9 @@ func (h *Handler) handleCustomImageRegistry(cluster *corev1.StorageCluster) erro
 		MetricsCollector:           h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.MetricsCollector),
 		MetricsCollectorProxy:      h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.MetricsCollectorProxy),
 		PxRepo:                     h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.PxRepo),
+		KubeScheduler:              h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.KubeScheduler),
+		KubeControllerManager:      h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.KubeControllerManager),
+		Pause:                      h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.Pause),
 	}
 	cluster.Status.Version = pxutil.GetImageTag(cluster.Spec.Image)
 	return nil
@@ -1326,6 +1329,9 @@ func (h *Handler) createManifestConfigMap(cluster *corev1.StorageCluster) error 
 			MetricsCollector:           cluster.Status.DesiredImages.MetricsCollector,
 			MetricsCollectorProxy:      cluster.Status.DesiredImages.MetricsCollectorProxy,
 			PxRepo:                     "",
+			KubeScheduler:              cluster.Status.DesiredImages.KubeScheduler,
+			KubeControllerManager:      cluster.Status.DesiredImages.KubeControllerManager,
+			Pause:                      cluster.Status.DesiredImages.Pause,
 		},
 	}
 


### PR DESCRIPTION
* adding `pause`, `kube-controller-manager-amd64` and `kube-scheduler-amd64` images override via `px-versions` CM

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

* adding the override for `pause`, `kube-controller-manager-amd64` and `kube-scheduler-amd64` images via `px-versions`  configmap

**Which issue(s) this PR fixes** (optional)
Closes # PWX-29505  (part 1)

**Special notes for your reviewer**:

The part 2 will be fixing install.portworx.com/versions REST endpoint.
For PX-specific test, please see [PWX-29505](https://portworx.atlassian.net/browse/PWX-29505) ticket.

This fix is related to the https://github.com/libopenstorage/operator/pull/1030

[PWX-29505]: https://portworx.atlassian.net/browse/PWX-29505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ