### PR TITLE
Removing check for alertmanager-operated service

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -3180,10 +3180,6 @@ func ValidateAlertManagerEnabled(pxImageList map[string]string, cluster *corev1.
 		return fmt.Errorf("failed to get service alertmanager-portworx")
 	}
 
-	if _, err := coreops.Instance().GetService("alertmanager-operated", cluster.Namespace); err != nil {
-		return fmt.Errorf("failed to get service alertmanager-operated")
-	}
-
 	logrus.Infof("Alert manager is enabled and deployed")
 	return nil
 }
@@ -3200,10 +3196,6 @@ func ValidateAlertManagerDisabled(pxImageList map[string]string, cluster *corev1
 			if !cluster.Spec.Monitoring.Prometheus.AlertManager.Enabled && !errors.IsNotFound(err) {
 				return "", true, fmt.Errorf("wait for service alertmanager-portworx deletion, err %v", err)
 			}
-		}
-
-		if _, err := coreops.Instance().GetService("alertmanager-operated", cluster.Namespace); !errors.IsNotFound(err) {
-			return "", true, fmt.Errorf("wait for service alertmanager-operated deletion, err %v", err)
 		}
 
 		return "", false, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing check for alertmanager-operated service as it created by cloud providers.

In Anthos cluster, this service is created by-default and when there were no alertmanager enabled in PX.

**Which issue(s) this PR fixes** (optional)
Closes # PTX-17518

**Special notes for your reviewer**:
Minor changes.

