### PR TITLE
PWX-30737: Updating scc to stork-scheduler clusterrole for OCP 4.11

### DIFF
--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -224,6 +224,7 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, ServiceAccountNameTelemetry),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-node-wiper"),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"),
+				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "stork-scheduler"),
 			},
 		},
 		{

--- a/drivers/storage/portworx/testspec/portworxSCC.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC.yaml
@@ -33,5 +33,6 @@ users:
 - system:serviceaccount:kube-test:px-telemetry
 - system:serviceaccount:kube-test:px-node-wiper
 - system:serviceaccount:kube-test:px-prometheus
+- system:serviceaccount:kube-test:stork-scheduler
 volumes:
 - '*'

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/libopenstorage/operator/drivers/storage/portworx/component"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
@@ -481,6 +482,12 @@ func (c *Controller) createStorkSchedClusterRole() error {
 					APIGroups:     []string{"policy"},
 					Resources:     []string{"podsecuritypolicies"},
 					ResourceNames: []string{constants.RestrictedPSPName},
+					Verbs:         []string{"use"},
+				},
+				{
+					APIGroups:     []string{"security.openshift.io"},
+					Resources:     []string{"securitycontextconstraints"},
+					ResourceNames: []string{component.PxSCCName},
 					Verbs:         []string{"use"},
 				},
 			},

--- a/pkg/controller/storagecluster/testspec/storkSchedClusterRole.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedClusterRole.yaml
@@ -53,3 +53,7 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["px-restricted"]
     verbs: ["use"]
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["portworx"]
+    verbs: ["use"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating Openshift securitycontextconstraint on stork-scheduler clusterrole .

**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PWX-30737

**Special notes for your reviewer**:
* Stork-scheduler pods were not getting scheduled due to error "unable to validate against any security context constraint"
* scc is  already present for many other components we manage. 
* After doing these changes, Stork scheduler pods are getting scheduled.
* oc get scc portworx -oyaml
```allowHostDirVolumePlugin: true
allowHostIPC: true
allowHostNetwork: true
allowHostPID: true
allowHostPorts: true
allowPrivilegeEscalation: true
allowPrivilegedContainer: true
allowedCapabilities:
- '*'
allowedUnsafeSysctls:
- '*'
apiVersion: security.openshift.io/v1
defaultAddCapabilities: null
fsGroup:
  type: RunAsAny
groups: []
kind: SecurityContextConstraints
metadata:
  creationTimestamp: "2023-05-10T21:15:16Z"
  generation: 5
  name: portworx
  resourceVersion: "936150"
  uid: c6a2c7f2-fa23-4186-8e31-30f89dce4041
priority: null
readOnlyRootFilesystem: false
requiredDropCapabilities: null
runAsUser:
  type: RunAsAny
seLinuxContext:
  type: RunAsAny
seccompProfiles:
- '*'
supplementalGroups:
  type: RunAsAny
users:
- system:serviceaccount:portworx:portworx
- system:serviceaccount:portworx:px-metrics-collector
- system:serviceaccount:portworx:px-telemetry
- system:serviceaccount:portworx:px-node-wiper
- system:serviceaccount:portworx:px-prometheus
- system:serviceaccount:portworx:stork-scheduler
volumes:
- '*'
```
dsds

