### PR TITLE
PWX-30737: Updating scc to stork-scheduler clusterrole for OCP 4.11 (…

### DIFF
--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -224,6 +224,7 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CollectorServiceAccountName),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-node-wiper"),
 				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"),
+				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "stork-scheduler"),
 			},
 		},
 	}

--- a/drivers/storage/portworx/testspec/portworxSCC.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC.yaml
@@ -35,5 +35,6 @@ users:
 - system:serviceaccount:kube-test:px-metrics-collector
 - system:serviceaccount:kube-test:px-node-wiper
 - system:serviceaccount:kube-test:px-prometheus
+- system:serviceaccount:kube-test:stork-scheduler
 volumes:
 - '*'

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/libopenstorage/operator/drivers/storage/portworx/component"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
@@ -481,6 +482,12 @@ func (c *Controller) createStorkSchedClusterRole() error {
 					APIGroups:     []string{"policy"},
 					Resources:     []string{"podsecuritypolicies"},
 					ResourceNames: []string{constants.RestrictedPSPName},
+					Verbs:         []string{"use"},
+				},
+				{
+					APIGroups:     []string{"security.openshift.io"},
+					Resources:     []string{"securitycontextconstraints"},
+					ResourceNames: []string{component.PxSCCName},
 					Verbs:         []string{"use"},
 				},
 			},

--- a/pkg/controller/storagecluster/testspec/storkSchedClusterRole.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedClusterRole.yaml
@@ -53,3 +53,7 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["px-restricted"]
     verbs: ["use"]
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["portworx"]
+    verbs: ["use"]


### PR DESCRIPTION
…#1040)

* PWX-30737: Updating stork-scheduler clusterrole for OCP 4.11
* Fix scc UT.
---------

**What this PR does / why we need it**:
Updating Openshift securitycontextconstraint on stork-scheduler clusterrole .

**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PWX-30737


**Special notes for your reviewer**:
* This is a cherry-pick PR
* Changes merged in with the following PR https://github.com/libopenstorage/operator/pull/1040
