### PR TITLE
PWX-30512: Blocks enabling FACD topology on existing clusters

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2507,6 +2507,49 @@ func TestValidationsForEssentials(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestValidationsForFACDTopology(t *testing.T) {
+	component.DeregisterAllComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	cluster := &corev1.StorageCluster{
+		Spec: corev1.StorageClusterSpec{
+			CommonConfig: corev1.CommonConfig{
+				Env: []v1.EnvVar{
+					{
+						Name:  "FACD_TOPOLOGY_ENABLED",
+						Value: "true",
+					},
+				},
+			},
+		},
+	}
+
+	// TestCase: Should succeed for new cluster
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Reset cluster to clean "installed" state, then add var, should fail
+	cluster = &corev1.StorageCluster{
+		Spec: corev1.StorageClusterSpec{
+			CommonConfig: corev1.CommonConfig{
+				Env: []v1.EnvVar{
+					{
+						Name:  "FACD_TOPOLOGY_ENABLED",
+						Value: "true",
+					},
+				},
+			},
+		},
+	}
+	cluster.Status.Phase = string(corev1.ClusterStateRunning)
+
+	// TestCase: Should fail for existing cluster
+	err = driver.PreInstall(cluster)
+	require.Error(t, err)
+}
+
 func TestUpdateClusterStatusFirstTime(t *testing.T) {
 	driver := portworx{}
 

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -144,6 +144,8 @@ const (
 	AnnotationDisableCSRAutoApprove = pxAnnotationPrefix + "/disable-csr-approve"
 	// AnnotationDisableCSRAutoApprove annotation to set priority for SCCs.
 	AnnotationSCCPriority = pxAnnotationPrefix + "/scc-priority"
+	// AnnotationFACDTopology is added when FACD topology was successfully installed on a *new* cluster (it's blocked for existing clusters)
+	AnnotationFACDTopology = pxAnnotationPrefix + "/facd-topology"
 
 	// EnvKeyPXImage key for the environment variable that specifies Portworx image
 	EnvKeyPXImage = "PX_IMAGE"


### PR DESCRIPTION
**What this PR does / why we need it**:
This disables adding the `FACD_TOPOLOGY_ENABLED` flag on existing clusters that don't already have it, only allowing new clusters to start with topology.

This is accomplished by, if this is a new install and the variable is present, adding an annotation to demark this on the STC. Then, in future startups, if this annotation is present we don't raise an error.

