### PR TITLE
PWX-31488 & PWX-31501: Crashloop backoff pods remained after, specify…

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -108,6 +108,14 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 		logrus.Debugf("pre-flight: container already running...")
 	}
 
+	defer func() {
+		// Clean up the pre-flight pods
+		logrus.Infof("pre-flight: cleaning pre-flight ds...")
+		if derr := preFlighter.DeletePreFlight(); derr != nil {
+			logrus.Errorf("pre-flight: error deleting pre-flight: %v", derr)
+		}
+	}()
+
 	cnt := 0
 	//  Wait for all the pre-flight pods to finish
 	for {
@@ -132,14 +140,6 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 			return err
 		}
 	}
-
-	defer func() {
-		// Clean up the pre-flight pods
-		logrus.Infof("pre-flight: cleaning pre-flight ds...")
-		if derr := preFlighter.DeletePreFlight(); derr != nil {
-			logrus.Errorf("pre-flight: error deleting pre-flight: %v", derr)
-		}
-	}()
 
 	// Process all the StorageNode.Status.Checks
 	var storageNodes []*corev1.StorageNode


### PR DESCRIPTION
…ing pre-flight skip.  Defer cleanup declaration needs to be done before wait loop.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->
**What this PR does / why we need it**:
So the current implementation of pre-flight actually blocks and waits for pre-flight pods to finish/exit.  It has a timeout of 5 mins.   This is known issue and we look to fix this in the next release.  so if the pods get into a crash loop backoff and don't exit it will be 5 mins before operator will continue.  

Setting the "skip" annotation to bypass the pre-flight will not take affect until after the pre-flight block exits.     The problem was even after the blocking loop timeout and the "skip" was processed.   The pre-flight pods remained in crashloop back and the only way to remove them was to kill the daemonset.    The reason for this was because the blocking loop was being executed before the defer which was doing the cleanup.   So when the blocking loop timed out and returned an error there was no cleanup.   Moving the defer to before the blocking loop timeout fixes this issue.   

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31488 & PWX-31501
**Special notes for your reviewer**:
At this time once pre-flight is started and gets into crashloop backoff,  we cannot fix the code to handle the pre-flight "skip" until the 5 min timeout.