### PR TITLE
PWX-31488 & PWX-31501: Crashloop backoff pods remained after, specify…

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -105,6 +105,14 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 		logrus.Debugf("pre-flight: container already running...")
 	}
 
+	defer func() {
+		// Clean up the pre-flight pods
+		logrus.Infof("pre-flight: cleaning pre-flight ds...")
+		if derr := preFlighter.DeletePreFlight(); derr != nil {
+			logrus.Errorf("pre-flight: error deleting pre-flight: %v", derr)
+		}
+	}()
+
 	cnt := 0
 	//  Wait for all the pre-flight pods to finish
 	for {
@@ -129,14 +137,6 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 			return err
 		}
 	}
-
-	defer func() {
-		// Clean up the pre-flight pods
-		logrus.Infof("pre-flight: cleaning pre-flight ds...")
-		if derr := preFlighter.DeletePreFlight(); derr != nil {
-			logrus.Errorf("pre-flight: error deleting pre-flight: %v", derr)
-		}
-	}()
 
 	// Process all the StorageNode.Status.Checks
 	var storageNodes []*corev1.StorageNode


### PR DESCRIPTION
…ing pre-flight skip.  Defer cleanup declaration needs to be done before wait loop. (#1058)

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Cherry-pick from master: https://github.com/libopenstorage/operator/pull/1058
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31488 & PWX-31501
**Special notes for your reviewer**:

