### PR TITLE
PWX-30943: removed the memory limit for prometheus

### DIFF
--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -635,7 +635,7 @@ func (c *prometheus) createPrometheusInstance(
 		prometheusInst.Spec.Resources.Limits = cluster.Spec.Monitoring.Prometheus.Resources.Limits
 	} else {
 		prometheusInst.Spec.Resources.Limits = map[v1.ResourceName]resource.Quantity{
-			v1.ResourceMemory:           resource.MustParse("800Mi"),
+			v1.ResourceMemory:           resource.MustParse("4Gi"),
 			v1.ResourceCPU:              resource.MustParse("1"),
 			v1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
 		}

--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -635,7 +635,6 @@ func (c *prometheus) createPrometheusInstance(
 		prometheusInst.Spec.Resources.Limits = cluster.Spec.Monitoring.Prometheus.Resources.Limits
 	} else {
 		prometheusInst.Spec.Resources.Limits = map[v1.ResourceName]resource.Quantity{
-			v1.ResourceMemory:           resource.MustParse("4Gi"),
 			v1.ResourceCPU:              resource.MustParse("1"),
 			v1.ResourceEphemeralStorage: resource.MustParse("5Gi"),
 		}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -7517,7 +7517,7 @@ func TestPrometheusInstall(t *testing.T) {
 	// Modify resources and security context.
 	cluster.Spec.Monitoring.Prometheus.Resources = v1.ResourceRequirements{
 		Requests: map[v1.ResourceName]resource.Quantity{
-			v1.ResourceMemory: resource.MustParse("8Gi"),
+			v1.ResourceMemory: resource.MustParse("4Gi"),
 			v1.ResourceCPU:    resource.MustParse("4"),
 		},
 	}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -7517,7 +7517,7 @@ func TestPrometheusInstall(t *testing.T) {
 	// Modify resources and security context.
 	cluster.Spec.Monitoring.Prometheus.Resources = v1.ResourceRequirements{
 		Requests: map[v1.ResourceName]resource.Quantity{
-			v1.ResourceMemory: resource.MustParse("4Gi"),
+			v1.ResourceMemory: resource.MustParse("8Gi"),
 			v1.ResourceCPU:    resource.MustParse("4"),
 		},
 	}

--- a/drivers/storage/portworx/testspec/prometheusInstance.yaml
+++ b/drivers/storage/portworx/testspec/prometheusInstance.yaml
@@ -21,7 +21,6 @@ spec:
     limits:
       cpu: 1
       ephemeral-storage: 5Gi
-      memory: 4Gi
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534

--- a/drivers/storage/portworx/testspec/prometheusInstance.yaml
+++ b/drivers/storage/portworx/testspec/prometheusInstance.yaml
@@ -21,7 +21,7 @@ spec:
     limits:
       cpu: 1
       ephemeral-storage: 5Gi
-      memory: 800Mi
+      memory: 4Gi
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534

--- a/drivers/storage/portworx/testspec/prometheusInstanceWithAlertManager.yaml
+++ b/drivers/storage/portworx/testspec/prometheusInstanceWithAlertManager.yaml
@@ -26,7 +26,6 @@ spec:
     limits:
       cpu: 1
       ephemeral-storage: 5Gi
-      memory: 4Gi
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534

--- a/drivers/storage/portworx/testspec/prometheusInstanceWithAlertManager.yaml
+++ b/drivers/storage/portworx/testspec/prometheusInstanceWithAlertManager.yaml
@@ -26,7 +26,7 @@ spec:
     limits:
       cpu: 1
       ephemeral-storage: 5Gi
-      memory: 800Mi
+      memory: 4Gi
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534

--- a/drivers/storage/portworx/testspec/prometheusInstanceWithRemoteWriteEndpoint.yaml
+++ b/drivers/storage/portworx/testspec/prometheusInstanceWithRemoteWriteEndpoint.yaml
@@ -23,7 +23,7 @@ spec:
     limits:
       cpu: 1
       ephemeral-storage: 5Gi
-      memory: 800Mi
+      memory: 4Gi
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534

--- a/drivers/storage/portworx/testspec/prometheusInstanceWithRemoteWriteEndpoint.yaml
+++ b/drivers/storage/portworx/testspec/prometheusInstanceWithRemoteWriteEndpoint.yaml
@@ -23,7 +23,6 @@ spec:
     limits:
       cpu: 1
       ephemeral-storage: 5Gi
-      memory: 4Gi
   securityContext:
     runAsNonRoot: true
     runAsUser: 65534


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Currently we observed failure of Prometheus deployment on testing cluster with memory limit of 800Mi as defined previously. And hence after some investigation:
 1. current testing cluster needs at least 1.5Gi to stabilize
 2. a previous test with cluster of 800-nodes used up to 3.7Gi
 3. customers are expected to deploy clusters at least with double the size of the testing cluster in 1

We decided to increase this limit to 4Gi so to cover most of the use case so far. More extensive investigation on whether a better (lower) limit could be specified will be carried out for next release. 

More details described in the ticket itself.

Edited Jun 6, 17:57 : ignore the statement in the description as we made decision to go with unbounded
https://github.com/libopenstorage/operator/pull/1061#issuecomment-1579214180

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

