### PR TITLE
PWX-31551: CSI privileged fix

### DIFF
--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -613,6 +613,10 @@ func getCSIDeploymentSpec(
 		args = append(args, "--feature-gates=Topology=true")
 	}
 
+	sc := &v1.SecurityContext{
+		Privileged: boolPtr(true),
+	}
+
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            CSIApplicationName,
@@ -648,6 +652,7 @@ func getCSIDeploymentSpec(
 									MountPath: "/csi",
 								},
 							},
+							SecurityContext: sc,
 						},
 					},
 					Volumes: []v1.Volume{
@@ -695,6 +700,7 @@ func getCSIDeploymentSpec(
 						MountPath: "/csi",
 					},
 				},
+				SecurityContext: sc,
 			},
 		)
 	}
@@ -721,6 +727,7 @@ func getCSIDeploymentSpec(
 					MountPath: "/csi",
 				},
 			},
+			SecurityContext: sc,
 		}
 		if csiConfig.IncludeEndpointsAndConfigMapsForLeases {
 			snapshotterContainer.Args = append(
@@ -758,6 +765,7 @@ func getCSIDeploymentSpec(
 						MountPath: "/csi",
 					},
 				},
+				SecurityContext: sc,
 			},
 		)
 	}
@@ -773,6 +781,7 @@ func getCSIDeploymentSpec(
 					"--v=3",
 					"--leader-election=true",
 				},
+				SecurityContext: sc,
 			},
 		)
 	}
@@ -809,6 +818,7 @@ func getCSIDeploymentSpec(
 						Protocol:      v1.ProtocolTCP,
 					},
 				},
+				SecurityContext: sc,
 			},
 		)
 	}
@@ -909,6 +919,10 @@ func getCSIStatefulSetSpec(
 	}
 	imagePullPolicy := pxutil.ImagePullPolicy(cluster)
 
+	sc := &v1.SecurityContext{
+		Privileged: boolPtr(true),
+	}
+
 	statefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            CSIApplicationName,
@@ -949,6 +963,7 @@ func getCSIStatefulSetSpec(
 									MountPath: "/csi",
 								},
 							},
+							SecurityContext: sc,
 						},
 						{
 							Name:            csiAttacherContainerName,
@@ -970,6 +985,7 @@ func getCSIStatefulSetSpec(
 									MountPath: "/csi",
 								},
 							},
+							SecurityContext: sc,
 						},
 					},
 					Volumes: []v1.Volume{

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-resizer:v1.2.3
@@ -54,6 +56,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeploymentWithPKS.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithPKS.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -51,10 +53,11 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
-
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-resizer:v1.2.3
@@ -68,6 +71,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
@@ -30,6 +30,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -43,6 +45,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-resizer:v1.2.3
@@ -56,6 +60,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -54,6 +56,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-resizer:v1.2.3
@@ -67,6 +71,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1_17.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1_17.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -54,6 +56,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-resizer:v1.2.3
@@ -67,6 +71,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
@@ -41,6 +41,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-attacher
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-attacher:v1.2.3
@@ -55,6 +57,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -69,6 +73,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
@@ -50,6 +50,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -63,6 +65,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           image: quay.io/k8scsi/csi-resizer:v1.2.3
           imagePullPolicy: Always
@@ -76,6 +80,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120.yaml
@@ -50,6 +50,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -63,6 +65,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           image: quay.io/k8scsi/csi-resizer:v1.2.3
           imagePullPolicy: Always
@@ -76,12 +80,16 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshot-controller
           image: quay.io/k8scsi/snapshot-controller:v1.2.3
           imagePullPolicy: Always
           args:
             - --v=3
             - --leader-election=true
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
@@ -51,6 +51,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -64,6 +66,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           image: quay.io/k8scsi/csi-resizer:v1.2.3
           imagePullPolicy: Always
@@ -77,12 +81,16 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshot-controller
           image: quay.io/k8scsi/snapshot-controller:v1.2.3
           imagePullPolicy: Always
           args:
             - --v=3
             - --leader-election=true
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
@@ -50,6 +50,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -63,6 +65,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           image: quay.io/k8scsi/csi-resizer:v1.2.3
           imagePullPolicy: Always
@@ -76,6 +80,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
@@ -50,6 +50,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshotter
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-snapshotter:v1.2.3
@@ -63,6 +65,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-resizer
           image: quay.io/k8scsi/csi-resizer:v1.2.3
           imagePullPolicy: Always
@@ -76,12 +80,16 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-snapshot-controller
           image: quay.io/k8scsi/snapshot-controller:v1.2.3
           imagePullPolicy: Always
           args:
             - --v=3
             - --leader-election=true
+          securityContext:
+            privileged: true
         - name: csi-health-monitor-controller
           image: quay.io/k8scsi/csi-health-monitor-controller:v1.2.3
           imagePullPolicy: Always
@@ -100,6 +108,8 @@ spec:
             - name: http-endpoint
               containerPort: 8080
               protocol: TCP
+          securityContext:
+            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/testspec/csiStatefulSet_0.3.yaml
+++ b/drivers/storage/portworx/testspec/csiStatefulSet_0.3.yaml
@@ -40,6 +40,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
         - name: csi-attacher
           imagePullPolicy: Always
           image: quay.io/k8scsi/csi-attacher:v1.2.3
@@ -52,6 +54,8 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          securityContext:
+            privileged: true
       volumes:
         - name: socket-dir
           hostPath:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

Switching security to `privileged:true` for all CSI containers

**What this PR does / why we need it**:

The latest OCP 4.13 has more restrictive SELinux policies, so the Portworx CSI PODs can no longer access the `csi.sock` file.

**ISSUE**: The SELinux block the access to our `csi.sock` file, and the following line pops up in the audit-log:

```
type=AVC msg=audit(1686023559.076:85637): avc:  denied  { connectto } for  pid=224568 comm="csi-snapshotter"
    path="/var/lib/kubelet/plugins/pxd.portworx.com/csi.sock"
    scontext=system_u:system_r:container_t:s0:c370,c397
    tcontext=system_u:system_r:container_runtime_t:s0
    tclass=unix_stream_socket permissive=0
``` 

The permissions (and SELinux label) on the `csi.sock` file is consistent with other (non-PX) CSI modules:
```
[root@nextpx-ocp413-op-n5rn9-worker-westus-9whzq plugins]# ls -alRZ /var/lib/kubelet/plugins
/var/lib/kubelet/plugins/disk.csi.azure.com:
total 0
drwxr-xr-x. 2 root root system_u:object_r:container_file_t:s0  22 Jun  5 19:42 .
drwxr-x---. 7 root root system_u:object_r:container_file_t:s0 107 Jun  6 02:40 ..
srwxr-xr-x. 1 root root system_u:object_r:container_file_t:s0   0 Jun  5 19:42 csi.sock

/var/lib/kubelet/plugins/file.csi.azure.com:
total 0
drwxr-xr-x. 2 root root system_u:object_r:container_file_t:s0  22 Jun  5 19:42 .
drwxr-x---. 7 root root system_u:object_r:container_file_t:s0 107 Jun  6 02:40 ..
srwxr-xr-x. 1 root root system_u:object_r:container_file_t:s0   0 Jun  5 19:42 csi.sock

/var/lib/kubelet/plugins/pxd.portworx.com:
total 0
drwxr-xr-x. 2 root root system_u:object_r:container_file_t:s0  22 Jun  5 19:54 .
drwxr-x---. 7 root root system_u:object_r:container_file_t:s0 107 Jun  6 02:40 ..
srwxr-xr-x. 1 root root system_u:object_r:container_file_t:s0   0 Jun  5 19:54 csi.sock
```
* so.. SELinux label on PX `csi.sock` file is not the issue

Listing CSI processes

```
# ps -efZ --forest
...
system_u:system_r:container_runtime_t:s0 root 3884     1  0 Jun05 ?        00:00:00 /usr/bin/conmon -b /run/containers/storage/overlay-containers/85f40fc0ee3d665c95f0a535081bda41f28b926db9448bda1579d6fe062561b6/userdata -c 85f40fc0ee3d665c95f0a535081bda4>
system_u:system_r:spc_t:s0      root        4034    3884  0 Jun05 ?        00:00:04  \_ /bin/azurediskplugin --endpoint=unix:///csi/csi.sock --logtostderr --v=2 --nodeid=nextpx-ocp413-op-n5rn9-worker-westus-9whzq --metrics-address=localhost:8206 --cloud->

system_u:system_r:container_runtime_t:s0 root 227716   1  0 03:56 ?        00:00:00 /usr/bin/conmon -b /run/containers/storage/overlay-containers/d5a35a91a90ef9ce46b40740356e2980d090a6e0c1d3b1c42d0b224204f7e3b5/userdata -c d5a35a91a90ef9ce46b40740356e298>
system_u:system_r:container_t:s0:c146,c491 root 227728 227716  0 03:56 ?   00:00:00  \_ /csi-provisioner --v=3 --csi-address=/csi/csi.sock --leader-election=true --default-fstype=ext4 --extra-create-metadata=true
system_u:system_r:container_runtime_t:s0 root 227759   1  0 03:56 ?        00:00:00 /usr/bin/conmon -b /run/containers/storage/overlay-containers/0d368fc8a9b3edcd34f7e99ddc6faa4189841726f904ae3a39376af1679fce48/userdata -c 0d368fc8a9b3edcd34f7e99ddc6faa4>
system_u:system_r:container_t:s0:c146,c491 root 227771 227759  0 03:56 ?   00:00:00  \_ /csi-snapshotter --v=3 --csi-address=/csi/csi.sock --leader-election=true
system_u:system_r:container_runtime_t:s0 root 227801   1  0 03:56 ?        00:00:00 /usr/bin/conmon -b /run/containers/storage/overlay-containers/20f9c4d9aa6d4ffdd5d632b340d789c3967349f51e9f0dfb37a778ed352dc389/userdata -c 20f9c4d9aa6d4ffdd5d632b340d789c>
system_u:system_r:container_t:s0:c146,c491 root 227813 227801  0 03:56 ?   00:00:00  \_ /csi-resizer --v=3 --csi-address=/csi/csi.sock --leader-election=true
system_u:system_r:container_runtime_t:s0 root 227842   1  0 03:56 ?        00:00:00 /usr/bin/conmon -b /run/containers/storage/overlay-containers/a84ad26c1b0eafad12d914a0f3235a3312fc4d6085fe671829ef105a0e2bdd63/userdata -c a84ad26c1b0eafad12d914a0f3235a3>
system_u:system_r:container_t:s0:c146,c491 root 227852 227842  0 03:56 ?   00:00:00  \_ /snapshot-controller --v=3 --leader-election=true
```
* note, Azure-CSI processes have `system_u:system_r:spc_t:s0` SELinux label (they are privileged processes), while
* the PX-CSI processes had `system_u:system_r:container_t:s0:c146,c491` SELinux (non-privileged processes)

So, as a fix, we are promoting all CSI processes to `privileged:true`.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-31551

**Special notes for your reviewer**:

