### PR TITLE
PWX-31585: added new certStoreType kv pair to accommodate changes in latest ccm-go

### DIFF
--- a/deploy/ccm/config_properties_px.yaml
+++ b/deploy/ccm/config_properties_px.yaml
@@ -27,6 +27,7 @@ cloud:
   auth:
     version: "1.0"
 productName: "portworx"
+certStoreType: "k8s"
 k8s:
   certSecretName: "pure-telemetry-certs"
   certSecretNamespace: CERT_SECRET_NAMESPACE

--- a/drivers/storage/portworx/testspec/ccmGoRegisterConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterConfigMap.yaml
@@ -39,6 +39,7 @@ data:
       auth:
         version: "1.0"
     productName: "portworx"
+    certStoreType: "k8s"
     k8s:
       certSecretName: "pure-telemetry-certs"
       certSecretNamespace: kube-test


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Starting from ccm-go 1.0.9, it introduced an extra config field "certStoreType" to differentiate different approach for storing appliance certificate when cloud CA returns it to ccm-go. And in order to accommodate their side of change, we also need to introduce this field into ccm-go's configmap to use the latest image with vulnerabilities fixed. 

More context at this commend (https://portworx.atlassian.net/browse/PWX-31585?focusedCommentId=248697)

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

