### PR TITLE
PWX-31739: Pre-flight should only run with PX version 3.0 and above.

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -640,9 +640,12 @@ func (c *Controller) syncStorageCluster(
 			cluster.Namespace, cluster.Name, err)
 	}
 
-	// If preflight failed, or previous check failed, reconcile would stop here until issues got resolved
-	if err := c.runPreflightCheck(cluster); err != nil {
-		return fmt.Errorf("preflight check failed for StorageCluster %v/%v: %v", cluster.Namespace, cluster.Name, err)
+	pxVer30, _ := version.NewVersion("3.0")
+	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) { // Preflight should only run on PX version 3.0.0 and above
+		// If preflight failed, or previous check failed, reconcile would stop here until issues got resolved
+		if err := c.runPreflightCheck(cluster); err != nil {
+			return fmt.Errorf("preflight check failed for StorageCluster %v/%v: %v", cluster.Namespace, cluster.Name, err)
+		}
 	}
 
 	// Ensure Stork is deployed with right configuration


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Pre-flight passes new parameters to oci-mon & px so we can only execute pre-flight with PX/OCI 3.0 and above.   Skip pre-flight if the version is lower thank 3.0

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

