### PR TITLE
PWX-31739: Pre-flight should only run with PX version 3.0 and above.

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -630,12 +630,15 @@ func (c *Controller) syncStorageCluster(
 			cluster.Namespace, cluster.Name, err)
 	}
 
-	// If preflight failed, or previous check failed, reconcile would stop here until issues got resolved
-	if err := c.runPreflightCheck(cluster); err != nil {
-		if updateErr := c.updateStorageClusterState(cluster, corev1.ClusterStateDegraded); updateErr != nil {
-			logrus.Errorf("Failed to update StorageCluster status. %v", updateErr)
+	pxVer30, _ := version.NewVersion("3.0")
+	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) { // Preflight should only run on PX version 3.0.0 and above
+		// If preflight failed, or previous check failed, reconcile would stop here until issues got resolved
+		if err := c.runPreflightCheck(cluster); err != nil {
+			if updateErr := c.updateStorageClusterState(cluster, corev1.ClusterStateDegraded); updateErr != nil {
+				logrus.Errorf("Failed to update StorageCluster status. %v", updateErr)
+			}
+			return fmt.Errorf("preflight check failed for StorageCluster %v/%v: %v", cluster.Namespace, cluster.Name, err)
 		}
-		return fmt.Errorf("preflight check failed for StorageCluster %v/%v: %v", cluster.Namespace, cluster.Name, err)
 	}
 
 	// Ensure Stork is deployed with right configuration


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Preflight should only run on PX/OCI 3.0 and above.   Pulling in this PR: https://github.com/libopenstorage/operator/pull/1071

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Opening this PR so we don't have to wait for CBT testing.   
