### PR TITLE
PWX-29398,PWX-30227: fix panic when GetZoneMap() returns empty zones

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -49,6 +49,10 @@ const (
 	defaultEksCloudStorageDeviceSize  = "150"
 )
 
+var (
+	ErrNodeListEmpty = stderr.New("no nodes were available for px installation")
+)
+
 type portworx struct {
 	k8sClient          client.Client
 	k8sVersion         *version.Version
@@ -344,6 +348,9 @@ func (p *portworx) getDefaultMaxStorageNodesPerZone(
 		return 0, err
 	}
 	numZones := len(zoneMap)
+	if numZones <= 0 {
+		return 0, ErrNodeListEmpty
+	}
 	storageNodes = uint64(len(nodeList.Items) / numZones)
 	return uint32(storageNodes), nil
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

We have encountered a case where `cloudprovider.GetZoneMap()` returned empty zone-map, and this caused golang panic due to "divide by zero"

As a fix, we will return the appropriate error rather than crashing w/ panic.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-29398 and PWX-30227

**Special notes for your reviewer**:

