### PR TITLE
Adding relatedImages into clusterserviceversion

### DIFF
--- a/deploy/olm-catalog/portworx/23.5.0/portworx-certified.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/23.5.0/portworx-certified.clusterserviceversion.yaml
@@ -60,6 +60,9 @@ spec:
   provider:
     name: Portworx
   keywords: ["portworx", "persistent storage", "storage", "cloud native", "open source"]
+  relatedImages:
+    - name: portworx-operator
+      image: registry.connect.redhat.com/portworx/openstorage-operator@sha256:744cccea5851eec50efab35c6eb00813388c58c7e5365a3da2463bd53d0ff2d8
   labels:
     operated-by: portworx-operator
   selector:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

commit to https://github.com/redhat-openshift-ecosystem/certified-operators/pull/2377 has FAILED due to missing `spec.relatedImages`

So, as a fix, we're adding a dummy `relatedImages` entry, pointing back to the same operator image.

**Which issue(s) this PR fixes** (optional)
Closes # -

**Special notes for your reviewer**:

