### PR TITLE
PWX-31842: PKS mounts-leak fix

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1130,7 +1130,7 @@ func (t *template) getEnvList() []v1.EnvVar {
 	if t.isPKS {
 		envMap["PRE-EXEC"] = &v1.EnvVar{
 			Name:  "PRE-EXEC",
-			Value: "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi",
+			Value: "rm -fr /var/lib/osd/driver",
 		}
 	}
 
@@ -1771,9 +1771,12 @@ func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 	pxVer2_9_1, _ := version.NewVersion("2.9.1")
 	if pxVersion.GreaterThanOrEqual(pxVer2_9_1) {
 		list = append(list, volumeInfo{
-			name:             "varlibosd",
-			hostPath:         "/var/lib/osd",
-			mountPath:        "/var/lib/osd",
+			name:      "varlibosd",
+			hostPath:  "/var/lib/osd",
+			mountPath: "/var/lib/osd",
+			pks: &pksVolumeInfo{
+				hostPath: "/var/vcap/store/lib/osd",
+			},
 			mountPropagation: mountPropagationModePtr(v1.MountPropagationBidirectional),
 		})
 	}
@@ -1793,13 +1796,6 @@ func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 			mountPath: "/etc/pwx",
 			pks: &pksVolumeInfo{
 				hostPath: "/var/vcap/store/etc/pwx",
-			},
-		},
-		{
-			name: "pxlogs",
-			pks: &pksVolumeInfo{
-				mountPath: "/var/lib/osd/log",
-				hostPath:  "/var/vcap/store/lib/osd/log",
 			},
 		},
 		{

--- a/drivers/storage/portworx/testspec/pks.yaml
+++ b/drivers/storage/portworx/testspec/pks.yaml
@@ -51,7 +51,7 @@ spec:
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
             - name: "PRE-EXEC"
-              value: "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi"
+              value: "rm -fr /var/lib/osd/driver"
           livenessProbe:
             periodSeconds: 30
             initialDelaySeconds: 840 # allow image pull in slow networks
@@ -85,8 +85,6 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
-            - name: pxlogs
-              mountPath: /var/lib/osd/log
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -129,9 +127,6 @@ spec:
         - name: optpwx
           hostPath:
             path: /var/vcap/store/opt/pwx
-        - name: pxlogs
-          hostPath:
-            path: /var/vcap/store/lib/osd/log
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/pks_2.9.1.yaml
+++ b/drivers/storage/portworx/testspec/pks_2.9.1.yaml
@@ -38,7 +38,7 @@ spec:
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
             - name: "PRE-EXEC"
-              value: "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi"
+              value: "rm -fr /var/lib/osd/driver"
           livenessProbe:
             periodSeconds: 30
             initialDelaySeconds: 840 # allow image pull in slow networks
@@ -75,8 +75,6 @@ spec:
             - name: varlibosd
               mountPath: /var/lib/osd
               mountPropagation: Bidirectional
-            - name: pxlogs
-              mountPath: /var/lib/osd/log
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -121,10 +119,7 @@ spec:
             path: /var/vcap/store/opt/pwx
         - name: varlibosd
           hostPath:
-            path: /var/lib/osd
-        - name: pxlogs
-          hostPath:
-            path: /var/vcap/store/lib/osd/log
+            path: /var/vcap/store/lib/osd
         - name: procmount
           hostPath:
             path: /proc

--- a/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
+++ b/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
@@ -38,7 +38,7 @@ spec:
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
             - name: "PRE-EXEC"
-              value: "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi"
+              value: "rm -fr /var/lib/osd/driver"
             - name: CSI_ENDPOINT
               value: unix:///var/vcap/data/kubelet/csi-plugins/pxd.portworx.com/csi.sock
           livenessProbe:
@@ -74,8 +74,6 @@ spec:
               mountPath: /etc/pwx
             - name: optpwx
               mountPath: /opt/pwx
-            - name: pxlogs
-              mountPath: /var/lib/osd/log
             - name: procmount
               mountPath: /host_proc
             - name: sysdmount
@@ -137,9 +135,6 @@ spec:
         - name: optpwx
           hostPath:
             path: /var/vcap/store/opt/pwx
-        - name: pxlogs
-          hostPath:
-            path: /var/vcap/store/lib/osd/log
         - name: registration-dir
           hostPath:
             path: /var/vcap/data/kubelet/plugins_registry

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -64,7 +64,6 @@ var (
 		"optpwx":           true,
 		"osddriver":        true,
 		"procmount":        true,
-		"pxlogs":           true,
 		"src":              true,
 		"sysdmount":        true,
 	}


### PR DESCRIPTION
* mounting changing OSD-mount to `-v /var/lib/osd:/var/vcap/store/lib/osd:shared`
* removing offending "pxlogs" (/var/vcap/store/lib/osd/log) mount
* changing `PRE-EXEC` to remove the /var/lib/osd/driver directory
* fixing UTs

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

ISSUE: the `/var/lib/osd` + `/var/lib/osd/log` mounts were causing the "mounts leak" issue on PKS platform

As a fix, we are:
* we are changing the OSD-mount to `/var/vcap/store/lib/osd`
* removing the `/var/lib/osd/log` mount
* we had to use `PRE-EXEC` to remove /var/lib/osd/driver directory, as the `pwx.sock` file inside causes 2-minute delays for every `pxctl` command

**Which issue(s) this PR fixes** (optional)
Closes # PWX-31842

**Special notes for your reviewer**:

