### PR TITLE
Pwx 31931 preflight on fresh install only (#1084)

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -641,7 +641,8 @@ func (c *Controller) syncStorageCluster(
 	}
 
 	pxVer30, _ := version.NewVersion("3.0")
-	if pxutil.IsFreshInstall(cluster) && pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) { // Preflight should only run on PX version 3.0.0 and above
+	// Preflight should only run freshInstall and if the PX version is 3.0.0 and above
+	if pxutil.IsFreshInstall(cluster) && pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
 		// If preflight failed, or previous check failed, reconcile would stop here until issues got resolved
 		if err := c.runPreflightCheck(cluster); err != nil {
 			return fmt.Errorf("preflight check failed for StorageCluster %v/%v: %v", cluster.Namespace, cluster.Name, err)


### PR DESCRIPTION
* PWX-31931: Only execute pre-flight on fresh PX install.



* PWX-31931: Ensure Annotation map exists.



* PWX-31931: If skipping pre-flight only set the annotation to false if its not set or empty.



* PWX-31931: Use Piyush review code.



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
PWX-31931 
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
This is a cherry-pick of PR: https://github.com/libopenstorage/operator/pull/1084 from px-rel-23.5.1