### PR TITLE
PWX-31634: Fix image override for portworx-kvdb

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -531,7 +531,11 @@ func (t *template) portworxContainer(cluster *corev1.StorageCluster) v1.Containe
 }
 
 func (t *template) kvdbContainer() v1.Container {
-	kvdbProxyImage := util.GetImageURN(t.cluster, pxutil.ImageNamePause)
+	imageName := pxutil.ImageNamePause
+	if t.cluster.Status.DesiredImages != nil && t.cluster.Status.DesiredImages.Pause != "" {
+		imageName = t.cluster.Status.DesiredImages.Pause
+	}
+	kvdbProxyImage := util.GetImageURN(t.cluster, imageName)
 	kvdbTargetPort := 9019
 	if t.startPort != pxutil.DefaultStartPort {
 		kvdbTargetPort = t.startPort + 15

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -426,6 +426,16 @@ func TestGetKVDBPodSpec(t *testing.T) {
 	actual, err = driver.GetKVDBPodSpec(cluster, nodeName)
 	require.NoError(t, err)
 	assertPodSpecEqual(t, expected, &actual)
+
+	// retry w/ a custom image
+	overridden := "foobar.acme.org/some-repo/pauzaner:1.2.3"
+	cluster.Status.DesiredImages = &corev1.ComponentImages{
+		Pause: overridden,
+	}
+	expected.Containers[0].Image = overridden
+	actual, err = driver.GetKVDBPodSpec(cluster, nodeName)
+	require.NoError(t, err)
+	assertPodSpecEqual(t, expected, &actual)
 }
 
 func TestPodSpecWithCustomServiceAccount(t *testing.T) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Fixes the image override for `portworx-kvdb`

ISSUE:
* when `cm/px-versions` has `pause: ...` image override, we were supposed to set up all `pause`-PODs with the requested image
* however, the `portworx-kvdb` POD ignored this override, and was still using the default `registry.k8s.io/pause:3.1` image-url

FIX:
* as a fix, we are now correctly overriding the `portworx-kvdb` POD image

**Which issue(s) this PR fixes** (optional)
Closes # PWX-31634

**Special notes for your reviewer**:

