### PR TITLE
PWX-31672: Recognize vSphere provider

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -839,6 +839,13 @@ func (t *template) getCloudProvider() string {
 		return cloudops.Vsphere
 	}
 
+	// VSPHERE_VCENTER env variable's existence is an indication that it's vSphere provider
+	for _, envVar := range t.cluster.Spec.Env {
+		if envVar.Name == "VSPHERE_VCENTER" {
+			return cloudops.Vsphere
+		}
+	}
+
 	return ""
 }
 

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -839,13 +839,6 @@ func (t *template) getCloudProvider() string {
 		return cloudops.Vsphere
 	}
 
-	// VSPHERE_VCENTER env variable's existence is an indication that it's vSphere provider
-	for _, envVar := range t.cluster.Spec.Env {
-		if envVar.Name == "VSPHERE_VCENTER" {
-			return cloudops.Vsphere
-		}
-	}
-
 	return ""
 }
 

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -781,8 +781,9 @@ func TestPodSpecWithKvdbSpec(t *testing.T) {
 func TestPodSpecForVsphere(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	nodeName := "testNode"
+	k8sClient := testutil.FakeK8sClient()
 
-	cluster := &corev1.StorageCluster{
+	originalSpec := &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
 			Namespace: "kube-system",
@@ -792,20 +793,75 @@ func TestPodSpecForVsphere(t *testing.T) {
 			CloudStorage: &corev1.CloudStorageSpec{},
 		},
 	}
+	// TestCase 1: Detect VSPHERE_VCENTER and set provider
+	cluster := originalSpec.DeepCopy()
+
 	env := make([]v1.EnvVar, 1)
 	env[0].Name = "VSPHERE_VCENTER"
 	env[0].Value = "some.vcenter.server.com"
 	cluster.Spec.Env = env
 
 	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
+	require.NoError(t, err)
 
 	expectedArgs := []string{
 		"-cloud_provider", "vsphere",
 		"-c", "px-cluster",
 		"-x", "kubernetes",
+		"-b",
+		"-secret_type", "k8s",
 	}
 
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	_, ok := cluster.Annotations[pxutil.AnnotationPreflightCheck]
+	require.True(t, ok)
+
 	actual, err := driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+
+	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
+
+	// TestCase 2: VSPHERE_VCENTER  not found, don't expect -cloud_provider
+	cluster = originalSpec.DeepCopy()
+	driver = portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
+	require.NoError(t, err)
+
+	expectedArgs = []string{
+		"-c", "px-cluster",
+		"-x", "kubernetes",
+		"-b",
+		"-secret_type", "k8s",
+	}
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+
+	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
+
+	// TestCase 3: provider set explicitly
+	cluster = originalSpec.DeepCopy()
+	provider := string(cloudops.AWS)
+	cluster.Spec.CloudStorage.Provider = &provider
+	driver = portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
+	require.NoError(t, err)
+
+	expectedArgs = []string{
+		"-cloud_provider", string(cloudops.AWS),
+		"-c", "px-cluster",
+		"-x", "kubernetes",
+		"-b",
+		"-secret_type", "k8s",
+	}
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 
 	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -417,22 +417,23 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 	if toUpdate.Annotations == nil {
 		toUpdate.Annotations = make(map[string]string)
 	}
-	providerName := toUpdate.Spec.CloudStorage.Provider
+	if toUpdate.Spec.CloudStorage != nil {
+		providerName := toUpdate.Spec.CloudStorage.Provider
 
-	// if provider is not set, let's check if it's vSphere
-	if providerName == nil || len(*providerName) == 0 {
-		provider := getCloudProvider(toUpdate)
-		if len(provider) > 0 {
-			providerName = &provider
+		// if provider is not set, let's check if it's vSphere
+		if providerName == nil || len(*providerName) == 0 {
+			provider := getCloudProvider(toUpdate)
+			if len(provider) > 0 {
+				providerName = &provider
+			}
 		}
-	}
 
-	if providerName != nil &&
-		preflight.Instance().ProviderName() != *providerName {
-		preflight.Instance().SetProvider(*providerName)
+		if providerName != nil &&
+			preflight.Instance().ProviderName() != *providerName {
+			preflight.Instance().SetProvider(*providerName)
+		}
+		toUpdate.Spec.CloudStorage.Provider = providerName
 	}
-
-	toUpdate.Spec.CloudStorage.Provider = providerName
 
 	// Initialize the preflight check annotation
 	if preflight.RequiresCheck() {

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stderr "errors"
 	"fmt"
+	"github.com/libopenstorage/cloudops"
 	"math"
 	"strconv"
 	"strings"
@@ -395,10 +396,44 @@ func (p *portworx) getCurrentMaxStorageNodesPerZone(
 	return 0, fmt.Errorf("storage disabled")
 }
 
+func isVsphere(cluster *corev1.StorageCluster) bool {
+	for _, env := range cluster.Spec.Env {
+		if env.Name == "VSPHERE_VCENTER" && len(env.Value) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func getCloudProvider(cluster *corev1.StorageCluster) string {
+	if isVsphere(cluster) {
+		return cloudops.Vsphere
+	}
+	// TODO: implement conditions for other providers
+	return ""
+}
+
 func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) error {
 	if toUpdate.Annotations == nil {
 		toUpdate.Annotations = make(map[string]string)
 	}
+	providerName := toUpdate.Spec.CloudStorage.Provider
+
+	// if provider is not set, let's check if it's vSphere
+	if providerName == nil || len(*providerName) == 0 {
+		provider := getCloudProvider(toUpdate)
+		if len(provider) > 0 {
+			providerName = &provider
+		}
+	}
+
+	if providerName != nil &&
+		preflight.Instance().ProviderName() != *providerName {
+		preflight.Instance().SetProvider(*providerName)
+	}
+
+	toUpdate.Spec.CloudStorage.Provider = providerName
+
 	// Initialize the preflight check annotation
 	if preflight.RequiresCheck() {
 		if _, ok := toUpdate.Annotations[pxutil.AnnotationPreflightCheck]; !ok {

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"github.com/libopenstorage/cloudops"
 	"math"
 	"net"
 	"os"
@@ -343,6 +344,25 @@ func IsIKS(cluster *corev1.StorageCluster) bool {
 func IsOpenshift(cluster *corev1.StorageCluster) bool {
 	enabled, err := strconv.ParseBool(cluster.Annotations[AnnotationIsOpenshift])
 	return err == nil && enabled
+}
+
+// IsVsphere returns true if VSPHERE_VCENTER is present in the spec
+func IsVsphere(cluster *corev1.StorageCluster) bool {
+	for _, env := range cluster.Spec.Env {
+		if env.Name == "VSPHERE_VCENTER" && len(env.Value) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// GetCloudProvider returns the cloud provider string
+func GetCloudProvider(cluster *corev1.StorageCluster) string {
+	if IsVsphere(cluster) {
+		return cloudops.Vsphere
+	}
+	// TODO: implement conditions for other providers
+	return ""
 }
 
 // IsHostPidEnabled returns if hostPid should be set to true for portworx pod.

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1327,24 +1327,6 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		logrus.Debugf("Failed to update driver: %v", err)
 	}
 
-	if toUpdate.Spec.CloudStorage != nil {
-		providerName := toUpdate.Spec.CloudStorage.Provider
-
-		// if provider is not set, let's check if it's vSphere
-		if providerName == nil || len(*providerName) == 0 {
-			provider := pxutil.GetCloudProvider(toUpdate)
-			if len(provider) > 0 {
-				providerName = &provider
-			}
-		}
-
-		if providerName != nil &&
-			preflight.Instance().ProviderName() != *providerName {
-			preflight.Instance().SetProvider(*providerName)
-		}
-		toUpdate.Spec.CloudStorage.Provider = providerName
-	}
-
 	if err := c.Driver.SetDefaultsOnStorageCluster(toUpdate); err != nil {
 		return err
 	}

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -641,10 +641,18 @@ func (c *Controller) syncStorageCluster(
 	}
 
 	pxVer30, _ := version.NewVersion("3.0")
-	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) { // Preflight should only run on PX version 3.0.0 and above
+	// Preflight should only run freshInstall and if the PX version is 3.0.0 and above
+	if pxutil.IsFreshInstall(cluster) && pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
 		// If preflight failed, or previous check failed, reconcile would stop here until issues got resolved
 		if err := c.runPreflightCheck(cluster); err != nil {
 			return fmt.Errorf("preflight check failed for StorageCluster %v/%v: %v", cluster.Namespace, cluster.Name, err)
+		}
+	} else {
+		if _, exists := cluster.Annotations[pxutil.AnnotationPreflightCheck]; !exists {
+			if cluster.Annotations == nil {
+				cluster.Annotations = make(map[string]string)
+			}
+			cluster.Annotations[pxutil.AnnotationPreflightCheck] = "false"
 		}
 	}
 

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -32,10 +32,17 @@ type CheckerOps interface {
 
 	// CheckCloudDrivePermission checks if permissions for drive operation is granted
 	CheckCloudDrivePermission(cluster *corev1.StorageCluster) error
+
+	// SetProvider helps set the provider when that information is not available to Init
+	SetProvider(string)
 }
 
 func (c *checker) ProviderName() string {
 	return c.providerName
+}
+
+func (c *checker) SetProvider(providerName string) {
+	c.providerName = providerName
 }
 
 func (c *checker) K8sDistributionName() string {

--- a/pkg/preflight/utils.go
+++ b/pkg/preflight/utils.go
@@ -11,7 +11,8 @@ func IsEKS() bool {
 
 // RequiresCheck returns whether a preflight check is needed based on the platform
 func RequiresCheck() bool {
-	return Instance().ProviderName() == string(cloudops.AWS)
+	return Instance().ProviderName() == string(cloudops.AWS) ||
+		Instance().ProviderName() == string(cloudops.Vsphere)
 }
 
 // RunningOnCloud checks whether portworx is running on cloud


### PR DESCRIPTION
    Using VSPHERE_VCENTER env variable as an indication to say
    that it's vsphere provider

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Manual test:
```Jun 24 06:29:12 ip-10-13-195-103.pwx.purestorage.com portworx[6882]: time="2023-06-24T06:29:12Z" level=info msg="PX-RunC arguments: -b -c px-cluster-49b447d6-dbba-4b89-a35c-0341644148c6 -dedicated_cache -fastpath_enable -fastpath_protocol local -j auto -max_storage_nodes_per_zone 5 -metadata size=64 -s size=50 -s size=50 -s size=100 -secret_type k8s -x kubernetes"```

Unit test:

```
=== RUN   TestPodSpecForVsphere
time="2023-06-24T08:15:20-07:00" level=info msg="telemetry registration endpoint register.cloud-support.purestorage.com is accessible on cluster px-cluster"
time="2023-06-24T08:15:20-07:00" level=info msg="telemetry will be enabled by default"
time="2023-06-24T08:15:20-07:00" level=warning msg="Could not get OSImage for node testNode" error="nodes \"testNode\" not found"
time="2023-06-24T08:15:20-07:00" level=info msg="telemetry registration endpoint register.cloud-support.purestorage.com is accessible on cluster px-cluster"
time="2023-06-24T08:15:20-07:00" level=info msg="telemetry will be enabled by default"
time="2023-06-24T08:15:20-07:00" level=warning msg="Could not get OSImage for node testNode" error="nodes \"testNode\" not found"
time="2023-06-24T08:15:20-07:00" level=info msg="telemetry registration endpoint register.cloud-support.purestorage.com is accessible on cluster px-cluster"
time="2023-06-24T08:15:20-07:00" level=info msg="telemetry will be enabled by default"
time="2023-06-24T08:15:20-07:00" level=warning msg="Could not get OSImage for node testNode" error="nodes \"testNode\" not found"
--- PASS: TestPodSpecForVsphere (0.45s)
PASS

Process finished with the exit code 0
```