### PR TITLE
PWX-31987: Add operator version to oci-mon/px environment.

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -27,6 +27,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/preflight"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
+	opVersion "github.com/libopenstorage/operator/pkg/version"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 )
 
@@ -1265,6 +1266,11 @@ func (t *template) getEnvList() []v1.EnvVar {
 				},
 			}
 		}
+	}
+
+	envMap[pxutil.EnvKeyOperatorVersion] = &v1.EnvVar{
+		Name:  pxutil.EnvKeyOperatorVersion,
+		Value: opVersion.Version,
 	}
 
 	envList := make([]v1.EnvVar, 0)

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -210,7 +210,7 @@ func TestPodSpecWithImagePullSecrets(t *testing.T) {
 
 	assert.Len(t, actual.ImagePullSecrets, 1)
 	assert.Equal(t, expectedPullSecret, actual.ImagePullSecrets[0])
-	assert.Len(t, actual.Containers[0].Env, 6)
+	assert.Len(t, actual.Containers[0].Env, 7)
 	var regConfigEnv *v1.EnvVar
 	var regSecretEnv *v1.EnvVar
 	for _, env := range actual.Containers[0].Env {
@@ -231,7 +231,7 @@ func TestPodSpecWithImagePullSecrets(t *testing.T) {
 
 	assert.Len(t, actual.ImagePullSecrets, 1)
 	assert.Equal(t, expectedPullSecret, actual.ImagePullSecrets[0])
-	assert.Len(t, actual.Containers[0].Env, 6)
+	assert.Len(t, actual.Containers[0].Env, 7)
 	regConfigEnv = nil
 	for _, env := range actual.Containers[0].Env {
 		if env.Name == "REGISTRY_CONFIG" {
@@ -3898,7 +3898,7 @@ func TestPodSpecForIKS(t *testing.T) {
 	actual, err := driver.GetStoragePodSpec(cluster, nodeName)
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 
-	assert.Len(t, actual.Containers[0].Env, 5)
+	assert.Len(t, actual.Containers[0].Env, 6)
 	var podIPEnv *v1.EnvVar
 	for _, env := range actual.Containers[0].Env {
 		if env.Name == "PX_POD_IP" {
@@ -3929,7 +3929,7 @@ func TestPodSpecForIKS(t *testing.T) {
 	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 
-	assert.Len(t, actual.Containers[0].Env, 4)
+	assert.Len(t, actual.Containers[0].Env, 5)
 	podIPEnv = nil
 	for _, env := range actual.Containers[0].Env {
 		if env.Name == "PX_POD_IP" {

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -646,6 +646,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 
 	setAutopilotDefaults(toUpdate)
 	setTLSDefaults(toUpdate)
+	pxutil.SetOperatorVersionEnv(toUpdate)
 	return nil
 }
 

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -737,7 +737,9 @@ func TestSetDefaultsOnStorageClusterWithPortworxDisabled(t *testing.T) {
 	// No defaults should be set
 	err := driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
-	require.Equal(t, corev1.StorageClusterSpec{}, cluster.Spec)
+	startingCluster := &corev1.StorageCluster{}
+	pxutil.SetOperatorVersionEnv(startingCluster)
+	require.Equal(t, startingCluster.Spec, cluster.Spec)
 
 	// Use default component versions if components are enabled
 	cluster.Spec.Stork = &corev1.StorkSpec{

--- a/drivers/storage/portworx/testspec/openshift_runc.yaml
+++ b/drivers/storage/portworx/testspec/openshift_runc.yaml
@@ -39,6 +39,8 @@ spec:
             ["-c", "px-cluster", "-a", "-secret_type", "k8s", "-b",
              "-r", "17001", "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/pks.yaml
+++ b/drivers/storage/portworx/testspec/pks.yaml
@@ -37,6 +37,8 @@ spec:
             ["-c", "px-cluster", "-a", "-secret_type", "k8s", "-b",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/pks_2.9.1.yaml
+++ b/drivers/storage/portworx/testspec/pks_2.9.1.yaml
@@ -26,6 +26,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
@@ -27,6 +27,8 @@ spec:
              "-r", "10001",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"
               value: "1500"
             - name: "PX_TEMPLATE_VERSION"

--- a/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
@@ -24,6 +24,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS"
               value: "300"
             - name: "PX_TEMPLATE_VERSION"

--- a/drivers/storage/portworx/testspec/px_csi_0.3.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_0.3.yaml
@@ -26,6 +26,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_csi_1.0.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_1.0.yaml
@@ -26,6 +26,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_disable_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_disable_telemetry.yaml
@@ -52,6 +52,8 @@ spec:
              "-secret_type", "k8s",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
             - name: "PX_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -40,6 +40,8 @@ spec:
              "-secret_type", "k8s",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
             - name: "PX_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
@@ -30,6 +30,8 @@ spec:
             "-userpwd", "kvdb-username:kvdb-password",
             "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-test"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
@@ -29,6 +29,8 @@ spec:
             "-userpwd", "kvdb-username:kvdb-password",
             "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-test"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_cert.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_cert.yaml
@@ -29,6 +29,8 @@ spec:
             "-userpwd", "kvdb-username:kvdb-password",
             "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-test"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
@@ -29,6 +29,8 @@ spec:
             "-userpwd", "kvdb-username:kvdb-password",
             "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-test"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
@@ -24,6 +24,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-test"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_master.yaml
+++ b/drivers/storage/portworx/testspec/px_master.yaml
@@ -40,6 +40,8 @@ spec:
              "-secret_type", "k8s",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
             - name: "PX_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
+++ b/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
@@ -24,6 +24,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
@@ -52,6 +52,8 @@ spec:
              "-secret_type", "k8s",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
             - name: "PX_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -52,6 +52,8 @@ spec:
              "-secret_type", "k8s",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
             - name: "PX_NAMESPACE"

--- a/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
@@ -52,6 +52,8 @@ spec:
              "-secret_type", "k8s",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_TEMPLATE_VERSION"
               value: "v4"
             - name: "PX_HTTP_PROXY"

--- a/drivers/storage/portworx/testspec/runc.yaml
+++ b/drivers/storage/portworx/testspec/runc.yaml
@@ -41,6 +41,8 @@ spec:
             "-rt_opts", "op1=10",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/testspec/runc_2.9.1.yaml
+++ b/drivers/storage/portworx/testspec/runc_2.9.1.yaml
@@ -26,6 +26,8 @@ spec:
             ["-c", "px-cluster",
              "-x", "kubernetes"]
           env:
+            - name: "OPERATOR_VERSION"
+              value: ""
             - name: "PX_NAMESPACE"
               value: "kube-system"
             - name: "PX_SECRETS_NAMESPACE"

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -28,6 +28,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
+	opVersion "github.com/libopenstorage/operator/pkg/version"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -255,6 +256,9 @@ const (
 
 	// TelemetryCertName is name of the telemetry cert.
 	TelemetryCertName = "pure-telemetry-certs"
+
+	// EnvKeyOperatorVersion is name operator env variable
+	EnvKeyOperatorVersion = "OPERATOR_VERSION"
 )
 
 var (
@@ -1319,4 +1323,22 @@ func SetTelemetryCertOwnerRef(
 	secret.OwnerReferences = references
 
 	return k8sClient.Update(context.TODO(), secret)
+}
+
+func SetOperatorVersionEnv(cluster *corev1.StorageCluster) {
+	// Add Operator version if does not exist
+	versionExist := false
+	for _, env := range cluster.Spec.Env {
+		if env.Name == EnvKeyOperatorVersion && len(env.Value) > 0 {
+			versionExist = true
+		}
+	}
+
+	if !versionExist {
+		cluster.Spec.Env = append(cluster.Spec.Env, v1.EnvVar{
+			Name:  EnvKeyOperatorVersion,
+			Value: opVersion.Version,
+		})
+	}
+
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Add the operator version as an environment variable to OCI-MON/PX pods.   This will allow use take action based on the Operator version if need be.  
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31987

**Special notes for your reviewer**:
Note: the addition of this will cause a PX restart.   @zoxpx is there a way to prevent the PX restart when someone updates the operator?