### PR TITLE
[23.5.1] PWX-32048: Fixes annotation not being properly added for FACD topology installs

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -453,6 +453,22 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 	}
 
 	setDefaultAutopilotProviders(toUpdate)
+
+	if pxutil.IsFreshInstall(toUpdate) {
+		// Check for FACD variable on a new install: if so, add an annotation saying
+		// it's okay to continue.
+		facdTopologyEnv := ""
+		for _, env := range toUpdate.Spec.Env {
+			if env.Name == "FACD_TOPOLOGY_ENABLED" {
+				facdTopologyEnv = strings.ToLower(env.Value)
+				break
+			}
+		}
+
+		if facdTopologyEnv == "true" {
+			toUpdate.Annotations[pxutil.AnnotationFACDTopology] = "true"
+		}
+	}
 	return nil
 }
 
@@ -551,31 +567,18 @@ func (p *portworx) validateFACDTopology(cluster *corev1.StorageCluster) error {
 		}
 	}
 
-	if facdTopologyEnv == "true" {
-		// FACD topology is enabled. See if we already have the annotation marking this as valid, or if not, check if this is a fresh install
-
-		// TODO: once we support upgrading to FACD topology, it will also be valid after whatever version supports that
-		isValid := false
-		if pxutil.IsFreshInstall(cluster) {
-			if cluster.Annotations == nil {
-				cluster.Annotations = make(map[string]string)
-			}
-			cluster.Annotations[pxutil.AnnotationFACDTopology] = "true"
-			isValid = true
-		}
-		if !isValid {
-			if a, ok := cluster.Annotations[pxutil.AnnotationFACDTopology]; ok && a != "" {
-				isValid = true
-			}
-		}
-
-		if !isValid {
-			// Fail the request!
-			return fmt.Errorf("FACD topology cannot be enabled on existing clusters")
-		}
+	if facdTopologyEnv != "true" {
+		return nil
 	}
 
-	return nil
+	// FACD topology is enabled. See if we already have the annotation marking this as valid.
+	// TODO: once we support upgrading to FACD topology, it will also be valid after whatever version supports that
+	if v, ok := cluster.Annotations[pxutil.AnnotationFACDTopology]; ok && v == "true" {
+		return nil
+	}
+
+	// Fail the request as we don't have the annotation allowing it
+	return fmt.Errorf("FACD topology cannot be enabled on existing clusters")
 }
 
 func (p *portworx) IsPodUpdated(

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2140,6 +2140,11 @@ func TestValidationsForFACDTopology(t *testing.T) {
 	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
 	require.NoError(t, err)
 	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				pxutil.AnnotationFACDTopology: "true",
+			},
+		},
 		Spec: corev1.StorageClusterSpec{
 			CommonConfig: corev1.CommonConfig{
 				Env: []v1.EnvVar{


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously the check would initially pass but the annotation wouldn't be added, resulting in failures down the line. This small restructure fixes it all up and adds the annotation before the pre-flight check, which is also more consistent with the entire code flow. Many thanks to @piyush-nimbalkar !

**Which issue(s) this PR fixes** (optional)
PWX-32048

