### PR TITLE
PWX-32048: Fixes annotation not being properly added for FACD topology installs

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2514,6 +2514,11 @@ func TestValidationsForFACDTopology(t *testing.T) {
 	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
 	require.NoError(t, err)
 	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				pxutil.AnnotationFACDTopology: "true",
+			},
+		},
 		Spec: corev1.StorageClusterSpec{
 			CommonConfig: corev1.CommonConfig{
 				Env: []v1.EnvVar{


### PR DESCRIPTION
What this PR does / why we need it:
Previously the check would initially pass but the annotation wouldn't be added, resulting in failures down the line. This small restructure fixes it all up and adds the annotation before the pre-flight check, which is also more consistent with the entire code flow. Many thanks to @piyush-nimbalkar  !

Which issue(s) this PR fixes (optional)
PWX-32048
