### PR TITLE
PWX-32051: move default ccm port 9029 and create ccm cm before PX start

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -210,6 +210,10 @@ func (t *telemetry) reconcileCCMGo(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	// Attempt to create the phonehome configmap early for reference
+	if _, err := t.createCCMGoConfigMapTelemetryPhonehome(cluster, ownerRef); err != nil {
+		logrus.WithError(err).Warnf("failed to create cm %s from %s", ConfigMapNameTelemetryPhonehome, configFileNameTelemetryPhonehome)
+	}
 	if cluster.Status.ClusterUID == "" {
 		logrus.Warn("clusterUID is empty, wait for it to reconcile telemetry components")
 		return nil

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -106,10 +106,11 @@ const (
 	stagingArcusRegisterProxyURL    = "register.staging-cloud-support.purestorage.com"
 
 	// Ports for telemetry components
-	defaultCCMListeningPort = 9024
-	defaultCollectorPort    = 10000
-	defaultRegisterPort     = 12001
-	defaultPhonehomePort    = 12002
+	defaultCCMListeningPort          = 9024
+	defaultCCMListeningPortForPXge30 = 9029
+	defaultCollectorPort             = 10000
+	defaultRegisterPort              = 12001
+	defaultPhonehomePort             = 12002
 
 	arcusPingInterval = 6 * time.Second
 	arcusPingRetry    = 5
@@ -1180,9 +1181,16 @@ func readConfigMapDataFromFile(
 }
 
 func getCCMListeningPort(cluster *corev1.StorageCluster) int {
+	defCCMPort := defaultCCMListeningPort
+
+	pxVer30, _ := version.NewVersion("3.0")
+	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
+		defCCMPort = defaultCCMListeningPortForPXge30
+	}
+
 	startPort := pxutil.StartPort(cluster)
 	if startPort == pxutil.DefaultStartPort {
-		return defaultCCMListeningPort
+		return defCCMPort
 	}
 	return startPort + 20
 }

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1282,6 +1282,7 @@ func (t *template) getVolumeMounts() []v1.VolumeMount {
 		t.getPKSVolumeInfoList,
 		t.getBottleRocketVolumeInfoList,
 		t.GetVolumeInfoForTLSCerts,
+		t.getTelemetryPhoneHomeVolumeInfoList,
 	}
 	for _, fn := range extensions {
 		volumeInfoList = append(volumeInfoList, fn()...)
@@ -1343,6 +1344,7 @@ func (t *template) getVolumes() []v1.Volume {
 		t.getPKSVolumeInfoList,
 		t.getBottleRocketVolumeInfoList,
 		t.GetVolumeInfoForTLSCerts,
+		t.getTelemetryPhoneHomeVolumeInfoList,
 	}
 	for _, fn := range extensions {
 		volumeInfoList = append(volumeInfoList, fn()...)
@@ -1472,6 +1474,29 @@ func (t *template) getCSIVolumeInfoList() []volumeInfo {
 		},
 	)
 	return volumeInfoList
+}
+
+func (t *template) getTelemetryPhoneHomeVolumeInfoList() []volumeInfo {
+	if pxutil.IsTelemetryEnabled(t.cluster.Spec) {
+		return []volumeInfo{
+			{
+				name:      "ccm-phonehome-config",
+				mountPath: "/etc/ccm",
+				configMapType: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: component.ConfigMapNameTelemetryPhonehome,
+					},
+					Items: []v1.KeyToPath{
+						{
+							Key:  component.TelemetryPropertiesFilename,
+							Path: component.TelemetryPropertiesFilename,
+						},
+					},
+				},
+			},
+		}
+	}
+	return []volumeInfo{}
 }
 
 func (t *template) getTelemetryVolumeInfoList() []volumeInfo {

--- a/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
@@ -108,6 +108,8 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
+            - mountPath: /etc/ccm
+              name: ccm-phonehome-config
         - env:
             - name: configFile
               value: /etc/ccm/ccm.properties
@@ -213,3 +215,9 @@ spec:
                 path: location
             name: px-telemetry-config
           name: ccm-config
+        - configMap:
+            items:
+              - key: ccm.properties
+                path: ccm.properties
+            name: px-telemetry-phonehome
+          name: ccm-phonehome-config

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -108,6 +108,8 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
+            - mountPath: /etc/ccm
+              name: ccm-phonehome-config
         - env:
             - name: configFile
               value: /etc/ccm/ccm.properties
@@ -218,3 +220,9 @@ spec:
                 path: location
             name: px-telemetry-config
           name: ccm-config
+        - configMap:
+            items:
+              - key: ccm.properties
+                path: ccm.properties
+            name: px-telemetry-phonehome
+          name: ccm-phonehome-config

--- a/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
@@ -110,6 +110,8 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
+            - mountPath: /etc/ccm
+              name: ccm-phonehome-config
         - env:
             - name: configFile
               value: /etc/ccm/ccm.properties
@@ -229,3 +231,9 @@ spec:
                 path: http_proxy
             name: px-ccm-service-proxy-config
           name: ccm-proxy-config
+        - configMap:
+            items:
+              - key: ccm.properties
+                path: ccm.properties
+            name: px-telemetry-phonehome
+          name: ccm-phonehome-config


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Need to determine loguploader port using the ccm configmap.   Export the ccm properties config to oci-mon and have it copy the cm to /etc/pwx for use by pxctl.
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-32051
**Special notes for your reviewer**:

