### PR TITLE
PWX-31915: kvdb-api pod cleanup

### DIFF
--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"github.com/libopenstorage/cloudops"
 	"math"
 	"net"
 	"os"
@@ -17,6 +16,7 @@ import (
 
 	"github.com/google/shlex"
 	"github.com/hashicorp/go-version"
+	"github.com/libopenstorage/cloudops"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -252,7 +252,8 @@ func (c *Controller) syncKVDB(
 	for _, p := range podList.Items {
 		if p.Spec.NodeName == storageNode.Name {
 			// Let's delete the pod so that a new one will be created.
-			if strings.ToLower(p.Status.Reason) == "outofpods" || strings.ToLower(p.Status.Reason) == "evicted" {
+			reason := strings.ToLower(p.Status.Reason)
+			if reason == "outofpods" || reason == "evicted" || reason == "terminated" {
 				logrus.Warningf("Found pod with %s status, will delete it: %+v", p.Status.Reason, p)
 				err = coreops.Instance().DeletePod(p.Name, p.Namespace, false)
 				if err != nil {


### PR DESCRIPTION
* will remove the terminated kvdb-api pods

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

We got reports of 2 instances, where Kubernetes stopped recycling a dummy `kvdb-api` POD
* the `kvdb-api` POD is not really running KVDB, it's running a `pause` instead
   - we just use it to report the readyness-status of the `kvdb` service running inside Portworx
* this POD uses `restartPolicy: Always` and `terminationGracePeriodSeconds: 30` -- so it normally never terminates, nor will it reach the `Completed` or `Failed` state
   - instead, within 30 seconds it is normally garbage-collected and restarted by Kubernetes

ISSUE:
We got two reports from different environments, where `kvdb-api` POD has terminated, and was not restarted by Kubernetes -- it would just terminate, and transition into `Completed` state
* the environments reporting this were OCP 4.12, during upgrade finalization; also Rancher node after reboot, w/ nodes using [graceful-shutdown](https://kubernetes.io/blog/2021/04/21/graceful-node-shutdown-beta/) plugin

FIX:
* we were not able to reproduce this issue in our lab
* however, we have captured a detailed state of one of such `Completed` PODs from a customer's site, and we're using this state to _implement the explicit POD-cleanup_, as a part of the "KVDB reconcile" process

**Which issue(s) this PR fixes** (optional)
Closes # PWX-31915

**Special notes for your reviewer**:

