### PR TITLE
PWX-32096: Only execute pre-flight if running on EKS.

### DIFF
--- a/pkg/preflight/utils.go
+++ b/pkg/preflight/utils.go
@@ -11,7 +11,7 @@ func IsEKS() bool {
 
 // RequiresCheck returns whether a preflight check is needed based on the platform
 func RequiresCheck() bool {
-	return Instance().ProviderName() == string(cloudops.AWS)
+	return IsEKS()
 }
 
 // RunningOnCloud checks whether portworx is running on cloud


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
DMThin default only on EKS.  Add the check so pre-flight only runs on EKS.

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-32096
**Special notes for your reviewer**:

