### PR TITLE
PTX-18636 Temporary remove validation of cloudStorage spec

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -842,10 +842,12 @@ func nodeSpecsToMaps(nodes []corev1.NodeSpec) map[string]*corev1.CloudStorageNod
 }
 
 func validateDeployedSpec(expected, live *corev1.StorageCluster) error {
+	/* Will find a better way to do this in PTX-18637
 	// Validate cloudStorage
 	if !reflect.DeepEqual(expected.Spec.CloudStorage, live.Spec.CloudStorage) {
 		return fmt.Errorf("deployed CloudStorage spec doesn't match expected")
 	}
+	*/
 	// Validate kvdb
 	if !reflect.DeepEqual(expected.Spec.Kvdb, live.Spec.Kvdb) {
 		return fmt.Errorf("deployed Kvdb spec doesn't match expected")


### PR DESCRIPTION
Temporary remove validation of cloudStorage spec, doing DeepEquals() is not a good method to do this since operator changes cloudStorage spec due to various events and environments. Will find a better way in PTX-18637

