### PR TITLE
PWX-32051: move default ccm port 9029 and create ccm cm before PX sta…

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -106,10 +106,11 @@ const (
 	stagingArcusRegisterProxyURL    = "register.staging-cloud-support.purestorage.com"
 
 	// Ports for telemetry components
-	defaultCCMListeningPort = 9024
-	defaultCollectorPort    = 10000
-	defaultRegisterPort     = 12001
-	defaultPhonehomePort    = 12002
+	defaultCCMListeningPort          = 9024
+	defaultCCMListeningPortForPXge30 = 9029
+	defaultCollectorPort             = 10000
+	defaultRegisterPort              = 12001
+	defaultPhonehomePort             = 12002
 
 	arcusPingInterval = 6 * time.Second
 	arcusPingRetry    = 5
@@ -209,6 +210,12 @@ func (t *telemetry) reconcileCCMGo(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	// Reconcile config maps for log uploader
+	// Attempt to create the cm for phonehome early for reference
+	restart, err := t.createCCMGoConfigMapTelemetryPhonehome(cluster, ownerRef)
+	if err != nil {
+		logrus.WithError(err).Warnf("failed to create cm %s from %s", ConfigMapNameTelemetryPhonehome, configFileNameTelemetryPhonehome)
+	}
 	if cluster.Status.ClusterUID == "" {
 		logrus.Warn("clusterUID is empty, wait for it to reconcile telemetry components")
 		return nil
@@ -230,7 +237,7 @@ func (t *telemetry) reconcileCCMGo(
 		logrus.WithError(err).Errorf("failed to create cm %s from %s", ConfigMapNameTelemetryTLSCertificate, configFileNameTelemetryTLSCertificate)
 		return err
 	}
-	if err := t.reconcileCCMGoTelemetryPhonehome(cluster, ownerRef); err != nil {
+	if err := t.reconcileCCMGoTelemetryPhonehome(cluster, ownerRef, restart); err != nil {
 		return err
 	}
 	if err := t.reconcileCCMGoTelemetryCollectorV2(cluster, ownerRef); err != nil {
@@ -372,6 +379,7 @@ func (t *telemetry) deleteCCMGoRegistrationService(
 func (t *telemetry) reconcileCCMGoTelemetryPhonehome(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
+	restart bool,
 ) error {
 	// Delete unused old components from ccm java
 	if err := k8sutil.DeleteConfigMap(t.k8sClient, TelemetryConfigMapName, cluster.Namespace, *ownerRef); err != nil {
@@ -380,19 +388,12 @@ func (t *telemetry) reconcileCCMGoTelemetryPhonehome(
 	if err := k8sutil.DeleteConfigMap(t.k8sClient, TelemetryCCMProxyConfigMapName, cluster.Namespace, *ownerRef); err != nil {
 		return err
 	}
-	// Reconcile config maps for log uploader
-	// Create cm for phonehome
-	restart, err := t.createCCMGoConfigMapTelemetryPhonehome(cluster, ownerRef)
-	if err != nil {
-		logrus.WithError(err).Errorf("failed to create cm %s from %s", ConfigMapNameTelemetryPhonehome, configFileNameTelemetryPhonehome)
-		return err
-	}
-	// Creat cm for phonehome proxy
+	// Create cm for phonehome proxy
 	if err := t.createCCMGoConfigMapTelemetryPhonehomeProxy(cluster, ownerRef); err != nil {
 		logrus.WithError(err).Errorf("failed to create cm %s from %s", ConfigMapNameTelemetryPhonehomeProxy, configFileNameTelemetryPhonehomeProxy)
 		return err
 	}
-	// create daemonset for phonehome
+	// Create daemonset for phonehome
 	if err := t.createDaemonSetTelemetryPhonehome(cluster, ownerRef, restart); err != nil {
 		logrus.WithError(err).Errorf("failed to create daemonset %s/%s", cluster.Namespace, DaemonSetNameTelemetryPhonehome)
 		return err
@@ -1176,9 +1177,16 @@ func readConfigMapDataFromFile(
 }
 
 func getCCMListeningPort(cluster *corev1.StorageCluster) int {
+	defCCMPort := defaultCCMListeningPort
+
+	pxVer30, _ := version.NewVersion("3.0")
+	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
+		defCCMPort = defaultCCMListeningPortForPXge30
+	}
+
 	startPort := pxutil.StartPort(cluster)
 	if startPort == pxutil.DefaultStartPort {
-		return defaultCCMListeningPort
+		return defCCMPort
 	}
 	return startPort + 20
 }

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1193,6 +1193,7 @@ func (t *template) getVolumeMounts() []v1.VolumeMount {
 		t.getIKSVolumeInfoList,
 		t.getPKSVolumeInfoList,
 		t.getBottleRocketVolumeInfoList,
+		t.getTelemetryPhoneHomeVolumeInfoList,
 	}
 	for _, fn := range extensions {
 		volumeInfoList = append(volumeInfoList, fn()...)
@@ -1253,6 +1254,7 @@ func (t *template) getVolumes() []v1.Volume {
 		t.getIKSVolumeInfoList,
 		t.getPKSVolumeInfoList,
 		t.getBottleRocketVolumeInfoList,
+		t.getTelemetryPhoneHomeVolumeInfoList,
 	}
 	for _, fn := range extensions {
 		volumeInfoList = append(volumeInfoList, fn()...)
@@ -1368,6 +1370,29 @@ func (t *template) getCSIVolumeInfoList() []volumeInfo {
 		},
 	)
 	return volumeInfoList
+}
+
+func (t *template) getTelemetryPhoneHomeVolumeInfoList() []volumeInfo {
+	if pxutil.IsTelemetryEnabled(t.cluster.Spec) {
+		return []volumeInfo{
+			{
+				name:      "ccm-phonehome-config",
+				mountPath: "/etc/ccm",
+				configMapType: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: component.ConfigMapNameTelemetryPhonehome,
+					},
+					Items: []v1.KeyToPath{
+						{
+							Key:  component.TelemetryPropertiesFilename,
+							Path: component.TelemetryPropertiesFilename,
+						},
+					},
+				},
+			},
+		}
+	}
+	return []volumeInfo{}
 }
 
 func (t *template) getTelemetryVolumeInfoList() []volumeInfo {

--- a/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
@@ -108,6 +108,8 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
+            - mountPath: /etc/ccm
+              name: ccm-phonehome-config
         - env:
             - name: configFile
               value: /etc/ccm/ccm.properties
@@ -213,3 +215,9 @@ spec:
                 path: location
             name: px-telemetry-config
           name: ccm-config
+        - configMap:
+            items:
+              - key: ccm.properties
+                path: ccm.properties
+            name: px-telemetry-phonehome
+          name: ccm-phonehome-config

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -108,6 +108,8 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
+            - mountPath: /etc/ccm
+              name: ccm-phonehome-config
         - env:
             - name: configFile
               value: /etc/ccm/ccm.properties
@@ -218,3 +220,9 @@ spec:
                 path: location
             name: px-telemetry-config
           name: ccm-config
+        - configMap:
+            items:
+              - key: ccm.properties
+                path: ccm.properties
+            name: px-telemetry-phonehome
+          name: ccm-phonehome-config

--- a/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
@@ -110,6 +110,8 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
+            - mountPath: /etc/ccm
+              name: ccm-phonehome-config
         - env:
             - name: configFile
               value: /etc/ccm/ccm.properties
@@ -229,3 +231,9 @@ spec:
                 path: http_proxy
             name: px-ccm-service-proxy-config
           name: ccm-proxy-config
+        - configMap:
+            items:
+              - key: ccm.properties
+                path: ccm.properties
+            name: px-telemetry-phonehome
+          name: ccm-phonehome-config


### PR DESCRIPTION
…rt (#1105) (#1109)

* PWX-32051: If PX version is 3.0 or greater use 9029 for CCM uploader port.



* PWX-32051: Create configmap for px-telemetry-phonehome before PX oci-mon pod launches. So it can be mounted in oci-mon container for reference.



* PWX-32051: Only create/update the uploader cm in one place and preserve the 'restart' flag and pass it thrugh when reconciling uploader cm.  Fix UTs



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
This is an approved cherry-pick from 23.5.1 branch:  https://github.com/libopenstorage/operator/pull/1109
