### PR TITLE
PWX-32127: Only add telemetry phonehome volume if px is at least 3.0

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1282,7 +1282,11 @@ func (t *template) getVolumeMounts() []v1.VolumeMount {
 		t.getPKSVolumeInfoList,
 		t.getBottleRocketVolumeInfoList,
 		t.GetVolumeInfoForTLSCerts,
-		t.getTelemetryPhoneHomeVolumeInfoList,
+	}
+	// Only add telemetry phonehome volume mount if PX is at least 3.0
+	pxVer30, _ := version.NewVersion("3.0")
+	if t.pxVersion.GreaterThanOrEqual(pxVer30) {
+		extensions = append(extensions, t.getTelemetryPhoneHomeVolumeInfoList)
 	}
 	for _, fn := range extensions {
 		volumeInfoList = append(volumeInfoList, fn()...)
@@ -1344,7 +1348,11 @@ func (t *template) getVolumes() []v1.Volume {
 		t.getPKSVolumeInfoList,
 		t.getBottleRocketVolumeInfoList,
 		t.GetVolumeInfoForTLSCerts,
-		t.getTelemetryPhoneHomeVolumeInfoList,
+	}
+	// Only add telemetry phonehome volume if PX is at least 3.0
+	pxVer30, _ := version.NewVersion("3.0")
+	if t.pxVersion.GreaterThanOrEqual(pxVer30) {
+		extensions = append(extensions, t.getTelemetryPhoneHomeVolumeInfoList)
 	}
 	for _, fn := range extensions {
 		volumeInfoList = append(volumeInfoList, fn()...)

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2912,6 +2912,7 @@ func TestPodWithTelemetryCCMVolume(t *testing.T) {
 	require.NoError(t, err)
 
 	podSpec, err := driver.GetStoragePodSpec(cluster, nodeName)
+	require.NoError(t, err)
 
 	hasCCMVol := false
 	hasCCMVolMount := false
@@ -2937,6 +2938,7 @@ func TestPodWithTelemetryCCMVolume(t *testing.T) {
 	require.NoError(t, err)
 
 	podSpec, err = driver.GetStoragePodSpec(cluster, nodeName)
+	require.NoError(t, err)
 
 	for _, vol := range podSpec.Volumes {
 		if vol.Name == "ccm-phonehome-config" {

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2874,6 +2874,86 @@ func TestPodWithTelemetryUpgrade(t *testing.T) {
 	require.Equal(t, len(expected.Containers), len(actual.Containers))
 }
 
+func TestPodWithTelemetryCCMVolume(t *testing.T) {
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.18.4",
+	}
+	fakeExtClient := fakeextclient.NewSimpleClientset()
+	apiextensionsops.SetInstance(apiextensionsops.New(fakeExtClient))
+	k8sClient := testutil.FakeK8sClient()
+	nodeName := "testNode"
+
+	// Start with older version of portworx
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-system",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/oci-monitor:2.8.0",
+			Monitoring: &corev1.MonitoringSpec{
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: true,
+					Image:   "portworx/px-telemetry:2.1.2",
+				},
+			},
+			CSI: &corev1.CSISpec{
+				Enabled: false,
+			},
+		},
+	}
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
+	require.NoError(t, err)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	podSpec, err := driver.GetStoragePodSpec(cluster, nodeName)
+
+	hasCCMVol := false
+	hasCCMVolMount := false
+
+	for _, vol := range podSpec.Volumes {
+		if vol.Name == "ccm-phonehome-config" {
+			hasCCMVol = true
+		}
+	}
+	for _, ctn := range podSpec.Containers {
+		for _, volMnt := range ctn.VolumeMounts {
+			if volMnt.Name == "ccm-phonehome-config" {
+				hasCCMVolMount = true
+			}
+		}
+	}
+	// The pod spec should neither contain ccm volume nor volume mount
+	assert.False(t, hasCCMVol || hasCCMVolMount)
+
+	// Then upgrade the cluster to 3.0 and obtain the new pod spec
+	cluster.Spec.Image = "portworx/oci-monitor:3.0.0"
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	podSpec, err = driver.GetStoragePodSpec(cluster, nodeName)
+
+	for _, vol := range podSpec.Volumes {
+		if vol.Name == "ccm-phonehome-config" {
+			hasCCMVol = true
+		}
+	}
+	for _, ctn := range podSpec.Containers {
+		for _, volMnt := range ctn.VolumeMounts {
+			if volMnt.Name == "ccm-phonehome-config" {
+				hasCCMVolMount = true
+			}
+		}
+	}
+	// Now the pod spec should contain both ccm volume and volume mount
+	assert.True(t, hasCCMVol && hasCCMVolMount)
+}
+
 func TestPodSpecWhenRunningOnMasterEnabled(t *testing.T) {
 	k8sClient := testutil.FakeK8sClient()
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))

--- a/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
@@ -108,8 +108,6 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
-            - mountPath: /etc/ccm
-              name: ccm-phonehome-config
         - env:
             - name: configFile
               value: /etc/ccm/ccm.properties
@@ -215,9 +213,3 @@ spec:
                 path: location
             name: px-telemetry-config
           name: ccm-config
-        - configMap:
-            items:
-              - key: ccm.properties
-                path: ccm.properties
-            name: px-telemetry-phonehome
-          name: ccm-phonehome-config

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -108,8 +108,6 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
-            - mountPath: /etc/ccm
-              name: ccm-phonehome-config
         - env:
             - name: configFile
               value: /etc/ccm/ccm.properties
@@ -220,9 +218,3 @@ spec:
                 path: location
             name: px-telemetry-config
           name: ccm-config
-        - configMap:
-            items:
-              - key: ccm.properties
-                path: ccm.properties
-            name: px-telemetry-phonehome
-          name: ccm-phonehome-config

--- a/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
@@ -110,8 +110,6 @@ spec:
               readOnly: true
             - name: dbusmount
               mountPath: /var/run/dbus
-            - mountPath: /etc/ccm
-              name: ccm-phonehome-config
         - env:
             - name: configFile
               value: /etc/ccm/ccm.properties
@@ -231,9 +229,3 @@ spec:
                 path: http_proxy
             name: px-ccm-service-proxy-config
           name: ccm-proxy-config
-        - configMap:
-            items:
-              - key: ccm.properties
-                path: ccm.properties
-            name: px-telemetry-phonehome
-          name: ccm-phonehome-config


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Currently change to introduce telemetry phonehome volume should only be applied to cluster greater than or equal to 3.0, otherwise we'll have regression failure for cluster running with Java CCM when px-telemetry-phonehome configmap is not part of the cluster

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

