### PR TITLE
PWX-32131: Remove ccm-phonehome-config mount.  This is a mount which …

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1191,8 +1191,12 @@ func (t *template) getVolumeMounts() []v1.VolumeMount {
 		t.getBottleRocketVolumeInfoList,
 	}
 	// Only add telemetry phonehome volume mount if PX is at least 3.0
+	preFltCheck := ""
+	if t.cluster.Annotations != nil {
+		preFltCheck = strings.TrimSpace(strings.ToLower(t.cluster.Annotations[pxutil.AnnotationPreflightCheck]))
+	}
 	pxVer30, _ := version.NewVersion("3.0")
-	if t.pxVersion.GreaterThanOrEqual(pxVer30) {
+	if t.pxVersion.GreaterThanOrEqual(pxVer30) && preFltCheck != "true" {
 		extensions = append(extensions, t.getTelemetryPhoneHomeVolumeInfoList)
 	}
 	for _, fn := range extensions {
@@ -1256,10 +1260,15 @@ func (t *template) getVolumes() []v1.Volume {
 		t.getBottleRocketVolumeInfoList,
 	}
 	// Only add telemetry phonehome volume if PX is at least 3.0
+	preFltCheck := ""
+	if t.cluster.Annotations != nil {
+		preFltCheck = strings.TrimSpace(strings.ToLower(t.cluster.Annotations[pxutil.AnnotationPreflightCheck]))
+	}
 	pxVer30, _ := version.NewVersion("3.0")
-	if t.pxVersion.GreaterThanOrEqual(pxVer30) {
+	if t.pxVersion.GreaterThanOrEqual(pxVer30) && preFltCheck != "true" {
 		extensions = append(extensions, t.getTelemetryPhoneHomeVolumeInfoList)
 	}
+
 	for _, fn := range extensions {
 		volumeInfoList = append(volumeInfoList, fn()...)
 	}

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -208,6 +208,14 @@ func (u *preFlightPortworx) RunPreFlight() error {
 		logrus.Infof("runPreflight: running pre-flight with existing PX-StoreV2 param, hard fail check enabled")
 	}
 
+	// Remove phone-home cm volume mount, does not exist yet
+	for i, volumeMount := range preflightDS.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if volumeMount.Name == "ccm-phonehome-config" {
+			preflightDS.Spec.Template.Spec.Containers[0].VolumeMounts = append(preflightDS.Spec.Template.Spec.Containers[0].VolumeMounts[:i],
+				preflightDS.Spec.Template.Spec.Containers[0].VolumeMounts[i+1:]...)
+			break
+		}
+	}
 	// Add pre-flight param
 	preflightDS.Spec.Template.Spec.Containers[0].Args = append([]string{"--pre-flight"},
 		preflightDS.Spec.Template.Spec.Containers[0].Args...)

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -155,14 +155,6 @@ func (u *preFlightPortworx) CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerR
 		logrus.Infof("runPreflight: running pre-flight with existing PX-StoreV2 param, hard fail check enabled")
 	}
 
-	// Remove phone-home cm volume mount, does not exist yet
-	for i, volumeMount := range preflightDS.Spec.Template.Spec.Containers[0].VolumeMounts {
-		if volumeMount.Name == "ccm-phonehome-config" {
-			preflightDS.Spec.Template.Spec.Containers[0].VolumeMounts = append(preflightDS.Spec.Template.Spec.Containers[0].VolumeMounts[:i],
-				preflightDS.Spec.Template.Spec.Containers[0].VolumeMounts[i+1:]...)
-			break
-		}
-	}
 	// Add pre-flight param
 	preflightDS.Spec.Template.Spec.Containers[0].Args = append([]string{"--pre-flight"},
 		preflightDS.Spec.Template.Spec.Containers[0].Args...)

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -418,9 +418,7 @@ func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
 		return nil
 	}
 
-	// Only do the preflight check on demand once a time
 	toUpdate := cluster.DeepCopy()
-	toUpdate.Annotations[pxutil.AnnotationPreflightCheck] = "false"
 	var err error
 
 	// Do the preflight check for eks only for now to check the cloud drive permission
@@ -467,6 +465,9 @@ func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
 			logrus.WithError(serr).Errorf("Failed to get StorageNodes used for validate.")
 		}
 	}
+
+	// Only do the preflight check once
+	toUpdate.Annotations[pxutil.AnnotationPreflightCheck] = "false"
 
 	condition := &corev1.ClusterCondition{
 		Source: pxutil.PortworxComponentName,


### PR DESCRIPTION
…does not exists yet.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The addition of this mount to the spec for fixing PWX-31626.  Caused pre-flight to fail cause the mount location does not exist when pre-flight is run.   Remove it.  
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-32131
**Special notes for your reviewer**:
This looks like more of a change than it is.    I changed the "RunPreFlight" function by pulled out the code which creates the preflight daemonset and moved into a separate function called "CreatePreFlightDaemonsetSpec" and just call that from "RunPreFlight".   This allowed me to use the "CreatePreFlightDaemonsetSpec" in a UT.
