### PR TITLE
PWX-32131: Remove ccm-phonehome-config mount.  This is a mount which …

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1284,8 +1284,12 @@ func (t *template) getVolumeMounts() []v1.VolumeMount {
 		t.GetVolumeInfoForTLSCerts,
 	}
 	// Only add telemetry phonehome volume mount if PX is at least 3.0
+	preFltCheck := ""
+	if t.cluster.Annotations != nil {
+		preFltCheck = strings.TrimSpace(strings.ToLower(t.cluster.Annotations[pxutil.AnnotationPreflightCheck]))
+	}
 	pxVer30, _ := version.NewVersion("3.0")
-	if t.pxVersion.GreaterThanOrEqual(pxVer30) {
+	if t.pxVersion.GreaterThanOrEqual(pxVer30) && preFltCheck != "true" {
 		extensions = append(extensions, t.getTelemetryPhoneHomeVolumeInfoList)
 	}
 	for _, fn := range extensions {
@@ -1350,10 +1354,15 @@ func (t *template) getVolumes() []v1.Volume {
 		t.GetVolumeInfoForTLSCerts,
 	}
 	// Only add telemetry phonehome volume if PX is at least 3.0
+	preFltCheck := ""
+	if t.cluster.Annotations != nil {
+		preFltCheck = strings.TrimSpace(strings.ToLower(t.cluster.Annotations[pxutil.AnnotationPreflightCheck]))
+	}
 	pxVer30, _ := version.NewVersion("3.0")
-	if t.pxVersion.GreaterThanOrEqual(pxVer30) {
+	if t.pxVersion.GreaterThanOrEqual(pxVer30) && preFltCheck != "true" {
 		extensions = append(extensions, t.getTelemetryPhoneHomeVolumeInfoList)
 	}
+
 	for _, fn := range extensions {
 		volumeInfoList = append(volumeInfoList, fn()...)
 	}

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -163,6 +163,45 @@ func TestValidate(t *testing.T) {
 	require.Contains(t, <-recorder.Events,
 		fmt.Sprintf("%v %v %s", v1.EventTypeNormal, util.PassPreFlight, "Enabling PX-StoreV2"))
 	require.Contains(t, *cluster.Spec.CloudStorage.SystemMdDeviceSpec, DefCmetaData)
+
+	//
+	// Validate Pre-flight Daemonset Pod Spec
+	//
+	cluster.Spec.Image = "portworx/oci-image:3.0.0"
+	cluster.Annotations = map[string]string{
+		pxutil.AnnotationPreflightCheck: "true",
+	}
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	podSpec, err := driver.GetStoragePodSpec(cluster, "")
+	require.NoError(t, err)
+
+	// phone-home cm volume mount, should not exists since pre-flight is enabled
+	var errChk error
+	for _, volumeMount := range podSpec.Containers[0].VolumeMounts {
+		if volumeMount.Name == "ccm-phonehome-config" {
+			// Set err mount exists
+			errChk = fmt.Errorf("ccm-phonehome-config volume mount exists when it should not")
+		}
+	}
+	require.NoError(t, errChk)
+
+	preFlighter := NewPreFlighter(cluster, k8sClient, podSpec)
+	require.NotNil(t, preFlighter)
+
+	/// Create preflighter podSpec
+	preflightDSCheck := preFlighter.CreatePreFlightDaemonsetSpec(clusterRef)
+
+	// Make sure the phone-home cm volume mount, still does not exists
+	errChk = nil
+	for _, volumeMount := range preflightDSCheck.Spec.Template.Spec.Containers[0].VolumeMounts {
+		if volumeMount.Name == "ccm-phonehome-config" {
+			// Set err mount exists
+			errChk = fmt.Errorf("ccm-phonehome-config volume mount exists when it should not")
+		}
+	}
+	require.NoError(t, errChk)
 }
 
 func TestGetSelectorLabels(t *testing.T) {

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -176,16 +176,14 @@ func TestValidate(t *testing.T) {
 
 	podSpec, err := driver.GetStoragePodSpec(cluster, "")
 	require.NoError(t, err)
+	require.Equal(t, 2, len(podSpec.Containers))
 
 	// phone-home cm volume mount, should not exists since pre-flight is enabled
-	var errChk error
-	for _, volumeMount := range podSpec.Containers[0].VolumeMounts {
-		if volumeMount.Name == "ccm-phonehome-config" {
-			// Set err mount exists
-			errChk = fmt.Errorf("ccm-phonehome-config volume mount exists when it should not")
+	for _, cnt := range podSpec.Containers {
+		for _, volumeMount := range cnt.VolumeMounts {
+			require.True(t, volumeMount.Name != "ccm-phonehome-config")
 		}
 	}
-	require.NoError(t, errChk)
 
 	preFlighter := NewPreFlighter(cluster, k8sClient, podSpec)
 	require.NotNil(t, preFlighter)
@@ -194,14 +192,11 @@ func TestValidate(t *testing.T) {
 	preflightDSCheck := preFlighter.CreatePreFlightDaemonsetSpec(clusterRef)
 
 	// Make sure the phone-home cm volume mount, still does not exists
-	errChk = nil
-	for _, volumeMount := range preflightDSCheck.Spec.Template.Spec.Containers[0].VolumeMounts {
-		if volumeMount.Name == "ccm-phonehome-config" {
-			// Set err mount exists
-			errChk = fmt.Errorf("ccm-phonehome-config volume mount exists when it should not")
+	for _, cnt := range preflightDSCheck.Spec.Template.Spec.Containers {
+		for _, volumeMount := range cnt.VolumeMounts {
+			require.True(t, volumeMount.Name != "ccm-phonehome-config")
 		}
 	}
-	require.NoError(t, errChk)
 }
 
 func TestGetSelectorLabels(t *testing.T) {

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -47,6 +47,8 @@ type PreFlightPortworx interface {
 	ProcessPreFlightResults(recorder record.EventRecorder, storageNodes []*corev1.StorageNode) error
 	// DeletePreFlight deletes the pre-flight daemonset
 	DeletePreFlight() error
+	// CreatePreFlightDaemonsetSpec is used to create the pre-fligh daemonset pod spec
+	CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerReference) *appsv1.DaemonSet
 }
 
 type preFlightPortworx struct {
@@ -90,62 +92,7 @@ func getPreFlightPodsFromNamespace(k8sClient client.Client, namespace string) (*
 	return ds, pods, err
 }
 
-// GetPreFlightPods returns the pods of the pre-flight daemonset
-func (u *preFlightPortworx) GetPreFlightPods() ([]*v1.Pod, error) {
-	_, pods, err := getPreFlightPodsFromNamespace(u.k8sClient, u.cluster.Namespace)
-	return pods, err
-}
-
-func (u *preFlightPortworx) GetPreFlightStatus() (int32, int32, int32, error) {
-	ds, pods, err := getPreFlightPodsFromNamespace(u.k8sClient, u.cluster.Namespace)
-	if err != nil {
-		return -1, -1, -1, err
-	}
-	totalPods := ds.Status.DesiredNumberScheduled
-	completedPods := 0
-	for _, pod := range pods {
-		if len(pod.Status.ContainerStatuses) > 0 {
-			for _, containerStatus := range pod.Status.ContainerStatuses {
-				if containerStatus.Name == "portworx" && containerStatus.Ready {
-					completedPods++
-				}
-			}
-		}
-	}
-	logrus.Infof("Pre-flight Status: Completed [%v] InProgress [%v] Total Pods [%v]", completedPods, totalPods-int32(completedPods), totalPods)
-	return int32(completedPods), totalPods - int32(completedPods), totalPods, nil
-}
-
-func (u *preFlightPortworx) RunPreFlight() error {
-	ownerRef := metav1.NewControllerRef(u.cluster, pxutil.StorageClusterKind())
-
-	err := u.createServiceAccount(ownerRef)
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			logrus.Infof("runPreFlight: ServiceAccount already exists, skipping...")
-		} else {
-			return err
-		}
-	}
-
-	err = u.createClusterRole()
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			logrus.Infof("runPreFlight: ClusterRole already exists, skipping...")
-		} else {
-			return err
-		}
-	}
-
-	err = u.createClusterRoleBinding()
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			logrus.Infof("runPreFlight: ClusterRoleBinding already exists, skipping...")
-		} else {
-			return err
-		}
-	}
-
+func (u *preFlightPortworx) CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerReference) *appsv1.DaemonSet {
 	// Create daemonset from podSpec
 	labels := map[string]string{
 		"name": pxPreFlightDaemonSetName,
@@ -240,6 +187,67 @@ func (u *preFlightPortworx) RunPreFlight() error {
 			}
 		}
 	}
+
+	return preflightDS
+}
+
+// GetPreFlightPods returns the pods of the pre-flight daemonset
+func (u *preFlightPortworx) GetPreFlightPods() ([]*v1.Pod, error) {
+	_, pods, err := getPreFlightPodsFromNamespace(u.k8sClient, u.cluster.Namespace)
+	return pods, err
+}
+
+func (u *preFlightPortworx) GetPreFlightStatus() (int32, int32, int32, error) {
+	ds, pods, err := getPreFlightPodsFromNamespace(u.k8sClient, u.cluster.Namespace)
+	if err != nil {
+		return -1, -1, -1, err
+	}
+	totalPods := ds.Status.DesiredNumberScheduled
+	completedPods := 0
+	for _, pod := range pods {
+		if len(pod.Status.ContainerStatuses) > 0 {
+			for _, containerStatus := range pod.Status.ContainerStatuses {
+				if containerStatus.Name == "portworx" && containerStatus.Ready {
+					completedPods++
+				}
+			}
+		}
+	}
+	logrus.Infof("Pre-flight Status: Completed [%v] InProgress [%v] Total Pods [%v]", completedPods, totalPods-int32(completedPods), totalPods)
+	return int32(completedPods), totalPods - int32(completedPods), totalPods, nil
+}
+
+func (u *preFlightPortworx) RunPreFlight() error {
+	ownerRef := metav1.NewControllerRef(u.cluster, pxutil.StorageClusterKind())
+
+	err := u.createServiceAccount(ownerRef)
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			logrus.Infof("runPreFlight: ServiceAccount already exists, skipping...")
+		} else {
+			return err
+		}
+	}
+
+	err = u.createClusterRole()
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			logrus.Infof("runPreFlight: ClusterRole already exists, skipping...")
+		} else {
+			return err
+		}
+	}
+
+	err = u.createClusterRoleBinding()
+	if err != nil {
+		if errors.IsAlreadyExists(err) {
+			logrus.Infof("runPreFlight: ClusterRoleBinding already exists, skipping...")
+		} else {
+			return err
+		}
+	}
+
+	preflightDS := u.CreatePreFlightDaemonsetSpec(ownerRef)
 
 	err = u.k8sClient.Create(context.TODO(), preflightDS)
 	if err != nil {

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -427,9 +427,7 @@ func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
 		return nil
 	}
 
-	// Only do the preflight check on demand once a time
 	toUpdate := cluster.DeepCopy()
-	toUpdate.Annotations[pxutil.AnnotationPreflightCheck] = "false"
 	var err error
 
 	// Do the preflight check for eks only for now to check the cloud drive permission
@@ -476,6 +474,9 @@ func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
 			logrus.WithError(serr).Errorf("Failed to get StorageNodes used for validate.")
 		}
 	}
+
+	// Only do the preflight check once
+	toUpdate.Annotations[pxutil.AnnotationPreflightCheck] = "false"
 
 	condition := &corev1.ClusterCondition{
 		Source: pxutil.PortworxComponentName,


### PR DESCRIPTION
…… (#1112)

* PWX-32131: Remove ccm-phonehome-config mount.  This is a mount which does not exists yet.



* WX-32131: Add to TestValidate routine to make sure that the phonehome cm is removed from pre-flight pod spec.  Expose routine to get the pre-flight podSpec and inspect it in the UT.



* WX-32131: missing file from previous commit.



* PWX-32131: Use pre-flight annotation setting to skip adding phonehome volume.



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
This is cherry-pick from the release branch
