### PR TITLE
PWX-32147 : add custom image registry support for plugin pod

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -3885,6 +3885,12 @@ spec:
                   pause:
                     type: string
                     description: Desired image for pause image.
+                  dynamicPlugin:
+                    type: string
+                    description: Desired image for dynamic plugin image.
+                  nginxinc:
+                    type: string
+                    description: Desired image for nginx-unprivileged image.
               conditions:
                 type: array
                 description: Contains details for the current condition of this cluster.

--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -3888,9 +3888,9 @@ spec:
                   dynamicPlugin:
                     type: string
                     description: Desired image for dynamic plugin image.
-                  nginxinc:
+                  dynamicPluginProxy:
                     type: string
-                    description: Desired image for nginx-unprivileged image.
+                    description: Desired image for nginx proxy image.
               conditions:
                 type: array
                 description: Contains details for the current condition of this cluster.

--- a/deploy/plugin/nginx-deployment.yaml
+++ b/deploy/plugin/nginx-deployment.yaml
@@ -21,7 +21,6 @@ spec:
             secretName: px-plugin-proxy
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged:1.23
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/plugin/plugin-deployment.yaml
+++ b/deploy/plugin/plugin-deployment.yaml
@@ -25,7 +25,6 @@ spec:
     spec:
       containers:
         - name: px-plugin
-          image: portworx/portworx-dynamic-plugin:1.0.0
           ports:
             - containerPort: 9443
               protocol: TCP

--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -3,6 +3,7 @@ package component
 import (
 	"context"
 	commonerrors "errors"
+	"github.com/libopenstorage/operator/drivers/storage/portworx/manifest"
 	"strings"
 
 	version "github.com/hashicorp/go-version"
@@ -362,7 +363,7 @@ func isVersionSupported(v string) bool {
 }
 
 func getDesiredPluginImage(cluster *corev1.StorageCluster) string {
-	var imageName string
+	imageName := manifest.DefaultDynamicPluginImage
 	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.DynamicPlugin != "" {
 		imageName = cluster.Status.DesiredImages.DynamicPlugin
 	}
@@ -371,7 +372,7 @@ func getDesiredPluginImage(cluster *corev1.StorageCluster) string {
 }
 
 func getDesiredPluginProxyImage(cluster *corev1.StorageCluster) string {
-	var imageName string
+	imageName := manifest.DefaultDynamicPluginProxyImage
 
 	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.DynamicPluginProxy != "" {
 		imageName = cluster.Status.DesiredImages.DynamicPluginProxy

--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -362,8 +362,7 @@ func isVersionSupported(v string) bool {
 }
 
 func getDesiredPluginImage(cluster *corev1.StorageCluster) string {
-	imageName := "portworx/portworx-dynamic-plugin:1.0.0"
-
+	var imageName string
 	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.DynamicPlugin != "" {
 		imageName = cluster.Status.DesiredImages.DynamicPlugin
 	}
@@ -372,7 +371,7 @@ func getDesiredPluginImage(cluster *corev1.StorageCluster) string {
 }
 
 func getDesiredPluginProxyImage(cluster *corev1.StorageCluster) string {
-	imageName := "nginxinc/nginx-unprivileged:1.23"
+	var imageName string
 
 	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.DynamicPluginProxy != "" {
 		imageName = cluster.Status.DesiredImages.DynamicPluginProxy

--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -231,7 +231,7 @@ func (p *plugin) createDeployment(filename, deploymentName string, ownerRef *met
 		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPluginImage(cluster)
 	}
 	if deployment.Name == NginxDeploymentName {
-		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredNginxcImage(cluster)
+		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPlugijnProxyImage(cluster)
 	}
 
 	existingDeployment := &appsv1.Deployment{}
@@ -371,11 +371,11 @@ func getDesiredPluginImage(cluster *corev1.StorageCluster) string {
 	return imageName
 }
 
-func getDesiredNginxcImage(cluster *corev1.StorageCluster) string {
+func getDesiredPlugijnProxyImage(cluster *corev1.StorageCluster) string {
 	imageName := "nginxinc/nginx-unprivileged:1.23"
 
-	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.Nginxc != "" {
-		imageName = cluster.Status.DesiredImages.Nginxc
+	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.DynamicPluginProxy != "" {
+		imageName = cluster.Status.DesiredImages.DynamicPluginProxy
 	}
 	imageName = util.GetImageURN(cluster, imageName)
 	return imageName

--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -231,7 +231,7 @@ func (p *plugin) createDeployment(filename, deploymentName string, ownerRef *met
 		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPluginImage(cluster)
 	}
 	if deployment.Name == NginxDeploymentName {
-		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPlugijnProxyImage(cluster)
+		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPluginProxyImage(cluster)
 	}
 
 	existingDeployment := &appsv1.Deployment{}
@@ -371,7 +371,7 @@ func getDesiredPluginImage(cluster *corev1.StorageCluster) string {
 	return imageName
 }
 
-func getDesiredPlugijnProxyImage(cluster *corev1.StorageCluster) string {
+func getDesiredPluginProxyImage(cluster *corev1.StorageCluster) string {
 	imageName := "nginxinc/nginx-unprivileged:1.23"
 
 	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.DynamicPluginProxy != "" {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -15027,6 +15027,9 @@ func TestPluginInstallAndUninstall(t *testing.T) {
 		},
 	}
 
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -15027,9 +15027,6 @@ func TestPluginInstallAndUninstall(t *testing.T) {
 		},
 	}
 
-	err = driver.SetDefaultsOnStorageCluster(cluster)
-	require.NoError(t, err)
-
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
 

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -50,8 +50,8 @@ const (
 	defaultNewAlertManagerImage             = "quay.io/prometheus/alertmanager:v0.24.0"
 
 	// default dynamic plugin images
-	defaultDynamicPluginImage      = "portworx/portworx-dynamic-plugin:1.0.0"
-	defaultDynamicPluginProxyImage = "nginxinc/nginx-unprivileged:1.23"
+	DefaultDynamicPluginImage      = "portworx/portworx-dynamic-plugin:1.0.0"
+	DefaultDynamicPluginProxyImage = "nginxinc/nginx-unprivileged:1.23"
 
 	defaultManifestRefreshInterval = 3 * time.Hour
 )
@@ -222,8 +222,8 @@ func defaultRelease(
 			Autopilot:          defaultAutopilotImage,
 			Lighthouse:         defaultLighthouseImage,
 			NodeWiper:          defaultNodeWiperImage,
-			DynamicPlugin:      defaultDynamicPluginImage,
-			DynamicPluginProxy: defaultDynamicPluginProxyImage,
+			DynamicPlugin:      DefaultDynamicPluginImage,
+			DynamicPluginProxy: DefaultDynamicPluginProxyImage,
 		},
 	}
 	fillCSIDefaults(rel, k8sVersion)
@@ -249,11 +249,11 @@ func fillDefaults(
 		rel.Components.NodeWiper = defaultNodeWiperImage
 	}
 	if rel.Components.DynamicPlugin == "" {
-		rel.Components.DynamicPlugin = defaultDynamicPluginImage
+		rel.Components.DynamicPlugin = DefaultDynamicPluginImage
 	}
 
 	if rel.Components.DynamicPluginProxy == "" {
-		rel.Components.DynamicPluginProxy = defaultDynamicPluginProxyImage
+		rel.Components.DynamicPluginProxy = DefaultDynamicPluginProxyImage
 	}
 
 	fillCSIDefaults(rel, k8sVersion)

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -49,6 +49,10 @@ const (
 	defaultNewPrometheusConfigReloaderImage = "quay.io/prometheus-operator/prometheus-config-reloader:v0.56.3"
 	defaultNewAlertManagerImage             = "quay.io/prometheus/alertmanager:v0.24.0"
 
+	// default dynamic plugin images
+	defaultDynamicPluginImage      = "portworx/portworx-dynamic-plugin:1.0.0"
+	defaultDynamicPluginProxyImage = "nginxinc/nginx-unprivileged:1.23"
+
 	defaultManifestRefreshInterval = 3 * time.Hour
 )
 
@@ -86,7 +90,7 @@ type Release struct {
 	KubeControllerManager      string `yaml:"kubeControllerManager,omitempty"`
 	Pause                      string `yaml:"pause,omitempty"`
 	DynamicPlugin              string `yaml:"dynamicPlugin,omitempty"`
-	Nginxc                     string `yaml:"nginxc,omitempty"`
+	DynamicPluginProxy         string `yaml:"dynamicPluginProxy,omitempty"`
 }
 
 // Version is the response structure from a versions source
@@ -242,6 +246,14 @@ func fillDefaults(
 	if rel.Components.NodeWiper == "" {
 		rel.Components.NodeWiper = defaultNodeWiperImage
 	}
+	if rel.Components.DynamicPlugin == "" {
+		rel.Components.DynamicPlugin = defaultDynamicPluginImage
+	}
+
+	if rel.Components.DynamicPluginProxy == "" {
+		rel.Components.DynamicPluginProxy = defaultDynamicPluginProxyImage
+	}
+
 	fillCSIDefaults(rel, k8sVersion)
 	fillPrometheusDefaults(rel, k8sVersion)
 	fillTelemetryDefaults(rel)

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -218,10 +218,12 @@ func defaultRelease(
 	rel := &Version{
 		PortworxVersion: DefaultPortworxVersion,
 		Components: Release{
-			Stork:      defaultStorkImage,
-			Autopilot:  defaultAutopilotImage,
-			Lighthouse: defaultLighthouseImage,
-			NodeWiper:  defaultNodeWiperImage,
+			Stork:              defaultStorkImage,
+			Autopilot:          defaultAutopilotImage,
+			Lighthouse:         defaultLighthouseImage,
+			NodeWiper:          defaultNodeWiperImage,
+			DynamicPlugin:      defaultDynamicPluginImage,
+			DynamicPluginProxy: defaultDynamicPluginProxyImage,
 		},
 	}
 	fillCSIDefaults(rel, k8sVersion)

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -85,6 +85,8 @@ type Release struct {
 	KubeScheduler              string `yaml:"kubeScheduler,omitempty"`
 	KubeControllerManager      string `yaml:"kubeControllerManager,omitempty"`
 	Pause                      string `yaml:"pause,omitempty"`
+	DynamicPlugin              string `yaml:"dynamicPlugin,omitempty"`
+	Nginxc                     string `yaml:"nginxc,omitempty"`
 }
 
 // Version is the response structure from a versions source

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -39,6 +39,8 @@ func TestManifestWithNewerPortworxVersion(t *testing.T) {
 			Telemetry:                 "image/ccm-service:3.2.11",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -76,6 +78,8 @@ func TestManifestWithNewerPortworxVersionAndConfigMapPresent(t *testing.T) {
 			Telemetry:                 "image/ccm-service:2.6.0",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.0",
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}
 
@@ -165,6 +169,8 @@ func TestManifestWithOlderPortworxVersion(t *testing.T) {
 			Telemetry:                 "image/ccm-service:3.2.11",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -254,6 +260,8 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			TelemetryProxy:            "purestorage/telemetry-envoy:1.0.0",
 			LogUploader:               "purestorage/log-upload:1.0.0",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -333,6 +341,8 @@ func TestManifestWithoutPortworxVersion(t *testing.T) {
 			Telemetry:                 "image/ccm-service:3.2.11",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}
 	cluster := &corev1.StorageCluster{

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -375,8 +375,8 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			toUpdate.Status.DesiredImages.DynamicPlugin = release.Components.DynamicPlugin
 		}
 
-		if toUpdate.Status.DesiredImages.Nginxc == "" || pxVersionChanged {
-			toUpdate.Status.DesiredImages.Nginxc = release.Components.Nginxc
+		if toUpdate.Status.DesiredImages.DynamicPluginProxy == "" || pxVersionChanged {
+			toUpdate.Status.DesiredImages.DynamicPluginProxy = release.Components.DynamicPluginProxy
 		}
 
 		// set misc image defaults

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -371,6 +371,14 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			}
 		}
 
+		if toUpdate.Status.DesiredImages.DynamicPlugin == "" || pxVersionChanged {
+			toUpdate.Status.DesiredImages.DynamicPlugin = release.Components.DynamicPlugin
+		}
+
+		if toUpdate.Status.DesiredImages.Nginxc == "" || pxVersionChanged {
+			toUpdate.Status.DesiredImages.Nginxc = release.Components.Nginxc
+		}
+
 		// set misc image defaults
 		imagesData := []struct {
 			desiredImage *string

--- a/drivers/storage/portworx/testspec/nginx-deployment.yaml
+++ b/drivers/storage/portworx/testspec/nginx-deployment.yaml
@@ -21,7 +21,7 @@ spec:
             secretName: px-plugin-proxy
       containers:
         - name: nginx
-          image: nginxinc/nginx-unprivileged:1.23
+          image: docker.io/nginxinc/nginx-unprivileged:1.23
           ports:
             - name: http
               containerPort: 8080

--- a/drivers/storage/portworx/testspec/plugin-deployment.yaml
+++ b/drivers/storage/portworx/testspec/plugin-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: px-plugin
-          image: portworx/portworx-dynamic-plugin:1.0.0
+          image: docker.io/portworx/portworx-dynamic-plugin:1.0.0
           ports:
             - containerPort: 9443
               protocol: TCP

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -610,6 +610,8 @@ type ComponentImages struct {
 	KubeScheduler              string `json:"kubeScheduler,omitempty"`
 	KubeControllerManager      string `json:"kubeControllerManager,omitempty"`
 	Pause                      string `json:"pause,omitempty"`
+	DynamicPlugin              string `json:"dynamicPlugin,omitempty"`
+	Nginxc                     string `json:"nginxc,omitempty"`
 }
 
 // Storage represents cluster storage details

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -611,7 +611,7 @@ type ComponentImages struct {
 	KubeControllerManager      string `json:"kubeControllerManager,omitempty"`
 	Pause                      string `json:"pause,omitempty"`
 	DynamicPlugin              string `json:"dynamicPlugin,omitempty"`
-	DynamicPluginProxy         string `json:"DynamicPluginProxy,omitempty"`
+	DynamicPluginProxy         string `json:"dynamicPluginProxy,omitempty"`
 }
 
 // Storage represents cluster storage details

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -611,7 +611,7 @@ type ComponentImages struct {
 	KubeControllerManager      string `json:"kubeControllerManager,omitempty"`
 	Pause                      string `json:"pause,omitempty"`
 	DynamicPlugin              string `json:"dynamicPlugin,omitempty"`
-	Nginxc                     string `json:"nginxc,omitempty"`
+	DynamicPluginProxy         string `json:"DynamicPluginProxy,omitempty"`
 }
 
 // Storage represents cluster storage details

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -1272,6 +1272,8 @@ func (h *Handler) handleCustomImageRegistry(cluster *corev1.StorageCluster) erro
 		KubeScheduler:              h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.KubeScheduler),
 		KubeControllerManager:      h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.KubeControllerManager),
 		Pause:                      h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.Pause),
+		DynamicPlugin:              h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.DynamicPlugin),
+		Nginxc:                     h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.Nginxc),
 	}
 	cluster.Status.Version = pxutil.GetImageTag(cluster.Spec.Image)
 	return nil
@@ -1329,6 +1331,8 @@ func (h *Handler) createManifestConfigMap(cluster *corev1.StorageCluster) error 
 			KubeScheduler:              cluster.Status.DesiredImages.KubeScheduler,
 			KubeControllerManager:      cluster.Status.DesiredImages.KubeControllerManager,
 			Pause:                      cluster.Status.DesiredImages.Pause,
+			DynamicPlugin:              cluster.Status.DesiredImages.DynamicPlugin,
+			Nginxc:                     cluster.Status.DesiredImages.Nginxc,
 		},
 	}
 

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -1273,7 +1273,7 @@ func (h *Handler) handleCustomImageRegistry(cluster *corev1.StorageCluster) erro
 		KubeControllerManager:      h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.KubeControllerManager),
 		Pause:                      h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.Pause),
 		DynamicPlugin:              h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.DynamicPlugin),
-		Nginxc:                     h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.Nginxc),
+		DynamicPluginProxy:         h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.DynamicPluginProxy),
 	}
 	cluster.Status.Version = pxutil.GetImageTag(cluster.Spec.Image)
 	return nil
@@ -1332,7 +1332,7 @@ func (h *Handler) createManifestConfigMap(cluster *corev1.StorageCluster) error 
 			KubeControllerManager:      cluster.Status.DesiredImages.KubeControllerManager,
 			Pause:                      cluster.Status.DesiredImages.Pause,
 			DynamicPlugin:              cluster.Status.DesiredImages.DynamicPlugin,
-			Nginxc:                     cluster.Status.DesiredImages.Nginxc,
+			DynamicPluginProxy:         cluster.Status.DesiredImages.DynamicPluginProxy,
 		},
 	}
 


### PR DESCRIPTION
Added custom Image Registery for px-plugin and px-plugin-proxy pod : 
1. Added DynamicPlugin and Nginxc image in manifest and Desired images
2. Changed deployment creation to use desired image at time of creation

Tests done : 
Tested on air-gapped cluster with CIR "docker.pwx.dev.purestorage.com" , both px-plugin and px-plugin-proxy pods were up and running fine

<img width="1146" alt="image" src="https://github.com/libopenstorage/operator/assets/107468860/f5569093-abcf-40e5-b967-2c08535e965f">



Events:
  Type     Reason          Age    From               Message
  ----     ------          ----   ----               -------
  Normal   Scheduled       7m21s  default-scheduler  Successfully assigned kube-system/px-plugin-proxy-d5c6f65d7-vkfqr to airgap-ocp-w8pqc-worker-2bl5l by airgap-ocp-w8pqc-master-0
  Warning  FailedMount     7m21s  kubelet            MountVolume.SetUp failed for volume "nginx-certs" : secret "px-plugin-proxy" not found
  Normal   AddedInterface  7m19s  multus             Add eth0 [10.129.2.23/23] from openshift-sdn
  Normal   Pulling         7m19s  kubelet            Pulling image "docker.pwx.dev.purestorage.com/nginxinc/nginx-unprivileged:1.23"
  Normal   Pulled          7m15s  kubelet            Successfully pulled image "docker.pwx.dev.purestorage.com/nginxinc/nginx-unprivileged:1.23" in 3.518983541s
  Normal   Created         7m15s  kubelet            Created container nginx
  Normal   Started         7m15s  kubelet            Started container nginx



Events:
  Type    Reason          Age    From               Message
  ----    ------          ----   ----               -------
  Normal  Scheduled       7m42s  default-scheduler  Successfully assigned kube-system/px-plugin-76bcf74b46-9jxks to airgap-ocp-w8pqc-worker-q9ljd by airgap-ocp-w8pqc-master-0
  Normal  AddedInterface  7m40s  multus             Add eth0 [10.130.2.74/23] from openshift-sdn
  Normal  Pulling         7m40s  kubelet            Pulling image "docker.pwx.dev.purestorage.com/portworx/portworx-dynamic-plugin:1.0.0"
  Normal  Pulled          7m37s  kubelet            Successfully pulled image "docker.pwx.dev.purestorage.com/portworx/portworx-dynamic-plugin:1.0.0" in 2.68198716s
  Normal  Created         7m37s  kubelet            Created container px-plugin
  Normal  Started         7m37s  kubelet            Started container px-plugin