### PR TITLE
PWX-31968: Pass in port to be used for readiness endpoint when runnin…

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -768,7 +768,7 @@ func (t *telemetry) createCCMGoConfigMapTelemetryPhonehome(
 ) (bool, error) {
 	cloudSupportPort, _, _ := getCCMCloudSupportPorts(cluster, defaultPhonehomePort)
 	config, err := readConfigMapDataFromFile(configFileNameTelemetryPhonehome, map[string]string{
-		configParameterPortworxPort:         fmt.Sprint(getCCMListeningPort(cluster)),
+		configParameterPortworxPort:         fmt.Sprint(GetCCMListeningPort(cluster)),
 		configParameterRestCloudSupportPort: fmt.Sprint(cloudSupportPort),
 	})
 	if err != nil {
@@ -866,8 +866,8 @@ func (t *telemetry) createDaemonSetTelemetryPhonehome(
 			for j := 0; j < len(container.Ports); j++ {
 				port := &container.Ports[j]
 				if port.Name == portNameLogUploaderContainer {
-					port.HostPort = int32(getCCMListeningPort(cluster))
-					port.ContainerPort = int32(getCCMListeningPort(cluster))
+					port.HostPort = int32(GetCCMListeningPort(cluster))
+					port.ContainerPort = int32(GetCCMListeningPort(cluster))
 				}
 			}
 		} else if container.Name == containerNameTelemetryProxy {
@@ -1176,7 +1176,7 @@ func readConfigMapDataFromFile(
 	return data, nil
 }
 
-func getCCMListeningPort(cluster *corev1.StorageCluster) int {
+func GetCCMListeningPort(cluster *corev1.StorageCluster) int {
 	defCCMPort := defaultCCMListeningPort
 
 	pxVer30, _ := version.NewVersion("3.0")

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -187,7 +187,9 @@ func TestValidate(t *testing.T) {
 	require.NotNil(t, preFlighter)
 
 	/// Create preflighter podSpec
-	preflightDSCheck := preFlighter.CreatePreFlightDaemonsetSpec(clusterRef)
+	preflightDSCheck, err := preFlighter.CreatePreFlightDaemonsetSpec(clusterRef)
+	require.NoError(t, err)
+	require.NotNil(t, preflightDSCheck)
 
 	// Make sure the phone-home cm volume mount, still does not exists
 	errChk = nil

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/go-version"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -13,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -48,7 +50,7 @@ type PreFlightPortworx interface {
 	// DeletePreFlight deletes the pre-flight daemonset
 	DeletePreFlight() error
 	// CreatePreFlightDaemonsetSpec is used to create the pre-fligh daemonset pod spec
-	CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerReference) *appsv1.DaemonSet
+	CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerReference) (*appsv1.DaemonSet, error)
 }
 
 type preFlightPortworx struct {
@@ -92,7 +94,7 @@ func getPreFlightPodsFromNamespace(k8sClient client.Client, namespace string) (*
 	return ds, pods, err
 }
 
-func (u *preFlightPortworx) CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerReference) *appsv1.DaemonSet {
+func (u *preFlightPortworx) CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerReference) (*appsv1.DaemonSet, error) {
 	// Create daemonset from podSpec
 	labels := map[string]string{
 		"name": pxPreFlightDaemonSetName,
@@ -134,6 +136,40 @@ func (u *preFlightPortworx) CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerR
 	   	u.cluster.Annotations[pxutil.AnnotationMiscArgs] = strings.TrimSpace(miscArgs)
 	*/
 
+	// Object preflightDS.Spec.Template.Spec is created above using 'u.podSpec' however
+	// check to make sure the necessary spec objects exist.
+	if len(u.podSpec.Containers) <= 0 {
+		return nil, fmt.Errorf("podSpec.Containers object not created")
+	}
+
+	if u.podSpec.Containers[0].Name != "portworx" {
+		return nil, fmt.Errorf("podSpec.Containers object not created correctly, 'portworx' container not first")
+	}
+
+	// Add pre-flight param
+	preflightDS.Spec.Template.Spec.Containers[0].Args = append([]string{"--pre-flight"},
+		preflightDS.Spec.Template.Spec.Containers[0].Args...)
+
+	pxVer31, _ := version.NewVersion("3.1")
+	if pxutil.GetPortworxVersion(u.cluster).GreaterThanOrEqual(pxVer31) {
+		// Requires OCI-Mon changes so only supported in 3.1
+		if preflightDS.Spec.Template.Spec.Containers[0].ReadinessProbe == nil {
+			return nil, fmt.Errorf("readinessProbe object not created")
+		}
+
+		if preflightDS.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet == nil {
+			return nil, fmt.Errorf("probeHandler.HTTPGet object not created")
+		}
+
+		preFltEndPtPort := component.GetCCMListeningPort(u.cluster) + 1 // preflight endpoint port  +1 CCM uploader port
+		logrus.Infof("runPreflight: Setting port: %d", preFltEndPtPort)
+		preflightDS.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Port = intstr.FromInt(preFltEndPtPort)
+		// Add pre-flight param w/--pre-flight-port
+		preflightDS.Spec.Template.Spec.Containers[0].Args = append(
+			[]string{"--pre-flight-port", fmt.Sprintf("%d", preFltEndPtPort)},
+			preflightDS.Spec.Template.Spec.Containers[0].Args...)
+	}
+
 	checkArgs := func(args []string) {
 		for i, arg := range args {
 			if arg == "-T" {
@@ -154,10 +190,6 @@ func (u *preFlightPortworx) CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerR
 	} else {
 		logrus.Infof("runPreflight: running pre-flight with existing PX-StoreV2 param, hard fail check enabled")
 	}
-
-	// Add pre-flight param
-	preflightDS.Spec.Template.Spec.Containers[0].Args = append([]string{"--pre-flight"},
-		preflightDS.Spec.Template.Spec.Containers[0].Args...)
 
 	if u.cluster.Spec.ImagePullSecret != nil && *u.cluster.Spec.ImagePullSecret != "" {
 		preflightDS.Spec.Template.Spec.ImagePullSecrets = append(
@@ -188,7 +220,7 @@ func (u *preFlightPortworx) CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerR
 		}
 	}
 
-	return preflightDS
+	return preflightDS, nil
 }
 
 // GetPreFlightPods returns the pods of the pre-flight daemonset
@@ -247,11 +279,14 @@ func (u *preFlightPortworx) RunPreFlight() error {
 		}
 	}
 
-	preflightDS := u.CreatePreFlightDaemonsetSpec(ownerRef)
+	preflightDS, specErr := u.CreatePreFlightDaemonsetSpec(ownerRef)
+	if specErr != nil {
+		logrus.Errorf("runPreFlight: failed to create preflight daemonset spec: %v", specErr)
+	}
 
 	err = u.k8sClient.Create(context.TODO(), preflightDS)
 	if err != nil {
-		logrus.Errorf("RunPreFlight: error creating: %v", err)
+		logrus.Errorf("runPreFlight: error creating: %v", err)
 	}
 
 	return err

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -632,7 +632,8 @@ func (c *Controller) syncStorageCluster(
 	}
 
 	pxVer30, _ := version.NewVersion("3.0")
-	if pxutil.IsFreshInstall(cluster) && pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) { // Preflight should only run on PX version 3.0.0 and above
+	// Preflight should only run freshInstall and if the PX version is 3.0.0 and above
+	if pxutil.IsFreshInstall(cluster) && pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
 		// If preflight failed, or previous check failed, reconcile would stop here until issues got resolved
 		if err := c.runPreflightCheck(cluster); err != nil {
 			if updateErr := c.updateStorageClusterState(cluster, corev1.ClusterStateDegraded); updateErr != nil {


### PR DESCRIPTION
…… (#1114)

* PWX-31968: Pass in port to be used for readiness endpoint when running the pre-flight pod.  The port will be used to determine when pre-flight pod is up and running.  Will not conflict with standard oci endpoint ports



* PWX-31968: Add validity checks to the code before accessing objects.  Also '--pre-flight-port' will only work with upgrade Oci/PX so add version check.



* PWX-32131: Fix compile issues after merging in latest from master



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Cherry-pick from master.
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31968
**Special notes for your reviewer**:

