### PR TITLE
PWX-31971 verify pre-flight results (#1089)

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -90,13 +90,6 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
-	storageNode := &corev1.StorageNode{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "node-1",
-			Namespace: cluster.Namespace,
-		},
-	}
-
 	labels := map[string]string{
 		"name": pxPreFlightDaemonSetName,
 	}
@@ -117,7 +110,26 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
-	k8sClient := testutil.FakeK8sClient(preflightDS)
+	checks := []corev1.CheckResult{
+		{
+			Type:    "status",
+			Reason:  "oci-mon: pre-flight completed",
+			Success: true,
+		},
+	}
+
+	status := corev1.NodeStatus{
+		Checks: checks,
+	}
+
+	storageNode := &corev1.StorageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "node-1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Status: status,
+	}
 
 	preFlightPod1 := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -134,6 +146,9 @@ func TestValidate(t *testing.T) {
 			},
 		},
 	}
+
+	k8sClient := testutil.FakeK8sClient(preflightDS)
+
 	err := k8sClient.Create(context.TODO(), preFlightPod1)
 	require.NoError(t, err)
 
@@ -200,6 +215,198 @@ func TestValidate(t *testing.T) {
 		}
 	}
 	require.NoError(t, errChk)
+}
+
+func TestValidateCheckFailure(t *testing.T) {
+	driver := portworx{}
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+	}
+
+	labels := map[string]string{
+		"name": pxPreFlightDaemonSetName,
+	}
+
+	clusterRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	preflightDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pxPreFlightDaemonSetName,
+			Namespace:       cluster.Namespace,
+			Labels:          labels,
+			UID:             types.UID("preflight-ds-uid"),
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
+
+	checks := []corev1.CheckResult{
+		{
+			Type:    "usage",
+			Reason:  "px-runc: PX-StoreV2 unsupported storage disk spec: 'consume unused' (-A/-a) options not valid with PX-StoreV2",
+			Success: false,
+		},
+		{
+			Type:    "status",
+			Reason:  "oci-mon: pre-flight completed",
+			Success: true,
+		},
+	}
+
+	status := corev1.NodeStatus{
+		Checks: checks,
+	}
+
+	storageNode := &corev1.StorageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "node-1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Status: status,
+	}
+
+	preFlightPod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "preflight-1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{UID: preflightDS.UID}},
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "portworx",
+					Ready: true,
+				},
+			},
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(preflightDS)
+
+	err := k8sClient.Create(context.TODO(), preFlightPod1)
+	require.NoError(t, err)
+
+	preflightDS.Status.DesiredNumberScheduled = int32(1)
+	err = k8sClient.Status().Update(context.TODO(), preflightDS)
+	require.NoError(t, err)
+
+	recorder := record.NewFakeRecorder(100)
+	err = driver.Init(k8sClient, runtime.NewScheme(), recorder)
+	require.NoError(t, err)
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	err = k8sClient.Create(context.TODO(), storageNode)
+	require.NoError(t, err)
+
+	err = driver.Validate(cluster)
+	require.NoError(t, err)
+	require.NotEmpty(t, recorder.Events)
+	require.Len(t, recorder.Events, 3)
+	<-recorder.Events // Pop first event which is Default telemetry enabled event
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedPreFlight, "usage pre-flight check failed"))
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v %s", v1.EventTypeNormal, util.PassPreFlight, "Not enabling PX-StoreV2"))
+}
+
+func TestValidateMissingRequiredCheck(t *testing.T) {
+	driver := portworx{}
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+	}
+
+	labels := map[string]string{
+		"name": pxPreFlightDaemonSetName,
+	}
+
+	clusterRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	preflightDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pxPreFlightDaemonSetName,
+			Namespace:       cluster.Namespace,
+			Labels:          labels,
+			UID:             types.UID("preflight-ds-uid"),
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
+
+	checks := []corev1.CheckResult{
+		{},
+	}
+
+	status := corev1.NodeStatus{
+		Checks: checks,
+	}
+
+	storageNode := &corev1.StorageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "node-1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Status: status,
+	}
+
+	preFlightPod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "preflight-1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{UID: preflightDS.UID}},
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "portworx",
+					Ready: true,
+				},
+			},
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(preflightDS)
+
+	err := k8sClient.Create(context.TODO(), preFlightPod1)
+	require.NoError(t, err)
+
+	preflightDS.Status.DesiredNumberScheduled = int32(1)
+	err = k8sClient.Status().Update(context.TODO(), preflightDS)
+	require.NoError(t, err)
+
+	recorder := record.NewFakeRecorder(100)
+	err = driver.Init(k8sClient, runtime.NewScheme(), recorder)
+	require.NoError(t, err)
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	err = k8sClient.Create(context.TODO(), storageNode)
+	require.NoError(t, err)
+
+	err = driver.Validate(cluster)
+	require.NoError(t, err)
+	require.NotEmpty(t, recorder.Events)
+	for i := 0; i < len(recorder.Events); i++ { // Get last record
+		<-recorder.Events
+	}
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v %s", v1.EventTypeNormal, util.PassPreFlight, "Not enabling PX-StoreV2"))
 }
 
 func TestGetSelectorLabels(t *testing.T) {

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -292,58 +292,93 @@ func (u *preFlightPortworx) RunPreFlight() error {
 	return err
 }
 
-func (u *preFlightPortworx) ProcessPreFlightResults(recorder record.EventRecorder, storageNodes []*corev1.StorageNode) error {
-	logrus.Infof("pre-flight: process pre-flight results...")
+func (u *preFlightPortworx) processNodesChecks(recorder record.EventRecorder, storageNodes []*corev1.StorageNode) bool {
+
+	if len(storageNodes) == 0 {
+		logrus.Errorf("pre-flight: storageNodes list empty, unable to process pre-flight results")
+		return false
+	}
 
 	passed := true
 	for _, node := range storageNodes {
+		// Process storageNode checks list for failures. Also make sure the "status" check entry
+		// exists, this indicates all the checks were submitted from the pre-flight pod.
 		logrus.Infof("storageNode[%s]: %#v ", node.Name, node.Status.Checks)
-		if len(node.Status.Checks) > 1 {
-			for _, check := range node.Status.Checks {
-				if check.Type != "status" {
-					msg := fmt.Sprintf("%s pre-flight check ", check.Type)
-					if check.Success {
-						msg = msg + "passed: " + check.Reason
-						k8sutil.InfoEvent(recorder, u.cluster, util.PassPreFlight, msg)
-					} else {
-						msg = msg + "failed: " + check.Reason
-						k8sutil.WarningEvent(recorder, u.cluster, util.FailedPreFlight, msg)
-					}
-				}
+		if len(node.Status.Checks) == 0 {
+			logrus.Errorf("storageNodes checks list empty, pre-flight results not returned")
+			passed = false
+			continue
+		}
+
+		statusExists := false
+		for _, check := range node.Status.Checks {
+			if check.Type == "status" {
+				statusExists = true
+				continue
 			}
+
+			msg := fmt.Sprintf("%s pre-flight check ", check.Type)
+			if check.Success {
+				msg = msg + "passed: " + check.Reason
+				k8sutil.InfoEvent(recorder, u.cluster, util.PassPreFlight, msg)
+				continue
+			}
+			msg = msg + "failed: " + check.Reason
+			k8sutil.WarningEvent(recorder, u.cluster, util.FailedPreFlight, msg)
+			passed = false // pre-flight status check failed, keep going for logging
+		}
+
+		if !statusExists {
+			logrus.Errorf("storageNodes checks list status entry not found, pre-flight did not complete")
 			passed = false
 		}
 	}
 
-	if passed {
-		if !u.hardFail { // Enable DMthin via misc args if not enabled already
-			u.cluster.Annotations[pxutil.AnnotationMiscArgs] = strings.TrimSpace(u.cluster.Annotations[pxutil.AnnotationMiscArgs] + " -T px-storev2")
-			// Remove depricate '-T dmthin'
-			u.cluster.Annotations[pxutil.AnnotationMiscArgs] = strings.ReplaceAll(u.cluster.Annotations[pxutil.AnnotationMiscArgs], "-T dmthin", "")
-			k8sutil.InfoEvent(recorder, u.cluster, util.PassPreFlight, "Enabling PX-StoreV2")
-		} else {
-			k8sutil.InfoEvent(recorder, u.cluster, util.PassPreFlight, "PX-StoreV2 currently enabled")
-		}
+	return passed
+}
 
-		// Add 64G metadata drive.
-		if u.cluster.Spec.CloudStorage == nil {
-			u.cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
-		}
-
-		if u.cluster.Spec.CloudStorage.SystemMdDeviceSpec == nil {
-			cmetaData := DefCmetaData
-			u.cluster.Spec.CloudStorage.SystemMdDeviceSpec = &cmetaData
-		}
+func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
+	if !u.hardFail { // Enable DMthin via misc args if not enabled already
+		u.cluster.Annotations[pxutil.AnnotationMiscArgs] = strings.TrimSpace(u.cluster.Annotations[pxutil.AnnotationMiscArgs] + " -T px-storev2")
+		// Remove depricate '-T dmthin'
+		u.cluster.Annotations[pxutil.AnnotationMiscArgs] = strings.ReplaceAll(u.cluster.Annotations[pxutil.AnnotationMiscArgs], "-T dmthin", "")
+		k8sutil.InfoEvent(recorder, u.cluster, util.PassPreFlight, "Enabling PX-StoreV2")
 	} else {
-		if !u.hardFail { // Enable DMthin via misc args if not enabled already
-			k8sutil.InfoEvent(recorder, u.cluster, util.PassPreFlight, "Not enabling PX-StoreV2")
-		} else { // hardFail is enabled, fail if any pre-flight check fails.
-			err := fmt.Errorf("PX-StoreV2 pre-check failed")
-			k8sutil.WarningEvent(recorder, u.cluster, util.FailedPreFlight, err.Error())
-			return err
-		}
+		k8sutil.InfoEvent(recorder, u.cluster, util.PassPreFlight, "PX-StoreV2 currently enabled")
 	}
 
+	// Add 64G metadata drive.
+	if u.cluster.Spec.CloudStorage == nil {
+		u.cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+	}
+
+	if u.cluster.Spec.CloudStorage.SystemMdDeviceSpec == nil {
+		cmetaData := DefCmetaData
+		u.cluster.Spec.CloudStorage.SystemMdDeviceSpec = &cmetaData
+	}
+}
+
+func (u *preFlightPortworx) processFailedChecks(recorder record.EventRecorder) error {
+	if !u.hardFail { // Enable DMthin via misc args if not enabled already
+		k8sutil.InfoEvent(recorder, u.cluster, util.PassPreFlight, "Not enabling PX-StoreV2")
+		return nil
+	}
+
+	// hardFail is enabled, fail if any pre-flight check fails.
+	err := fmt.Errorf("PX-StoreV2 pre-check failed")
+	k8sutil.WarningEvent(recorder, u.cluster, util.FailedPreFlight, err.Error())
+	return err
+}
+
+func (u *preFlightPortworx) ProcessPreFlightResults(recorder record.EventRecorder, storageNodes []*corev1.StorageNode) error {
+	logrus.Infof("pre-flight: process pre-flight results...")
+
+	passed := u.processNodesChecks(recorder, storageNodes)
+	if !passed {
+		return u.processFailedChecks(recorder)
+	}
+
+	u.processPassedChecks(recorder)
 	return nil
 }
 


### PR DESCRIPTION
* PWX-31971: Make sure pre-flight results are the product of a valid pre-flight run.  Add operator version to env.



* PWX-31971: Revert change made for testing



* PWX-31971: Remove code which adds operator version env variable. Add more pre-flight check results unit tests



* PWX-31971: gofmt fix.



* PWX-31672: Recognize vSphere provider (#1088)

* PWX-31969: Use lowercase chars in -T param. (#1097)



* PWX-32048: Fixes annotation not being properly added for FACD topology installs (#1101)

* PWX-32073: Update csi-provisioner operation timeout from 10s to 5m (#1099)



* PTX-18636 Temporary remove validation of cloudStorage spec (#1108)



* PWX-32051: move default ccm port 9029 and create ccm cm before PX start (#1105)

* PWX-32051: If PX version is 3.0 or greater use 9029 for CCM uploader port.



* PWX-32051: Create configmap for px-telemetry-phonehome before PX oci-mon pod launches. So it can be mounted in oci-mon container for reference.



* PWX-32051: Only create/update the uploader cm in one place and preserve the 'restart' flag and pass it thrugh when reconciling uploader cm.  Fix UTs



---------



* PWX-32127: Only add telemetry phonehome volume if px is at least 3.0 (#1111)

* Only add telemetry phonehome volume if px is at least 3.0

* PWX-31915: kvdb-api pod cleanup (#1106)

* will remove the terminated kvdb-api pods



* Operator default images should not include csi-health-monitor-controller (#1096)

* Operator default images should not include csi-health-monitor-controller

* fix lint failure

* fix failing test

* fix review comments

* PWX-32131: Remove ccm-phonehome-config mount.  This is a mount which … (#1115)

* PWX-32131: Remove ccm-phonehome-config mount.  This is a mount which … (#1112)

* PWX-32131: Remove ccm-phonehome-config mount.  This is a mount which does not exists yet.



* WX-32131: Add to TestValidate routine to make sure that the phonehome cm is removed from pre-flight pod spec.  Expose routine to get the pre-flight podSpec and inspect it in the UT.



* WX-32131: missing file from previous commit.



* PWX-32131: Use pre-flight annotation setting to skip adding phonehome volume.



---------



* PWX-32131: PR review changes.



---------



* added missing http filters config for envoy running with proxy (#1118)

* PWX-31971: Refactor the code based on PR review to improve maintainability and readability.



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Cherry-pick changes from master.  
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31971
**Special notes for your reviewer**:

