### PR TITLE
Operator default images should not include csi-health-monitor-controller

### DIFF
--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
@@ -90,26 +90,6 @@ spec:
             - --leader-election=true
           securityContext:
             privileged: true
-        - name: csi-health-monitor-controller
-          image: quay.io/k8scsi/csi-health-monitor-controller:v1.2.3
-          imagePullPolicy: Always
-          args:
-            - "--v=3"
-            - "--csi-address=$(ADDRESS)"
-            - "--leader-election"
-            - "--http-endpoint=:8080"
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /csi
-          ports:
-            - name: http-endpoint
-              containerPort: 8080
-              protocol: TCP
-          securityContext:
-            privileged: true
       schedulerName: stork
       volumes:
         - name: socket-dir

--- a/drivers/storage/portworx/util/csi_generator.go
+++ b/drivers/storage/portworx/util/csi_generator.go
@@ -203,8 +203,11 @@ func (g *CSIGenerator) GetCSIConfiguration() *CSIConfiguration {
 	}
 
 	// IncludeExternalHealthMonitor only with PX 2.10.0+ and k8s 1.21+
+	// Disabling the csi-health-monitor-controller
+	// csi-health-monitor-controller container should never start by default
+	// TODO : add this back with condition on when to start csi-health-monitor-controller container
 	if g.kubeVersion.GreaterThanOrEqual(k8sVer1_21) && g.pxVersion.GreaterThanOrEqual(pxVer2_10) {
-		cv.IncludeHealthMonitorController = true
+		cv.IncludeHealthMonitorController = false
 	}
 
 	return cv


### PR DESCRIPTION
Cherry-pick https://github.com/libopenstorage/operator/pull/1096 to 23.7.0

https://portworx.atlassian.net/browse/PWX-31944
In an airgapped environment, we were including the csi-health-monitor-controller.
We should never start this container by default.

Disabling the csi-health-monitor-controller until further notice.