### PR TITLE
PWX-32197: added missing http filters config for envoy running with proxy

### DIFF
--- a/deploy/ccm/envoy-config-collector-custom-proxy.yaml
+++ b/deploy/ccm/envoy-config-collector-custom-proxy.yaml
@@ -25,6 +25,8 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           http_filters:
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           route_config:
             name: local_route
             virtual_hosts:

--- a/deploy/ccm/envoy-config-register-custom-proxy.yaml
+++ b/deploy/ccm/envoy-config-register-custom-proxy.yaml
@@ -25,6 +25,8 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           http_filters:
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           route_config:
             name: local_route
             virtual_hosts:

--- a/deploy/ccm/envoy-config-rest-custom-proxy.yaml
+++ b/deploy/ccm/envoy-config-rest-custom-proxy.yaml
@@ -25,6 +25,8 @@ static_resources:
               "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           http_filters:
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           route_config:
             name: local_route
             virtual_hosts:

--- a/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap_proxy.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap_proxy.yaml
@@ -37,6 +37,8 @@ data:
                   "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               http_filters:
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               route_config:
                 name: local_route
                 virtual_hosts:

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeProxyConfigMap_proxy.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeProxyConfigMap_proxy.yaml
@@ -37,6 +37,8 @@ data:
                   "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               http_filters:
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               route_config:
                 name: local_route
                 virtual_hosts:

--- a/drivers/storage/portworx/testspec/ccmGoRegisterProxyConfigMap_proxy.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterProxyConfigMap_proxy.yaml
@@ -37,6 +37,8 @@ data:
                   "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
               http_filters:
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
               route_config:
                 name: local_route
                 virtual_hosts:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
cherry-picked from approved master [PR](https://github.com/libopenstorage/operator/pull/1118)

Those missing sections have been put in the config for envoy running without proxy but overlooked for the proxied environment. So adding them as fix for current issue

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

