### PR TITLE
PWX-32399: fix PX privileged SCC

### DIFF
--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -195,7 +195,7 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 			AllowHostNetwork:         true,
 			AllowHostPID:             false,
 			AllowHostPorts:           false,
-			AllowPrivilegeEscalation: boolPtr(false),
+			AllowPrivilegeEscalation: boolPtr(true),
 			AllowPrivilegedContainer: true,
 			AllowedUnsafeSysctls:     []string{"*"},
 			AllowedCapabilities: []corev1.Capability{

--- a/drivers/storage/portworx/testspec/portworxSCC.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC.yaml
@@ -3,7 +3,7 @@ allowHostIPC: false
 allowHostNetwork: true
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: false
+allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities:
 - '*'


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

OpenShift does not tolerate both `allowPrivilegedContainer: true` and `allowPrivilegeEscalation: false` SCC setting
* if attempted, the POD startup will be blocked with the following warning:
```
...
Events:
  Type     Reason        Age                      From                       Message
  ----     ------        ----                     ----                       -------
  Warning  FailedCreate  5m29s (x746 over 3h29m)  storagecluster-controller  (combined from similar events): \
Error creating: Pod "test-stc-xrfkb" is invalid: spec.containers[0].securityContext: Invalid value: ...: \
cannot set `allowPrivilegeEscalation` to false and `privileged` to true
```

FIX:
* since we need these containers to run as `privileged`, we will also need to enable `allowPrivilegeEscalation`

**Which issue(s) this PR fixes** (optional)
Closes # PWX-32399

**Special notes for your reviewer**:

