### PR TITLE
PWX-29716, PWX-32103: Implements PortworxDiag NodeSelector, adds unit tests

### DIFF
--- a/pkg/controller/portworxdiag/controller_test.go
+++ b/pkg/controller/portworxdiag/controller_test.go
@@ -2,16 +2,18 @@ package portworxdiag
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
-	portworxv1 "github.com/libopenstorage/operator/pkg/apis/portworx/v1"
+	diagv1 "github.com/libopenstorage/operator/pkg/apis/portworx/v1"
 	"github.com/libopenstorage/operator/pkg/mock"
 	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	fakeextclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +24,7 @@ import (
 	fakek8sclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	k8scontroller "k8s.io/kubernetes/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -72,7 +75,7 @@ func TestRegisterCRD(t *testing.T) {
 	fakeExtClient := fakeextclient.NewSimpleClientset()
 	coreops.SetInstance(coreops.New(fakeClient))
 	apiextensionsops.SetInstance(apiextensionsops.New(fakeExtClient))
-	group := portworxv1.SchemeGroupVersion.Group
+	group := diagv1.SchemeGroupVersion.Group
 	portworxDiagCRDName := "portworxdiags" + "." + group
 
 	// When the CRDs are created, just updated their status so the validation
@@ -110,9 +113,9 @@ func TestRegisterCRD(t *testing.T) {
 		Get(context.TODO(), portworxDiagCRDName, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.Equal(t, portworxDiagCRDName, pdCRD.Name)
-	require.Equal(t, portworxv1.SchemeGroupVersion.Group, pdCRD.Spec.Group)
+	require.Equal(t, diagv1.SchemeGroupVersion.Group, pdCRD.Spec.Group)
 	require.Len(t, pdCRD.Spec.Versions, 1)
-	require.Equal(t, portworxv1.SchemeGroupVersion.Version, pdCRD.Spec.Versions[0].Name)
+	require.Equal(t, diagv1.SchemeGroupVersion.Version, pdCRD.Spec.Versions[0].Name)
 	require.True(t, pdCRD.Spec.Versions[0].Served)
 	require.True(t, pdCRD.Spec.Versions[0].Storage)
 	subresource := &apiextensionsv1.CustomResourceSubresources{
@@ -123,8 +126,8 @@ func TestRegisterCRD(t *testing.T) {
 	require.Equal(t, apiextensionsv1.NamespaceScoped, pdCRD.Spec.Scope)
 	require.Equal(t, "portworxdiag", pdCRD.Spec.Names.Singular)
 	require.Equal(t, "portworxdiags", pdCRD.Spec.Names.Plural)
-	require.Equal(t, reflect.TypeOf(portworxv1.PortworxDiag{}).Name(), pdCRD.Spec.Names.Kind)
-	require.Equal(t, reflect.TypeOf(portworxv1.PortworxDiagList{}).Name(), pdCRD.Spec.Names.ListKind)
+	require.Equal(t, reflect.TypeOf(diagv1.PortworxDiag{}).Name(), pdCRD.Spec.Names.Kind)
+	require.Equal(t, reflect.TypeOf(diagv1.PortworxDiagList{}).Name(), pdCRD.Spec.Names.ListKind)
 	require.Equal(t, []string{"pxdiag"}, pdCRD.Spec.Names.ShortNames)
 
 	// If CRDs are already present, then should update it
@@ -202,4 +205,530 @@ func keepCRDActivated(fakeClient *fakeextclient.Clientset, crdName string) error
 		}
 		return false, nil
 	})
+}
+
+func TestShouldPodBeOnNode(t *testing.T) {
+	// Diag is nil: should return false
+	should := shouldPodBeOnNode("some-uuid", "node1", []v1.Node{}, nil)
+	require.False(t, should)
+
+	// Diag.Spec.Portworx is nil: should return false
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: nil,
+		},
+	})
+	require.False(t, should)
+
+	// NodeSelector.All is true: should return true
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					All: true,
+				},
+			},
+		},
+	})
+	require.True(t, should)
+
+	// NodeSelector.All is false, NodeSelector.IDs is nil and NodeSelector.Labels is nil: should return true
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					IDs:    nil,
+					Labels: nil,
+				},
+			},
+		},
+	})
+	require.False(t, should)
+
+	// NodeSelector.All is false, NodeSelector.IDs is empty and NodeSelector.Labels is empty: should return false
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					IDs:    []string{},
+					Labels: map[string]string{},
+				},
+			},
+		},
+	})
+	require.False(t, should)
+
+	// NodeSelector.IDs contains the given node ID: should return true
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					IDs: []string{"some-uuid"},
+				},
+			},
+		},
+	})
+	require.True(t, should)
+
+	// NodeSelector.IDs contains some node IDs but not the given node ID: should return false
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					IDs: []string{"another-uuid"},
+				},
+			},
+		},
+	})
+	require.False(t, should)
+
+	// NodeSelector.Labels is populated, no matching node: should return false
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node2",
+			},
+		},
+	}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	})
+	require.False(t, should)
+
+	// NodeSelector.Labels is populated, label missing: should return false
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+				Labels: map[string]string{
+					"baz": "nah",
+				},
+			},
+		},
+	}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	})
+	require.False(t, should)
+
+	// NodeSelector.Labels is populated, label present but wrong value: should return false
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+				Labels: map[string]string{
+					"foo": "nah",
+				},
+			},
+		},
+	}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	})
+	require.False(t, should)
+
+	// NodeSelector.Labels is populated, label present and correct value: should return true
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
+	}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	})
+	require.True(t, should)
+
+	// NodeSelector.Labels is populated, one label present, one not: should return false
+	should = shouldPodBeOnNode("some-uuid", "node1", []v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+				Labels: map[string]string{
+					"foo": "bar",
+					"baz": "nah",
+				},
+			},
+		},
+	}, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					Labels: map[string]string{
+						"foo": "bar",
+						"baz": "bar",
+					},
+				},
+			},
+		},
+	})
+	require.False(t, should)
+
+	// NodeSelector.IDs and Labels is populated, disjoint set: should return true for both nodes
+	nodes := []v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node2",
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+		},
+	}
+	// Both node1 and node2 should be valid
+	// node1 because it has the correct ID
+	// node2 because it has the correct label
+	should = shouldPodBeOnNode("some-uuid", "node1", nodes, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					IDs: []string{"some-uuid"},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	})
+	require.True(t, should)
+	should = shouldPodBeOnNode("some-uuid", "node2", nodes, &diagv1.PortworxDiag{
+		Spec: diagv1.PortworxDiagSpec{
+			Portworx: &diagv1.PortworxComponent{
+				NodeSelector: diagv1.NodeSelector{
+					IDs: []string{"some-uuid"},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	})
+	require.True(t, should)
+}
+
+func TestGetNodeToPodMap(t *testing.T) {
+	res := getNodeToPodMap(nil)
+	require.Empty(t, res)
+
+	res = getNodeToPodMap(&v1.PodList{})
+	require.Empty(t, res)
+
+	pod1 := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod1",
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node1",
+		},
+	}
+	pod2 := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod2",
+		},
+		Spec: v1.PodSpec{
+			NodeName: "node2",
+		},
+	}
+
+	res = getNodeToPodMap(&v1.PodList{
+		Items: []v1.Pod{pod1, pod2},
+	})
+	require.Len(t, res, 2)
+	require.Contains(t, res, "node1")
+	require.Contains(t, res, "node2")
+	require.Equal(t, *res["node1"], pod1)
+	require.Equal(t, *res["node2"], pod2)
+}
+
+func TestGetNodeIDToStatusMap(t *testing.T) {
+	// Test cases:
+	// * a nil node list should return an empty map
+	// * an empty node list should return an empty map
+	// * a node list with two nodes should return a map with two entries
+	// * a node list with different statuses should return a map with two entries with the correct statuses
+	// * a node list with a node with an empty node ID should not include the node in the map
+
+	res := getNodeIDToStatusMap(nil)
+	require.Empty(t, res)
+
+	res = getNodeIDToStatusMap([]diagv1.NodeStatus{})
+	require.Empty(t, res)
+
+	res = getNodeIDToStatusMap([]diagv1.NodeStatus{
+		{
+			NodeID: "node1",
+			Status: diagv1.NodeStatusInProgress,
+		},
+	})
+	require.Len(t, res, 1)
+	require.Contains(t, res, "node1")
+	require.Equal(t, res["node1"], diagv1.NodeStatusInProgress)
+
+	res = getNodeIDToStatusMap([]diagv1.NodeStatus{
+		{
+			NodeID: "node1",
+			Status: diagv1.NodeStatusInProgress,
+		},
+		{
+			NodeID: "node2",
+			Status: diagv1.NodeStatusCompleted,
+		},
+	})
+	require.Len(t, res, 2)
+	require.Contains(t, res, "node1")
+	require.Contains(t, res, "node2")
+	require.Equal(t, res["node1"], diagv1.NodeStatusInProgress)
+	require.Equal(t, res["node2"], diagv1.NodeStatusCompleted)
+
+	res = getNodeIDToStatusMap([]diagv1.NodeStatus{
+		{
+			NodeID: "",
+			Status: diagv1.NodeStatusInProgress,
+		},
+	})
+	require.Empty(t, res)
+}
+
+func TestGetPodsDiff(t *testing.T) {
+	// Node 0 will be missing a status entirely (should add a status and create a pod)
+	// Node 1 will have a status but be missing a pod (should create a pod)
+	// Node 2 will be completed successfully (should delete a pod)
+	// Node 3 will be completed and failed (should delete a pod)
+	// Node 4 will be in progress (should not change anything)
+	// Node 5 will not match the selector (should delete the existing pod)
+	// Node 6 will not match the selector (should not create a new pod)
+
+	// Test object setup
+	n := 7
+	pods := make([]v1.Pod, n)
+	nodes := make([]v1.Node, n)
+	nodeIDToName := make(map[string]string)
+	for i := 0; i < n; i++ {
+		pods[i] = v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("pod%d", i)},
+			Spec:       v1.PodSpec{NodeName: fmt.Sprintf("node%d", i)},
+		}
+		nodes[i] = v1.Node{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node%d", i)}}
+		nodeIDToName[fmt.Sprintf("id%d", i)] = fmt.Sprintf("node%d", i)
+	}
+
+	prs, err := getPodsDiff(
+		&v1.PodList{Items: pods[2:6]}, // Only pass in a subset of the nodes to simulate some not existing
+		&v1.NodeList{Items: nodes},
+		&diagv1.PortworxDiag{
+			Spec: diagv1.PortworxDiagSpec{
+				Portworx: &diagv1.PortworxComponent{
+					NodeSelector: diagv1.NodeSelector{
+						IDs: []string{"id0", "id1", "id2", "id3", "id4"},
+					},
+				},
+			},
+			Status: diagv1.PortworxDiagStatus{
+				NodeStatuses: []diagv1.NodeStatus{
+					{NodeID: "id1", Status: diagv1.NodeStatusPending},
+					{NodeID: "id2", Status: diagv1.NodeStatusCompleted},
+					{NodeID: "id3", Status: diagv1.NodeStatusFailed},
+					{NodeID: "id4", Status: diagv1.NodeStatusInProgress},
+					{NodeID: "id5", Status: diagv1.NodeStatusInProgress},
+					{NodeID: "id6", Status: diagv1.NodeStatusInProgress},
+				},
+			},
+		}, nodeIDToName)
+	require.ElementsMatch(t, prs.nodeStatusesToAdd, []*diagv1.NodeStatus{
+		{
+			NodeID: "id0",
+			Status: diagv1.NodeStatusPending,
+		},
+	})
+	require.ElementsMatch(t, prs.nodesToCreatePodsFor, []string{"node0", "node1"})
+	require.ElementsMatch(t, prs.podsToDelete, []*v1.Pod{&pods[2], &pods[3], &pods[5]})
+	require.NoError(t, err)
+}
+
+func TestGetOverallPhase(t *testing.T) {
+	phase, msg := getOverallPhase([]diagv1.NodeStatus{})
+	require.Equal(t, diagv1.DiagStatusPending, phase)
+	require.Empty(t, msg)
+
+	// If all phases are empty or pending, the overall phase should be pending
+	phase, msg = getOverallPhase([]diagv1.NodeStatus{
+		{Status: ""},
+		{Status: ""},
+		{Status: diagv1.NodeStatusPending},
+	})
+	require.Equal(t, diagv1.DiagStatusPending, phase)
+	require.Empty(t, msg)
+
+	// If all phases are completed, the overall phase should be completed
+	phase, msg = getOverallPhase([]diagv1.NodeStatus{
+		{Status: diagv1.NodeStatusCompleted},
+		{Status: diagv1.NodeStatusCompleted},
+		{Status: diagv1.NodeStatusCompleted},
+	})
+	require.Equal(t, diagv1.DiagStatusCompleted, phase)
+	require.Equal(t, "All diags collected successfully", msg)
+
+	// If all phases are failed, the overall phase should be failed
+	phase, msg = getOverallPhase([]diagv1.NodeStatus{
+		{Status: diagv1.NodeStatusFailed},
+		{Status: diagv1.NodeStatusFailed},
+		{Status: diagv1.NodeStatusFailed},
+	})
+	require.Equal(t, diagv1.DiagStatusFailed, phase)
+	require.Equal(t, "All diags failed to collect", msg)
+
+	// If some phases are pending and some are completed, the overall phase should be partial failure
+	phase, msg = getOverallPhase([]diagv1.NodeStatus{
+		{Status: diagv1.NodeStatusPending},
+		{Status: diagv1.NodeStatusCompleted},
+		{Status: diagv1.NodeStatusCompleted},
+	})
+	require.Equal(t, diagv1.DiagStatusPartialFailure, phase)
+	require.Equal(t, "Some diags failed to collect", msg)
+
+	// If some phases are failed and some are completed, the overall phase should be partial failure
+	phase, msg = getOverallPhase([]diagv1.NodeStatus{
+		{Status: diagv1.NodeStatusFailed},
+		{Status: diagv1.NodeStatusCompleted},
+		{Status: diagv1.NodeStatusCompleted},
+	})
+	require.Equal(t, diagv1.DiagStatusPartialFailure, phase)
+	require.Equal(t, "Some diags failed to collect", msg)
+
+	// If some phases are in progress, no matter what the phase should be in progress
+	phase, msg = getOverallPhase([]diagv1.NodeStatus{
+		{Status: diagv1.NodeStatusInProgress},
+		{Status: diagv1.NodeStatusCompleted},
+		{Status: diagv1.NodeStatusFailed},
+		{Status: diagv1.NodeStatusPending},
+	})
+	require.Equal(t, diagv1.DiagStatusInProgress, phase)
+	require.Equal(t, "Diag collection is in progress", msg)
+
+	// If an unknown status slips in, the overall phase should be unknown unless another node is in progress
+	phase, msg = getOverallPhase([]diagv1.NodeStatus{
+		{Status: diagv1.NodeStatusPending},
+		{Status: "InvalidStatus"},
+	})
+	require.Equal(t, diagv1.DiagStatusUnknown, phase)
+	require.Empty(t, msg)
+}
+
+func TestGetDiagObject(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient := testutil.FakeK8sClient(&diagv1.PortworxDiag{})
+	podControl := &k8scontroller.FakePodControl{}
+	recorder := record.NewFakeRecorder(10)
+	controller := Controller{
+		client:     k8sClient,
+		Driver:     driver,
+		podControl: podControl,
+		recorder:   recorder,
+	}
+
+	// First find with no objects created
+	diag, otherRunning, err := controller.getDiagObject(context.TODO(), reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test",
+			Namespace: "portworx",
+		},
+	})
+	require.Nil(t, diag)
+	require.False(t, otherRunning)
+	require.NoError(t, err)
+
+	// Create another diag object
+	diagInProgress := &diagv1.PortworxDiag{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "otherdiag",
+			Namespace: "portworx",
+		},
+		Status: diagv1.PortworxDiagStatus{
+			Phase: diagv1.DiagStatusInProgress,
+		},
+	}
+	err = k8sClient.Create(context.Background(), diagInProgress)
+	require.NoError(t, err)
+
+	diag, otherRunning, err = controller.getDiagObject(context.TODO(), reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test",
+			Namespace: "portworx",
+		},
+	})
+	require.Nil(t, diag)
+	require.True(t, otherRunning)
+	require.NoError(t, err)
+
+	// Create our diag object
+	diagOurs := &diagv1.PortworxDiag{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "portworx",
+		},
+		Status: diagv1.PortworxDiagStatus{
+			Phase: diagv1.DiagStatusInProgress,
+		},
+	}
+	err = k8sClient.Create(context.Background(), diagOurs)
+	require.NoError(t, err)
+
+	diag, otherRunning, err = controller.getDiagObject(context.TODO(), reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test",
+			Namespace: "portworx",
+		},
+	})
+	require.Equal(t, diagOurs, diag)
+	require.True(t, otherRunning)
+	require.NoError(t, err)
+
+	// Delete the other diag object, now we should be able to run
+	err = k8sClient.Delete(context.Background(), diagInProgress)
+	require.NoError(t, err)
+
+	diag, otherRunning, err = controller.getDiagObject(context.TODO(), reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test",
+			Namespace: "portworx",
+		},
+	})
+	require.Equal(t, diagOurs, diag)
+	require.False(t, otherRunning)
+	require.NoError(t, err)
 }

--- a/pkg/controller/portworxdiag/portworxdiag.go
+++ b/pkg/controller/portworxdiag/portworxdiag.go
@@ -105,23 +105,16 @@ func (c *Controller) StartWatch() error {
 	return nil
 }
 
-func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := logrus.WithFields(map[string]interface{}{
-		"Request.Namespace": req.Namespace,
-		"Request.Name":      req.Name,
-	})
-	log.Infof("Reconciling PortworxDiag")
-
+func (c *Controller) getDiagObject(ctx context.Context, req reconcile.Request) (*diagv1.PortworxDiag, bool, error) {
 	// List all PortworxDiag instances, pick out ours, and set it to "Pending" if other diags are running
 	diags := &diagv1.PortworxDiagList{}
 	err := c.client.List(context.TODO(), diags, &client.ListOptions{Namespace: req.Namespace})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// Request objects not found, could have been deleted after reconcile request.
-			return reconcile.Result{}, nil
-		}
-		// Error reading the objects - requeue the request.
-		return reconcile.Result{}, err
+		// Error reading the objects - requeue the request (no items returns a successful empty list).
+		return nil, false, err
+	}
+	if len(diags.Items) == 0 {
+		return nil, false, nil
 	}
 
 	// Sort all diags by creation timestamp
@@ -140,7 +133,20 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			otherDiagRunning = true
 		}
 	}
+	return diag, otherDiagRunning, nil
+}
 
+func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := logrus.WithFields(map[string]interface{}{
+		"Request.Namespace": req.Namespace,
+		"Request.Name":      req.Name,
+	})
+	log.Infof("Reconciling PortworxDiag")
+
+	diag, otherDiagRunning, err := c.getDiagObject(ctx, req)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 	if diag == nil {
 		// Request objects not found, could have been deleted after reconcile request.
 		return reconcile.Result{}, nil
@@ -204,6 +210,9 @@ func (c *Controller) getDiagPods(ns, diagName string) (*v1.PodList, error) {
 
 func getNodeToPodMap(podList *v1.PodList) map[string]*v1.Pod {
 	pods := make(map[string]*v1.Pod)
+	if podList == nil {
+		return pods
+	}
 	for _, p := range podList.Items {
 		tmp := p // To avoid referencing the loop variable
 		pods[p.Spec.NodeName] = &tmp
@@ -228,9 +237,64 @@ type podReconcileStatus struct {
 	nodeStatusesToAdd    []*diagv1.NodeStatus
 }
 
+func shouldPodBeOnNode(nodeID string, nodeName string, nodes []v1.Node, diag *diagv1.PortworxDiag) bool {
+	if diag == nil || diag.Spec.Portworx == nil {
+		// Just in case, sanity check
+		return false
+	}
+
+	// If we're selecting all nodes, short-circuit
+	if diag.Spec.Portworx.NodeSelector.All {
+		return true
+	}
+	// If there's no node selector and we're not selecting all nodes, collect none
+	if len(diag.Spec.Portworx.NodeSelector.IDs) == 0 && len(diag.Spec.Portworx.NodeSelector.Labels) == 0 {
+		return false
+	}
+
+	// Filter by node ID first since it's the one we already have (save on API calls)
+	// If there's no IDs provided, do nothing and move on to the label match.
+	for _, id := range diag.Spec.Portworx.NodeSelector.IDs {
+		if id == nodeID {
+			return true
+		}
+	}
+
+	// Node ID didn't match, check if node labels match label selectors
+	if len(diag.Spec.Portworx.NodeSelector.Labels) == 0 {
+		return false
+	}
+
+	// Find node object in list
+	var node *v1.Node
+	for _, n := range nodes {
+		if strings.EqualFold(n.Name, nodeName) {
+			nTemp := n // To avoid referencing the loop variable
+			node = &nTemp
+			break
+		}
+	}
+
+	if node == nil {
+		return false
+	}
+
+	// Check if node labels matches label selectors
+	for k, v := range diag.Spec.Portworx.NodeSelector.Labels {
+		label, ok := node.Labels[k]
+		if !ok {
+			return false // Label missing entirely
+		}
+		if label != v {
+			return false // Label values don't match
+		}
+	}
+	return true // All labels in selector passed
+}
+
 // getPodsDiff will return the pods that need to be created and deleted, as well as how many pods exist (but are not complete) and
 // how many are complete
-func getPodsDiff(pods *v1.PodList, diag *diagv1.PortworxDiag, nodeIDToNodeName map[string]string) (podReconcileStatus, error) {
+func getPodsDiff(pods *v1.PodList, nodes *v1.NodeList, diag *diagv1.PortworxDiag, nodeIDToNodeName map[string]string) (podReconcileStatus, error) {
 	// Check on all of our storage nodes
 	prs := podReconcileStatus{
 		podsToDelete:         make([]*v1.Pod, 0),
@@ -244,31 +308,48 @@ func getPodsDiff(pods *v1.PodList, diag *diagv1.PortworxDiag, nodeIDToNodeName m
 	for nodeID, nodeName := range nodeIDToNodeName {
 		existingPod := nodeToPod[nodeName]
 
-		if status, ok := nodeIDToStatus[nodeID]; ok {
-			if status == diagv1.NodeStatusCompleted || status == diagv1.NodeStatusFailed {
-				// Delete any pods that are done processing
-				if existingPod != nil {
-					prs.podsToDelete = append(prs.podsToDelete, existingPod)
-				}
-			} else { // Diag is still running... do nothing if already exists
-				if existingPod == nil {
-					// Create pod if it's missing
-					prs.nodesToCreatePodsFor = append(prs.nodesToCreatePodsFor, nodeName)
-				}
-			}
-		} else { // This node is missing a status in the Diag, go and add it
+		shouldExist := shouldPodBeOnNode(nodeID, nodeName, nodes.Items, diag)
+
+		status, ok := nodeIDToStatus[nodeID]
+		if !ok && shouldExist {
+			// This node is missing a status in the Diag, go and add it
 			prs.nodeStatusesToAdd = append(prs.nodeStatusesToAdd, &diagv1.NodeStatus{NodeID: nodeID, Status: diagv1.NodeStatusPending, Message: ""})
 			if existingPod == nil {
 				// Also create a pod if it's missing
 				prs.nodesToCreatePodsFor = append(prs.nodesToCreatePodsFor, nodeName)
 			}
+			continue
 		}
+
+		// This node exists in the status
+		// Delete any pods that are complete/failed
+		if status == diagv1.NodeStatusCompleted || status == diagv1.NodeStatusFailed {
+			if existingPod != nil {
+				prs.podsToDelete = append(prs.podsToDelete, existingPod)
+			}
+			continue
+		}
+
+		// If a pod shouldn't exist, don't add one
+		if !shouldExist {
+			// Delete any pods that shouldn't exist (shouldn't ever happen, but just in case)
+			if existingPod != nil {
+				prs.podsToDelete = append(prs.podsToDelete, existingPod)
+			}
+			continue
+		}
+
+		// Diag should still be running... create pod if it's missing
+		if existingPod == nil {
+			prs.nodesToCreatePodsFor = append(prs.nodesToCreatePodsFor, nodeName)
+		}
+		continue
 	}
 
 	return prs, nil
 }
 
-func getOverallPhase(diag *diagv1.PortworxDiag) (string, string) {
+func getOverallPhase(statuses []diagv1.NodeStatus) (string, string) {
 	// If all nodes are not yet started or empty: phase is "Not Yet Started"
 	// If all nodes in status are complete: phase is "Completed"
 	// If all nodes are failed: phase is "Failed"
@@ -276,12 +357,12 @@ func getOverallPhase(diag *diagv1.PortworxDiag) (string, string) {
 	// If at least one node is in progress: phase is "In Progress"
 	// Worst case, return an "unknown" status
 
-	if len(diag.Status.NodeStatuses) == 0 {
+	if len(statuses) == 0 {
 		return diagv1.DiagStatusPending, ""
 	}
 
 	phaseCount := map[string]int{}
-	for _, n := range diag.Status.NodeStatuses {
+	for _, n := range statuses {
 		if _, ok := phaseCount[n.Status]; !ok {
 			phaseCount[n.Status] = 1
 			continue
@@ -289,23 +370,25 @@ func getOverallPhase(diag *diagv1.PortworxDiag) (string, string) {
 		phaseCount[n.Status] += 1
 	}
 
-	logrus.Debugf("Counts of diag pods in each phase: %v", phaseCount)
-
-	if emptyCount, ok := phaseCount[""]; ok && emptyCount == len(diag.Status.NodeStatuses) {
-		return diagv1.DiagStatusPending, ""
+	emptyPendingCount := 0
+	if emptyCount, ok := phaseCount[""]; ok {
+		emptyPendingCount += emptyCount
+	}
+	if pendingCount, ok := phaseCount[diagv1.NodeStatusPending]; ok {
+		emptyPendingCount += pendingCount
 	}
 
-	if pendingCount, ok := phaseCount[diagv1.NodeStatusPending]; ok && pendingCount == len(diag.Status.NodeStatuses) {
+	if emptyPendingCount == len(statuses) {
 		return diagv1.DiagStatusPending, ""
 	}
 
 	completeCount, ok := phaseCount[diagv1.NodeStatusCompleted]
-	if ok && completeCount == len(diag.Status.NodeStatuses) {
+	if ok && completeCount == len(statuses) {
 		return diagv1.DiagStatusCompleted, "All diags collected successfully"
 	}
 
 	failedCount, ok := phaseCount[diagv1.NodeStatusFailed]
-	if ok && failedCount == len(diag.Status.NodeStatuses) {
+	if ok && failedCount == len(statuses) {
 		return diagv1.DiagStatusFailed, "All diags failed to collect"
 	}
 
@@ -315,7 +398,7 @@ func getOverallPhase(diag *diagv1.PortworxDiag) (string, string) {
 		pendingCount = 0
 	}
 
-	if failedCount+pendingCount+completeCount == len(diag.Status.NodeStatuses) {
+	if failedCount+pendingCount+completeCount == len(statuses) {
 		return diagv1.DiagStatusPartialFailure, "Some diags failed to collect"
 	}
 
@@ -350,7 +433,7 @@ func getChangedClusterUUIDPatch(diag *diagv1.PortworxDiag, stc *corev1.StorageCl
 
 func getOverallPhasePatch(diag *diagv1.PortworxDiag) []map[string]interface{} {
 	patches := []map[string]interface{}{}
-	newPhase, newMessage := getOverallPhase(diag)
+	newPhase, newMessage := getOverallPhase(diag.Status.NodeStatuses)
 	logrus.Debugf("New phase for PortworxDiag is '%s'", newPhase)
 	if diag.Status.Phase != newPhase {
 		op := "add"
@@ -513,8 +596,19 @@ func (c *Controller) syncPortworxDiag(diag *diagv1.PortworxDiag) error {
 		return err
 	}
 
+	// List all k8s nodes in the cluster, but only if we have a label selector
+	// Otherwise just pass an empty list through
+	nodes := &v1.NodeList{Items: []v1.Node{}}
+	if diag.Spec.Portworx.NodeSelector.Labels != nil {
+		err = c.client.List(context.Background(), nodes)
+		if err != nil {
+			logrus.WithError(err).Error("Failed to list nodes in cluster")
+			return fmt.Errorf("failed to list k8s nodes: %v", err)
+		}
+	}
+
 	// Get what changes we need to make between real and desired
-	prs, err := getPodsDiff(pods, diag, nodeIDToNodeName)
+	prs, err := getPodsDiff(pods, nodes, diag, nodeIDToNodeName)
 	if err != nil {
 		logrus.WithError(err).Error("Failed to check pods for required operations")
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds support for `Spec.Portworx.NodeSelector.IDs` and `Spec.Portworx.NodeSelector.Labels` in the operator
* Reorganizes a couple methods to make them cleaner
* Adds unit tests for all the substantial methods in the diag controller (I don't unit test front-to-back yet but it gets the critical functionality)

**Which issue(s) this PR fixes** (optional)
PWX-29716 (node selector)
PWX-32103 (unit tests)
