### PR TITLE
PWX-32179: Reduces volume mounts for PX diag collector pod

### DIFF
--- a/pkg/controller/portworxdiag/pod.go
+++ b/pkg/controller/portworxdiag/pod.go
@@ -33,40 +33,15 @@ func v1Volume(name, path string, hpType v1.HostPathType) v1.Volume {
 
 func volumes() []v1.Volume {
 	return []v1.Volume{
-		v1Volume("dockersock", "/var/run/docker.sock", v1.HostPathUnset),
-		v1Volume("containerddir", "/run/containerd", v1.HostPathUnset),
-		v1Volume("criosock", "/var/run/crio", v1.HostPathUnset),
-		v1Volume("crioconf", "/etc/crictl.yaml", v1.HostPathFileOrCreate),
-		v1Volume("optpwx", "/opt/pwx", v1.HostPathUnset),
 		v1Volume("procmount", "/proc", v1.HostPathUnset),
-		v1Volume("sysdmount", "/etc/systemd/system", v1.HostPathUnset),
-		v1Volume("dbusmount", "/var/run/dbus", v1.HostPathUnset),
-		v1Volume("varlibosd", "/var/lib/osd", v1.HostPathUnset),
 		v1Volume("diagsdump", "/var/cores", v1.HostPathUnset),
-		v1Volume("etcpwx", "/etc/pwx", v1.HostPathUnset),
-		v1Volume("journalmount1", "/var/run/log", v1.HostPathUnset),
-		v1Volume("journalmount2", "/var/log", v1.HostPathUnset),
-		v1Volume("registration-dir", "/var/lib/kubelet/plugins_registry", v1.HostPathDirectoryOrCreate),
-		v1Volume("csi-driver-path", "/var/lib/kubelet/plugins/pxd.portworx.com", v1.HostPathDirectoryOrCreate),
 	}
 }
 
 func volumeMounts() []v1.VolumeMount {
-	mp := v1.MountPropagationBidirectional
 	return []v1.VolumeMount{
-		{Name: "dockersock", MountPath: "/var/run/docker.sock"},
-		{Name: "containerddir", MountPath: "/run/containerd"},
-		{Name: "criosock", MountPath: "/var/run/crio"},
-		{Name: "crioconf", MountPath: "/etc/crictl.yaml"},
-		{Name: "optpwx", MountPath: "/opt/pwx"},
 		{Name: "procmount", MountPath: "/host_proc"},
-		{Name: "sysdmount", MountPath: "/etc/systemd/system"},
-		{Name: "dbusmount", MountPath: "/var/run/dbus"},
-		{Name: "varlibosd", MountPath: "/var/lib/osd", MountPropagation: &mp},
 		{Name: "diagsdump", MountPath: "/var/cores"},
-		{Name: "etcpwx", MountPath: "/etc/pwx"},
-		{Name: "journalmount1", MountPath: "/var/run/log", ReadOnly: true},
-		{Name: "journalmount2", MountPath: "/var/log", ReadOnly: true},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Originally I just copied all the same mounts from the Portworx pod. Most of them aren't necessary: we only need `/proc` (to `nsenter` into the host) and `/var/cores` (to clean up old diag files).

Tested by comparing diags before and after and they were a nearly identical size, all files were present, etc.

