### PR TITLE
PWX-32177: Removes unnecessary permissions from diag collector pods

### DIFF
--- a/pkg/controller/portworxdiag/pod.go
+++ b/pkg/controller/portworxdiag/pod.go
@@ -46,7 +46,6 @@ func volumeMounts() []v1.VolumeMount {
 }
 
 func makeDiagPodTemplate(cluster *corev1.StorageCluster, diag *portworxv1.PortworxDiag, ns string, nodeName string, nodeID string) (*v1.PodTemplateSpec, error) {
-	svcLinks := true
 	terminationGP := int64(10)
 	privileged := true
 
@@ -79,11 +78,8 @@ func makeDiagPodTemplate(cluster *corev1.StorageCluster, diag *portworxv1.Portwo
 		},
 		Spec: v1.PodSpec{
 			NodeName:                      nodeName,
-			HostPID:                       true,                      // We *do* need this
-			HostNetwork:                   true,                      // Do we need this?: https://portworx.atlassian.net/browse/PWX-32177
-			RestartPolicy:                 v1.RestartPolicyOnFailure, //
-			DNSPolicy:                     v1.DNSClusterFirst,        // Do we need this? https://portworx.atlassian.net/browse/PWX-32177
-			EnableServiceLinks:            &svcLinks,                 // Do we need this? https://portworx.atlassian.net/browse/PWX-32177
+			HostPID:                       true,
+			RestartPolicy:                 v1.RestartPolicyOnFailure,
 			ServiceAccountName:            pxutil.PortworxServiceAccountName(cluster),
 			TerminationGracePeriodSeconds: &terminationGP,
 			Volumes:                       volumes(),


### PR DESCRIPTION
**What this PR does / why we need it**:
Like the last PR, the pod spec was mostly copied from the standard portworx pod spec. This left some extra things like HostNetwork, DNSPolicy, and EnableServiceLinks that we don't need.

I again confirmed it worked by checking the size of a diag before and after the change and they were nearly identical, confirming all the same data is still there.

**Which issue(s) this PR fixes** (optional)
PWX-32177
