### PR TITLE
PWX-31981: Remove depricated '-T dmthin' misc argument

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -654,6 +655,18 @@ func (c *Controller) syncStorageCluster(
 				cluster.Annotations = make(map[string]string)
 			}
 			cluster.Annotations[pxutil.AnnotationPreflightCheck] = "false"
+		}
+	}
+
+	if _, miscExists := cluster.Annotations[pxutil.AnnotationMiscArgs]; miscExists {
+		// Cleanup remove '-T dmthin' from misc args if it exists.  It would have been added due to a bug
+		miscAnnotations := cluster.Annotations[pxutil.AnnotationMiscArgs]
+		dmThinStr := `-T *dmthin`
+		if dmExists, err := regexp.MatchString(dmThinStr, miscAnnotations); err == nil {
+			rexp := regexp.MustCompile(dmThinStr)
+			if dmExists {
+				cluster.Annotations[pxutil.AnnotationMiscArgs] = rexp.ReplaceAllString(miscAnnotations, "")
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
When upgrading PX to 3.0 with op 23.5.0, storage spec was updated with -T dmthin.   This was bug and was corrected with other fixes however the spec still contained the -T dmthin.   Even though its ignored we should remove it to avoid confusion.
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31981
**Special notes for your reviewer**:

