### PR TITLE
update dynamic plugin image for 23.7.0 

### DIFF
--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -50,7 +50,7 @@ const (
 	defaultNewAlertManagerImage             = "quay.io/prometheus/alertmanager:v0.24.0"
 
 	// default dynamic plugin images
-	DefaultDynamicPluginImage      = "portworx/portworx-dynamic-plugin:1.0.0"
+	DefaultDynamicPluginImage      = "portworx/portworx-dynamic-plugin:1.1.0"
 	DefaultDynamicPluginProxyImage = "nginxinc/nginx-unprivileged:1.23"
 
 	defaultManifestRefreshInterval = 3 * time.Hour

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -39,7 +39,7 @@ func TestManifestWithNewerPortworxVersion(t *testing.T) {
 			Telemetry:                 "image/ccm-service:3.2.11",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
-			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}
@@ -78,7 +78,7 @@ func TestManifestWithNewerPortworxVersionAndConfigMapPresent(t *testing.T) {
 			Telemetry:                 "image/ccm-service:2.6.0",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.0",
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
-			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}
@@ -169,7 +169,7 @@ func TestManifestWithOlderPortworxVersion(t *testing.T) {
 			Telemetry:                 "image/ccm-service:3.2.11",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
-			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}
@@ -260,7 +260,7 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			TelemetryProxy:            "purestorage/telemetry-envoy:1.0.0",
 			LogUploader:               "purestorage/log-upload:1.0.0",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
-			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}
@@ -341,7 +341,7 @@ func TestManifestWithoutPortworxVersion(t *testing.T) {
 			Telemetry:                 "image/ccm-service:3.2.11",
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
-			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
 		},
 	}

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2125,7 +2125,7 @@ func TestStorageClusterDefaultsForPlugin(t *testing.T) {
 
 	err := driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
-	require.Equal(t, cluster.Status.DesiredImages.DynamicPlugin, "portworx/portworx-dynamic-plugin:1.0.0")
+	require.Equal(t, cluster.Status.DesiredImages.DynamicPlugin, "portworx/portworx-dynamic-plugin:1.1.0")
 	require.Equal(t, cluster.Status.DesiredImages.DynamicPluginProxy, "nginxinc/nginx-unprivileged:1.23")
 }
 
@@ -8474,7 +8474,7 @@ func (m *fakeManifest) GetVersions(
 			MetricsCollectorProxy:      "envoyproxy/envoy:v1.19.1",
 			LogUploader:                "purestorage/log-upload:1.2.3",
 			TelemetryProxy:             "purestorage/envoy:1.2.3",
-			DynamicPlugin:              "portworx/portworx-dynamic-plugin:1.0.0",
+			DynamicPlugin:              "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:         "nginxinc/nginx-unprivileged:1.23",
 		},
 	}

--- a/drivers/storage/portworx/testspec/plugin-deployment.yaml
+++ b/drivers/storage/portworx/testspec/plugin-deployment.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: px-plugin
-          image: docker.io/portworx/portworx-dynamic-plugin:1.0.0
+          image: docker.io/portworx/portworx-dynamic-plugin:1.1.0
           ports:
             - containerPort: 9443
               protocol: TCP


### PR DESCRIPTION
Updating dynamic plugin pod image for 23.7.0 from portworx/portworx-dynamic-plugin:1.0.0 to portworx/portworx-dynamic-plugin:1.1.0

px-installer changes : https://github.com/portworx/px-installer/pull/1825