### PR TITLE
PWX-31981: Remove depricated '-T dmthin' misc argument (#1155)

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -623,7 +623,7 @@ func (c *Controller) miscCleanUp(cluster *corev1.StorageCluster) error {
 		dmMatched := dmThinRexp.FindStringSubmatch(miscAnnotations)
 		if len(dmMatched) > 0 {
 			cluster.Annotations[pxutil.AnnotationMiscArgs] = dmThinRexp.ReplaceAllString(miscAnnotations, "")
-			if err := k8s.UpdateStorageCluster(c.client, cluster); err != nil {
+			if err := c.client.Update(context.TODO(), cluster); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
* PWX-31981: Remove '-T dmthin' from annotation portworx.io/misc-args if it exists.



* PWX-31981: Make sure to update the spec after cleanup.



* PWX-31981: Review suggestions, move regx to global and FindStringSubmatch.



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Remove depricated '-T dmthin' misc argument
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31981
**Special notes for your reviewer**:
Cherry-pick from master... 