### PR TITLE
PWX-31962: Fixing up test name and provider logic

### DIFF
--- a/test/integration_test/basic_dmthin_test.go
+++ b/test/integration_test/basic_dmthin_test.go
@@ -73,7 +73,7 @@ var testDmthinCases = []types.TestCase{
 	},
 }
 
-func TestStorageClusterBasicDMthin(t *testing.T) {
+func TestDMthinCloudDrivesBasic(t *testing.T) {
 	for _, testCase := range testDmthinCases {
 		testCase.RunTest(t)
 	}

--- a/test/integration_test/cloud_provider/cloud_drive.go
+++ b/test/integration_test/cloud_provider/cloud_drive.go
@@ -1,6 +1,7 @@
 package cloud_provider
 
 import (
+	"github.com/libopenstorage/cloudops"
 	"github.com/libopenstorage/operator/test/integration_test/utils"
 	"log"
 	"strings"
@@ -21,7 +22,8 @@ func stringPtr(str string) *string {
 }
 
 func isVsphere() bool {
-	return strings.Contains(utils.PxEnvVars, "VSPHERE_VCENTER")
+	return strings.Contains(utils.PxEnvVars, "VSPHERE_VCENTER") ||
+		utils.CloudProvider == cloudops.Vsphere
 }
 
 func GetCloudProvider() Provider {


### PR DESCRIPTION
    TestStorageClusterBasicDMthin has the same prefix with another test
    TestStorageClusterBasic. This is causing the dmthin test to run in
    unintended jenkins jobs.

    There is an additional way of knowing the provider which is to use
    the value from --cloud-provider

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

