### PR TITLE
PWX-32497: fix portworx (privileged) SCC

### DIFF
--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -194,7 +194,7 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 			AllowHostIPC:             false,
 			AllowHostNetwork:         true,
 			AllowHostPID:             false,
-			AllowHostPorts:           false,
+			AllowHostPorts:           true,
 			AllowPrivilegeEscalation: boolPtr(true),
 			AllowPrivilegedContainer: true,
 			AllowedUnsafeSysctls:     []string{"*"},

--- a/drivers/storage/portworx/testspec/portworxSCC.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC.yaml
@@ -2,7 +2,7 @@ allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: true
 allowHostPID: false
-allowHostPorts: false
+allowHostPorts: true
 allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities:


### PR DESCRIPTION
* re-enabling the AllowHostPorts, since telemetry uses it

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The telemetry DaemonSet uses HostPorts, and the portworx (privileged) SCC was disabling it.

As a consequence the px-telemetry DaemonSet was not getting associated with any SCC:
```
# oc get ds px-telemetry-phonehome --output yaml | oc adm policy scc-review --filename -
RESOURCE   SERVICE ACCOUNT   ALLOWED BY
```
.. so Kubernetes tried to match it with any/all public SCC's -- and made a huge mess, and a very confusing error (complains about everything...):
```
Warning  FailedCreate  119s (x55 over 3h57m)  daemonset-controller  Error creating: pods "px-telemetry-phonehome-" is forbidden: unable to validate against any security context constraint: [
provider "anyuid": Forbidden: not usable by user or serviceaccount
spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used
spec.volumes[1]: Invalid value: "hostPath": hostPath volumes are not allowed to be used
spec.volumes[2]: Invalid value: "hostPath": hostPath volumes are not allowed to be used
spec.volumes[3]: Invalid value: "hostPath": hostPath volumes are not allowed to be used
spec.initContainers[0].securityContext.runAsUser: Invalid value: 1111: must be in the ranges: [1000670000, 1000679999]
spec.initContainers[0].securityContext.containers[0].hostPort: Invalid value: 17021: Host ports are not allowed to be used
spec.initContainers[0].securityContext.containers[1].hostPort: Invalid value: 20002: Host ports are not allowed to be used
spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed
spec.containers[0].securityContext.containers[0].hostPort: Invalid value: 17021: Host ports are not allowed to be used
spec.containers[0].securityContext.containers[1].hostPort: Invalid value: 20002: Host ports are not allowed to be used
spec.containers[1].securityContext.runAsUser: Invalid value: 1111: must be in the ranges: [1000670000, 1000679999]
spec.containers[1].securityContext.containers[0].hostPort: Invalid value: 17021: Host ports are not allowed to be used
spec.containers[1].securityContext.containers[1].hostPort: Invalid value: 20002: Host ports are not allowed to be used
provider "restricted": Forbidden: not usable by user or serviceaccount
provider "nonroot-v2": Forbidden: not usable by user or serviceaccount
provider "nonroot": Forbidden: not usable by user or serviceaccount
provider "hostmount-anyuid": Forbidden: not usable by user or serviceaccount
provider "portworx-restricted": Forbidden: not usable by user or serviceaccount
provider "machine-api-termination-handler": Forbidden: not usable by user or serviceaccount
provider "hostnetwork-v2": Forbidden: not usable by user or serviceaccount
provider "hostnetwork": Forbidden: not usable by user or serviceaccount
provider "hostaccess": Forbidden: not usable by user or serviceaccount
provider "node-exporter": Forbidden: not usable by user or serviceaccount
provider "privileged": Forbidden: not usable by user or serviceaccount]
```

FIX:
* the fix was to enable the `allowHostPorts:true` in portworx SCC
  - after the fix it's associating correctly w/ SCC, and also deploying correctly:

```
$ oc get ds px-telemetry-phonehome --output yaml | oc adm policy scc-review --filename -
RESOURCE                           SERVICE ACCOUNT   ALLOWED BY
DaemonSet/px-telemetry-phonehome   px-telemetry      portworx

$ oc get ds px-telemetry-phonehome
NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
px-telemetry-phonehome   5         5         5       5            5           <none>          28m
```

**Which issue(s) this PR fixes** (optional)
Closes # PWX-32497

**Special notes for your reviewer**:

