### PR TITLE
PWX-32539: When preflight enables PX-storeV2 for vsphere.  It should …

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -177,7 +177,7 @@ func TestValidate(t *testing.T) {
 	<-recorder.Events // Pop first event which is Default telemetry enabled event
 	require.Contains(t, <-recorder.Events,
 		fmt.Sprintf("%v %v %s", v1.EventTypeNormal, util.PassPreFlight, "Enabling PX-StoreV2"))
-	require.Contains(t, *cluster.Spec.CloudStorage.SystemMdDeviceSpec, DefCmetaData)
+	require.Contains(t, *cluster.Spec.CloudStorage.SystemMdDeviceSpec, DefCmetaAWS)
 
 	//
 	// Validate Pre-flight Daemonset Pod Spec

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -33,7 +33,7 @@ const (
 	// PxPreFlightServiceAccountName name of portworx pre flight service account
 	PxPreFlightServiceAccountName = "px-pre-flight"
 	// DefCmetaData default metadata cloud device for DMthin AWS
-	DefCmetaData = "type=gp3,size=64"
+	DefCmetaAWS = "type=gp3,size=64"
 	// DefCmetaVsphere default metadata cloud device for DMthin Vsphere
 	DefCmetaVsphere = "type=eagerzeroedthick,size=64"
 )
@@ -355,7 +355,7 @@ func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
 	}
 
 	if u.cluster.Spec.CloudStorage.SystemMdDeviceSpec == nil {
-		cmetaData := DefCmetaData
+		cmetaData := DefCmetaAWS
 		if pxutil.IsVsphere(u.cluster) {
 			cmetaData = DefCmetaVsphere
 		}

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -32,8 +32,10 @@ const (
 	pxPreFlightDaemonSetName          = "px-pre-flight"
 	// PxPreFlightServiceAccountName name of portworx pre flight service account
 	PxPreFlightServiceAccountName = "px-pre-flight"
-	// DefCmetaData default metadata cloud device for DMthin
+	// DefCmetaData default metadata cloud device for DMthin AWS
 	DefCmetaData = "type=gp3,size=64"
+	// DefCmetaVsphere default metadata cloud device for DMthin Vsphere
+	DefCmetaVsphere = "type=eagerzeroedthick,size=64"
 )
 
 // PreFlightPortworx provides a set of APIs to uninstall portworx
@@ -354,6 +356,9 @@ func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
 
 	if u.cluster.Spec.CloudStorage.SystemMdDeviceSpec == nil {
 		cmetaData := DefCmetaData
+		if pxutil.IsVsphere(u.cluster) {
+			cmetaData = DefCmetaVsphere
+		}
 		u.cluster.Spec.CloudStorage.SystemMdDeviceSpec = &cmetaData
 	}
 }


### PR DESCRIPTION
…add a default 'type=eagerzeroedthick,size=64' SystemMdDeviceSpec if none is provided.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Preflight should add a default 'type=eagerzeroedthick,size=64' SystemMdDeviceSpec if none is provided.  When running on vsphere.
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-32539
**Special notes for your reviewer**:

