### PR TITLE
PWX-32193 Watch for diag pod changes and reconcile PortworxDiag obj

### DIFF
--- a/pkg/controller/portworxdiag/portworxdiag.go
+++ b/pkg/controller/portworxdiag/portworxdiag.go
@@ -103,6 +103,18 @@ func (c *Controller) StartWatch() error {
 		return fmt.Errorf("failed to watch PortworxDiags: %v", err)
 	}
 
+	// Watch for changes to Pods that belong to PortworxDiag object
+	err = c.ctrl.Watch(
+		&source.Kind{Type: &v1.Pod{}},
+		&handler.EnqueueRequestForOwner{
+			IsController: true,
+			OwnerType:    &diagv1.PortworxDiag{},
+		},
+	)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

- The diag pods are created with controller reference to the corresponding PortworxDiag object.
- The added controller watch will ensure that if there is a change in the diag pods, the diag reconciler is called with the parent PortworxDiag object.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-32193

**Special notes for your reviewer**:

