### PR TITLE
PWX-32773: OCP-4.13 non-privileged deployment fix

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -483,7 +483,7 @@ func (t *template) portworxContainer(cluster *corev1.StorageCluster) v1.Containe
 		sc.Privileged = boolPtr(false)
 		sc.Capabilities = &v1.Capabilities{
 			Add: []v1.Capability{
-				"SYS_ADMIN", "SYS_PTRACE", "SYS_RAWIO", "SYS_MODULE", "LINUX_IMMUTABLE",
+				"SYS_ADMIN", "SYS_CHROOT", "SYS_PTRACE", "SYS_RAWIO", "SYS_MODULE", "LINUX_IMMUTABLE",
 			},
 		}
 	}

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2286,7 +2286,7 @@ func TestOpenshiftRuncPodSpec(t *testing.T) {
 		Privileged: boolPtr(false),
 		Capabilities: &v1.Capabilities{
 			Add: []v1.Capability{
-				"SYS_ADMIN", "SYS_PTRACE", "SYS_RAWIO", "SYS_MODULE", "LINUX_IMMUTABLE",
+				"SYS_ADMIN", "SYS_CHROOT", "SYS_PTRACE", "SYS_RAWIO", "SYS_MODULE", "LINUX_IMMUTABLE",
 			},
 		},
 	}
@@ -2408,7 +2408,7 @@ func TestPodSpecForBottleRocketAMI(t *testing.T) {
 
 	// double-check permissions
 	expectedCapabilities := []v1.Capability{
-		"SYS_ADMIN", "SYS_PTRACE", "SYS_RAWIO", "SYS_MODULE", "LINUX_IMMUTABLE",
+		"SYS_ADMIN", "SYS_CHROOT", "SYS_PTRACE", "SYS_RAWIO", "SYS_MODULE", "LINUX_IMMUTABLE",
 	}
 	require.NotNil(t, actual.Containers[0].SecurityContext.Privileged)
 	assert.False(t, *actual.Containers[0].SecurityContext.Privileged)


### PR DESCRIPTION
Adding SYS_CHROOT capability into non-privileged deployment

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

PX deployment with `privileged:false` annotation was failing on the OCP-4.13.

FIX:
* we're adding `SYS_CHROOT` capability into the requested capabilities -- this enables deployment on OCP-4.13

**Which issue(s) this PR fixes** (optional)
Closes # PWX-32773

**Special notes for your reviewer**:

