### PR TITLE
PWX-30419: Use reconcile loop to check pre-flight status. Timeout aft…

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -44,6 +44,7 @@ const (
 	storageClusterUninstallAndWipeMsg = "Portworx service removed. Portworx drives and data wiped."
 	labelPortworxVersion              = "PX Version"
 	defaultEksCloudStorageDevice      = "type=gp3,size=150"
+	preFlightTimeOut                  = 15 * time.Minute
 )
 
 type portworx struct {
@@ -89,69 +90,115 @@ func (p *portworx) Init(
 }
 
 func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
+
+	condition := &corev1.ClusterCondition{
+		Source: pxutil.PortworxComponentName,
+		Type:   corev1.ClusterConditionTypePreflight,
+	}
+
+	setClusterCondition := func(status corev1.ClusterConditionStatus, msg string) {
+		condition.Status = status
+		condition.Message = msg
+		util.UpdateStorageClusterCondition(cluster, condition)
+	}
+
 	podSpec, err := p.GetStoragePodSpec(cluster, "")
 	if err != nil {
+		err = fmt.Errorf("pre-flight: get storage pod spec: %v", err)
+		setClusterCondition(corev1.ClusterConditionStatusFailed, err.Error())
 		return err
 	}
 
 	preFlighter := NewPreFlighter(cluster, p.k8sClient, podSpec)
 
+	deletePreflight := func() {
+		_, _, err := GetPreFlightPodsFromNamespace(p.k8sClient, cluster.Namespace)
+		if err == nil {
+			// Clean up the pre-flight pods
+			logrus.Infof("pre-flight: cleaning pre-flight ds...")
+			if derr := preFlighter.DeletePreFlight(); derr != nil {
+				logrus.Errorf("pre-flight: error deleting pre-flight: %v", derr)
+			}
+		}
+	}
+
+	check, ok := cluster.Annotations[pxutil.AnnotationPreflightCheck]
+	check = strings.TrimSpace(strings.ToLower(check))
+	if !ok || check == "skip" {
+		setClusterCondition(corev1.ClusterConditionStatusDisabled, "pre-flight: skipped...")
+		logrus.Infof(condition.Message)
+		deletePreflight()
+		return nil
+	}
+
 	// Start the pre-flight container. The pre-flight checks at this time are specific to enabling DMthin
 	err = preFlighter.RunPreFlight()
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
+			err = fmt.Errorf("pre-flight: run error: %v", err)
+			setClusterCondition(corev1.ClusterConditionStatusFailed, err.Error())
+			deletePreflight()
 			return err
 		}
 		logrus.Debugf("pre-flight: container already running...")
 	}
 
-	defer func() {
-		// Clean up the pre-flight pods
-		logrus.Infof("pre-flight: cleaning pre-flight ds...")
-		if derr := preFlighter.DeletePreFlight(); derr != nil {
-			logrus.Errorf("pre-flight: error deleting pre-flight: %v", derr)
+	completed, inProgress, total, age, err := preFlighter.GetPreFlightStatus()
+	if err != nil {
+		if errors.IsNotFound(err) {
+			setClusterCondition(corev1.ClusterConditionStatusInProgress, "pre-flight: has not started yet...")
+			logrus.Infof(condition.Message)
+			return nil
 		}
-	}()
+		err = fmt.Errorf("pre-flight: error getting pre-flight status: %v", err)
+		setClusterCondition(corev1.ClusterConditionStatusFailed, err.Error())
+		deletePreflight()
+		return err
+	}
 
-	cnt := 0
-	//  Wait for all the pre-flight pods to finish
-	for {
-		time.Sleep(3 * time.Second) // Pause before status check
-		completed, inProgress, total, err := preFlighter.GetPreFlightStatus()
-		if err != nil {
-			logrus.Errorf("pre-flight: error getting pre-flight status: %v", err)
+	progressStr := fmt.Sprintf("Completed [%v] In Progress [%v] Total [%v]", completed, inProgress, total)
+	logrus.Infof("pre-flight: %s", progressStr)
+	if total != 0 && completed == total {
+		logrus.Infof("pre-flight: checks completed...")
+	} else {
+		if age >= preFlightTimeOut {
+			err = fmt.Errorf("pre-flight: pre-flight check timed out")
+			setClusterCondition(corev1.ClusterConditionStatusTimeout, err.Error())
+			k8sutil.WarningEvent(p.recorder, cluster, util.FailedPreFlight, err.Error())
+			deletePreflight()
 			return err
 		}
-		logrus.Infof("pre-flight: Completed [%v] In Progress [%v] Total [%v]", completed, inProgress, total)
-
-		if total != 0 && completed == total {
-			logrus.Infof("pre-flight: completed...")
-			break
-		}
-
-		// Add five minute timeout.  If we do reconcile loop check we will need a different way.
-		cnt++
-		if cnt == 200 { // 3s * 100 = 300s (10 mins)
-			err = fmt.Errorf("pre-flight: pre-flight status check timed out")
-			logrus.Errorf("%v", err)
-			return err
-		}
+		setClusterCondition(corev1.ClusterConditionStatusInProgress,
+			fmt.Sprintf("pre-flight: Operation still in progress: %s", progressStr))
+		logrus.Infof(condition.Message)
+		return nil
 	}
 
 	// Process all the StorageNode.Status.Checks
 	var storageNodes []*corev1.StorageNode
 
 	storageNodes, err = p.storageNodesList(cluster)
-	if err == nil {
-		err = preFlighter.ProcessPreFlightResults(p.recorder, storageNodes)
-		if err != nil {
-			logrus.Errorf("pre-flight: Error processing results: %v", err)
-		}
-	} else {
-		logrus.Errorf("pre-flight incomplete: Error getting storage node list: %v", err)
+	if err != nil {
+		err = fmt.Errorf("pre-flight incomplete: Error getting storage node list: %v", err)
+		setClusterCondition(corev1.ClusterConditionStatusFailed, err.Error())
+		deletePreflight()
+		return err
 	}
 
-	return err
+	logrus.Infof("pre-flight: process pre-flight results...")
+	err = preFlighter.ProcessPreFlightResults(p.recorder, storageNodes)
+	if err != nil {
+		err = fmt.Errorf("pre-flight: Error processing results: %v", err)
+		setClusterCondition(corev1.ClusterConditionStatusFailed, err.Error())
+		deletePreflight()
+		return err
+	}
+
+	setClusterCondition(corev1.ClusterConditionStatusCompleted, "pre-flight: done...")
+	logrus.Infof(condition.Message)
+	deletePreflight()
+
+	return nil
 }
 
 func (p *portworx) initializeComponents() {

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -87,6 +87,9 @@ func TestValidate(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
 			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPreflightCheck: "true",
+			},
 		},
 	}
 
@@ -147,6 +150,7 @@ func TestValidate(t *testing.T) {
 		},
 	}
 
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	k8sClient := testutil.FakeK8sClient(preflightDS)
 
 	err := k8sClient.Create(context.TODO(), preFlightPod1)
@@ -223,6 +227,9 @@ func TestValidateCheckFailure(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
 			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPreflightCheck: "true",
+			},
 		},
 	}
 
@@ -288,6 +295,7 @@ func TestValidateCheckFailure(t *testing.T) {
 		},
 	}
 
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	k8sClient := testutil.FakeK8sClient(preflightDS)
 
 	err := k8sClient.Create(context.TODO(), preFlightPod1)
@@ -324,6 +332,9 @@ func TestValidateMissingRequiredCheck(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
 			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPreflightCheck: "true",
+			},
 		},
 	}
 
@@ -380,6 +391,7 @@ func TestValidateMissingRequiredCheck(t *testing.T) {
 		},
 	}
 
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	k8sClient := testutil.FakeK8sClient(preflightDS)
 
 	err := k8sClient.Create(context.TODO(), preFlightPod1)

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -9246,7 +9246,8 @@ func TestEKSPreflightCheck(t *testing.T) {
 	require.Equal(t, corev1.ClusterConditionStatusFailed, condition.Status)
 
 	// TestCase: without the permission fixed, preflight check should return error directly
-	errMsg = "please make sure your cluster meet all prerequisites and rerun preflight check"
+	errMsg = "FATAL: preflight checks have failed on your cluster.  " +
+		"Check events, logs and contact support to help make sure your cluster meets all prerequisites"
 	err = controller.runPreflightCheck(cluster)
 	require.Error(t, err)
 	require.Contains(t, errMsg, err.Error())
@@ -9259,15 +9260,21 @@ func TestEKSPreflightCheck(t *testing.T) {
 
 	// TestCase: fix the permission then rerun preflight
 	cluster.Annotations[pxutil.AnnotationPreflightCheck] = "true"
+	// Cloud drive permission check will only be checked once when the status condition is not set.
+	cluster.Status.Conditions = []corev1.ClusterCondition{}
 	preflightOps.EXPECT().CheckCloudDrivePermission(cluster).Return(nil)
 	err = controller.runPreflightCheck(cluster)
 	require.NoError(t, err)
 
+	// Pre-flight checks now contain DMthin checks which will not be executed unless cloud permission checks passes.
+	// Since the DMthin checks will not be  executed the condition returned will be 'ClusterConditionStatusInProgress'.
+	// This is good enough to determine if cloud permission is working. If it had failed DMthin would not be run and
+	// the condition would have been ClusterConditionStatusFailed.
 	err = testutil.Get(k8sClient, cluster, cluster.Name, cluster.Namespace)
 	require.NoError(t, err)
 	condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypePreflight)
 	require.NotNil(t, condition)
-	require.Equal(t, corev1.ClusterConditionStatusCompleted, condition.Status)
+	require.Equal(t, corev1.ClusterConditionStatusInProgress, condition.Status)
 }
 
 func TestStorageClusterStateDuringValidation(t *testing.T) {

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -409,57 +409,73 @@ func (c *Controller) validateCloudStorageLabelKey(cluster *corev1.StorageCluster
 	return nil
 }
 
-func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
+func isPreflightComplete(cluster *corev1.StorageCluster) bool {
+	// Check pre-check status
 	check, ok := cluster.Annotations[pxutil.AnnotationPreflightCheck]
 	check = strings.TrimSpace(strings.ToLower(check))
 	if !ok || check == "skip" {
-		return nil
+		return true
 	} else if check == "false" {
 		condition := util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypePreflight)
-		if condition != nil && condition.Status == corev1.ClusterConditionStatusFailed {
-			return fmt.Errorf("please make sure your cluster meet all prerequisites and rerun preflight check")
-		}
-		// preflight passed or not required
-		logrus.Infof("preflight check not required")
-		return nil
-	}
-
-	toUpdate := cluster.DeepCopy()
-	var err error
-
-	// Do the preflight check for eks only for now to check the cloud drive permission
-	if preflight.IsEKS() {
-		if err = preflight.Instance().CheckCloudDrivePermission(cluster); err != nil {
-			logrus.WithError(err).Errorf("permission check for eks cloud drive failed")
+		if condition != nil {
+			if condition.Status == corev1.ClusterConditionStatusCompleted {
+				return true
+			}
+		} else {
+			return true
 		}
 	}
-	// TODO: validate cloud permission for other providers as well
+	return false
+}
 
-	// Skip of over driver Validate() if an error has occurred
-	if err == nil {
-		// Create StorageNodes to return pre-flight checks used by c.Driver.Validate()
+func (c *Controller) driverValidate(toUpdate *corev1.StorageCluster) (*corev1.ClusterCondition, error) {
+	storageNodes := &corev1.StorageNodeList{}
+	serr := c.client.List(context.TODO(), storageNodes,
+		&client.ListOptions{Namespace: toUpdate.Namespace})
+	if serr == nil && len(storageNodes.Items) == 0 { // Only do if storageNodes don't exist
 		k8sNodeList := &v1.NodeList{}
-		err = c.client.List(context.TODO(), k8sNodeList)
+		err := c.client.List(context.TODO(), k8sNodeList)
 		if err == nil {
+			// Create StorageNodes to return pre-flight checks used by c.Driver.Validate().
 			for _, node := range k8sNodeList.Items {
 				if !coreops.Instance().IsNodeMaster(node) {
 					logrus.Infof("Create pre-flight storage node entry for node: %s", node.Name)
-					c.createStorageNode(cluster, node.Name)
+					c.createStorageNode(toUpdate, node.Name)
+				} else {
+					logrus.Infof("Skipping pre-flight storage node entry for master node: %s", node.Name)
 				}
 			}
 		} else {
 			logrus.WithError(err).Errorf("Failed to get cluster nodes")
+			// *** Should we just return an error on pre-flight here? ***
 		}
+	}
 
-		// Run driver specific pre-flights
-		err = c.Driver.Validate(toUpdate)
-		if err != nil {
-			logrus.WithError(err).Errorf("pre-flight validate failed")
-		}
+	defCondition := &corev1.ClusterCondition{ // set default InProgress condition
+		Source:  pxutil.PortworxComponentName,
+		Type:    corev1.ClusterConditionTypePreflight,
+		Message: "pre-flight: In progress",
+		Status:  corev1.ClusterConditionStatusInProgress,
+	}
 
+	// Run driver specific pre-flights
+	err := c.Driver.Validate(toUpdate)
+	if err != nil {
+		defCondition.Status = corev1.ClusterConditionStatusFailed // Update default condition on error
+		defCondition.Message = fmt.Sprintf("pre-flight: validate failed %v", err)
+		logrus.WithError(err).Errorf(defCondition.Message)
+	}
+
+	// Get condition set from Validate()
+	condition := util.GetStorageClusterCondition(toUpdate, pxutil.PortworxComponentName, corev1.ClusterConditionTypePreflight)
+	if condition == nil { // Set condition status set if was not in Validate()
+		condition = defCondition
+	}
+
+	if condition.Status != corev1.ClusterConditionStatusInProgress { // Status not in progress must be done or an issue occurred
 		// Delete StorageNodes created for c.Driver.Validate() checks.
-		storageNodes := &corev1.StorageNodeList{}
-		serr := c.client.List(context.TODO(), storageNodes,
+		storageNodes = &corev1.StorageNodeList{}
+		serr = c.client.List(context.TODO(), storageNodes,
 			&client.ListOptions{Namespace: toUpdate.Namespace})
 		if serr == nil {
 			for _, storageNode := range storageNodes.Items {
@@ -474,22 +490,76 @@ func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
 		}
 	}
 
-	// Only do the preflight check once
-	toUpdate.Annotations[pxutil.AnnotationPreflightCheck] = "false"
+	return condition, err
+}
 
-	condition := &corev1.ClusterCondition{
-		Source: pxutil.PortworxComponentName,
-		Type:   corev1.ClusterConditionTypePreflight,
+func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
+	check, ok := cluster.Annotations[pxutil.AnnotationPreflightCheck]
+	check = strings.TrimSpace(strings.ToLower(check))
+	if !ok || check == "skip" {
+		_ = c.Driver.Validate(cluster.DeepCopy())
+		return nil
+	} else if check == "false" {
+		condition := util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypePreflight)
+		if condition != nil && (condition.Status == corev1.ClusterConditionStatusFailed || condition.Status == corev1.ClusterConditionStatusTimeout) {
+			return fmt.Errorf("FATAL: preflight checks have failed on your cluster.  " +
+				"Check events, logs and contact support to help make sure your cluster meets all prerequisites")
+		}
+		// preflight passed or not required
+		logrus.Infof("preflight check not required")
+		return nil
+	}
+
+	// Only do the preflight check on demand once a time
+
+	var (
+		condition *corev1.ClusterCondition
+		err       error
+	)
+
+	defCondition := &corev1.ClusterCondition{ // set default InProgress condition
+		Source:  pxutil.PortworxComponentName,
+		Type:    corev1.ClusterConditionTypePreflight,
+		Message: "pre-flight: In progress",
+		Status:  corev1.ClusterConditionStatusInProgress,
+	}
+
+	// Do the preflight check for eks only for now to check the cloud drive permission
+	if preflight.IsEKS() {
+		//  Only executed once in 1st pre-flight loop cycle.  If preflight condition is not set its 1st time through  pre-flight loop
+		condition = util.GetStorageClusterCondition(cluster, pxutil.PortworxComponentName, corev1.ClusterConditionTypePreflight)
+		if condition == nil {
+			if err = preflight.Instance().CheckCloudDrivePermission(cluster); err != nil {
+				condition = defCondition
+				condition.Status = corev1.ClusterConditionStatusFailed
+				condition.Message = "permission check for eks cloud drive failed"
+				logrus.WithError(err).Errorf(condition.Message)
+			}
+		}
+	}
+
+	// TODO: validate cloud permission for other providers as well
+
+	toUpdate := cluster.DeepCopy()
+
+	// Skip over driver Validate() if an error has occurred
+	if err == nil {
+		condition, err = c.driverValidate(toUpdate)
+	}
+
+	if condition == nil {
+		condition = defCondition
 	}
 
 	if err != nil {
 		logrus.Errorf("storage cluster preflight check failed")
-		condition.Status = corev1.ClusterConditionStatusFailed
-		condition.Message = err.Error()
+		toUpdate.Annotations[pxutil.AnnotationPreflightCheck] = "false"
 	} else {
-		logrus.Infof("storage cluster preflight check passed")
-		condition.Status = corev1.ClusterConditionStatusCompleted
+		if condition.Status != corev1.ClusterConditionStatusInProgress {
+			toUpdate.Annotations[pxutil.AnnotationPreflightCheck] = "false"
+		}
 	}
+
 	util.UpdateStorageClusterCondition(toUpdate, condition)
 
 	// Update the cluster only if anything has changed
@@ -500,8 +570,14 @@ func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
 		}
 
 		cluster.Status = *toUpdate.Status.DeepCopy()
+
 		if err := c.client.Status().Update(context.TODO(), cluster); err != nil {
-			return fmt.Errorf("update storage cluster status failure, %v", err)
+			logrus.Errorf("preflight updateStorageClusterStatus failed trying again...")
+			if err := c.client.Status().Update(context.TODO(), cluster); err != nil {
+				k8s.WarningEvent(c.recorder, cluster, util.FailedPreFlight,
+					"preflight check failed to update storage cluster status. Need to rerun preflight or skip it")
+				return fmt.Errorf("update storage cluster status failure, %v", err)
+			}
 		}
 	}
 	return err
@@ -674,9 +750,12 @@ func (c *Controller) syncStorageCluster(
 		}
 	}
 
-	// General clean cause by previous issues
 	if err := c.miscCleanUp(cluster); err != nil {
 		return err
+	}
+
+	if !isPreflightComplete(cluster) {
+		return nil // not ready yet, continue
 	}
 
 	// Ensure Stork is deployed with right configuration


### PR DESCRIPTION
…er 15m. (#1070)

* PWX-28826 Boilerplace



* more boilerplate



* PWX-28826:  Pre-flight check for DMthin.



* PWX-28826: Add comments and move StorageNode cleanup.



* Passed checks should be Info events.



* Passed checks should be Info events. (#1010)



* Pwx 28826 (#1011)

* Pwx 28826 (#1012)

* PWX-28826: Update with the latest master changes. (#1013)

* Updating CSV to use 23.3.1 released image

* Update for 23.3.1 release

* Controller gen vendor



* PWX-29389 Add CRD for portworx diags collection



* PWX-29409: Ignore zones with no nodes (#1008)

In disaggregated mode, there could be zones in which no storage nodes
  might be present. Such a zone would make the maxSNPZ value to be 0.
  CHanging the behavior to ignore 0 nodes in a zone for maxSNPZ
  calculation.



---------








* Add PassPreFlight event tag and logging



* PWX-28826: Check status of portworx container in pre-flight pod and remove 'wait' code.



* PWX-28826: Fix unit test.



* PWX-28826: Fix unit test.



* PWX-28826: PR review changes and fix portworx_test.go UTs



* PWX-28826: fix gomack Validate calls.  Also comment out the two tests that don't work since Validate was removed from the controller.validate() func. PWX-30373 to try and fix later.



* PWX-30373: Re-add back in the commented out tests and add K8s version check failure to trigger the needed workflow.



* PWX-28826: Exit pre-check wait if running CBT namespace.



* PWX-28826: Add 5 min timeout to pre-flight status check.



* PWX-28826: Exit GetPreFlightStatus() with success if running CBT namespace.



* PWX-28826: Don't automatically enable dmthin via pre-flight check if running CBT namespace.



* PWX-30373: Revert UT and integration test hacks.  Need to mock the functionality correctly.



* PWX-28826: Increase pre-flight daemonset ready wait to 10mins.



* PWX-28826: fix 'TestValidate' UT.  Don't error if pre-flight daemonset exists.



* Use reconcile loop to check pre-flight status.  Timeout after 15m.



* PWX-28826: Startup check was not handling if preflight was not enabled.



* PWX-28826: Re-enable preflight for integration tests.



* PWX-28826: disable preflight for integration tests.



* PWX-28826: Only do preflight if AWS.



* PWX-30496: if '-T dmthin' exists in stc before preflight is ran and preflight fails don't start.  Add default metadata dev for dmthin if it does not exist.



* PWX-28826: Use condition set to determine of CheckCloudDrivePermission check is to be run. Handle skip annotation and pod cleanup.



* PWX-28826: Remove debug logging



* PWX-30419:  Remove more debug logging.



* PWX-30419: Revert to correct version.



* PWX-30419: Fix unit test.  Need to enable pre-flight.



* PWX-30419: Fix TestEKSPreflightCheck unit test. Pre-flight now includes DMthin checks so need to handle that.



* update from master, conflict fix.

* PWX-28826: Use cluster condition to determine pre-flight status.



* PWX-28826: return cluster condition from driverValidate as that to determin status..



* Add err message to default condition message and make sure to use default condition on CloudDrivePermission error.



* PWX-28826: Add a constant for pre-flight timeout value.



* PWX-28826: pre-flight timeout should prevent startup.  Add event for timeout.



* PWX-28826: Fix unit tests.



* PWX-28826: Use progress string.



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-30419
**Special notes for your reviewer**:

Merge from master.