### PR TITLE
PWX-32800: ignore proxy's root CA cert for now

### DIFF
--- a/drivers/storage/portworx/manifest/common.go
+++ b/drivers/storage/portworx/manifest/common.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"crypto/tls"
 	"io"
 	"net/http"
 	"net/url"
@@ -44,6 +45,9 @@ func getManifestFromURL(manifestURL string, proxy string) ([]byte, error) {
 
 		client := &http.Client{
 			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
 				Proxy: http.ProxyURL(proxyURL),
 			},
 		}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Currently operator fails to refresh all components' image tags due to not able to access manifest host and has to fall back to default tags. This will introduce two issues:
1. our torpedo jobs will perform the version check for all images and this mismatch (default vs actual from manifest) will break those jobs
2. when customers use this operator to deploy px, they'll get the default (usually obsolete) images instead of the ones corresponding to the px version that they want

Operator fails due to it's using HTTPS proxy to access the manifest url without the proxy's root CA cert. Since current release is not intended to use cert but instead use basic authentication (user, password) of the proxy, ignore the requirement for now and will introduce proxy's CA cert as part of operator's trusted CA store along with corresponding changes inside envoy config in the next release

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

