### PR TITLE
PWX-32850: When preflight is unsupported we need to make sure we are …

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -748,12 +748,11 @@ func (c *Controller) syncStorageCluster(
 			return fmt.Errorf("preflight check failed for StorageCluster %v/%v: %v", cluster.Namespace, cluster.Name, err)
 		}
 	} else {
-		if _, exists := cluster.Annotations[pxutil.AnnotationPreflightCheck]; !exists {
-			if cluster.Annotations == nil {
-				cluster.Annotations = make(map[string]string)
-			}
-			cluster.Annotations[pxutil.AnnotationPreflightCheck] = "false"
+		// Always disable preflight if not supported.
+		if cluster.Annotations == nil {
+			cluster.Annotations = make(map[string]string)
 		}
+		cluster.Annotations[pxutil.AnnotationPreflightCheck] = "false"
 	}
 
 	if err := c.miscCleanUp(cluster); err != nil {


### PR DESCRIPTION
…setting the pre-flight annotation to false.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
When preflight was not supposed to be run.   We were only setting the annotation to false when the annotation did not exist.  Problem here was it existed and was set to "true".    This prevented the cluster configuration changes from being applied since it continually though preflight should be run.      The fix is to make sure preflight annotation is set to false when pre-flight is not supported.  
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-32850
**Special notes for your reviewer**:

