### PR TITLE
fixup for https proxy with basic authn

### DIFF
--- a/deploy/ccm/envoy-config-collector-custom-https-proxy.yaml
+++ b/deploy/ccm/envoy-config-collector-custom-https-proxy.yaml
@@ -184,8 +184,3 @@ static_resources:
               socket_address:
                 address: CUSTOM_PROXY_ADDRESS
                 port_value: CUSTOM_PROXY_PORT
-    transport_socket:
-      name: envoy.transport_sockets.tls
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        sni: CUSTOM_PROXY_ADDRESS

--- a/deploy/ccm/envoy-config-register-custom-https-proxy.yaml
+++ b/deploy/ccm/envoy-config-register-custom-https-proxy.yaml
@@ -182,8 +182,3 @@ static_resources:
               socket_address:
                 address: CUSTOM_PROXY_ADDRESS
                 port_value: CUSTOM_PROXY_PORT
-    transport_socket:
-      name: envoy.transport_sockets.tls
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        sni: CUSTOM_PROXY_ADDRESS

--- a/deploy/ccm/envoy-config-rest-custom-https-proxy.yaml
+++ b/deploy/ccm/envoy-config-rest-custom-https-proxy.yaml
@@ -178,8 +178,3 @@ static_resources:
               socket_address:
                 address: CUSTOM_PROXY_ADDRESS
                 port_value: CUSTOM_PROXY_PORT
-    transport_socket:
-      name: envoy.transport_sockets.tls
-      typed_config:
-        "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-        sni: CUSTOM_PROXY_ADDRESS

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -1059,14 +1059,8 @@ func CanAccessArcusRegisterEndpoint(
 	}
 	client := &http.Client{}
 	if proxy != "" {
-		if strings.Contains(strings.ToLower(proxy), "@") {
-			if !strings.HasPrefix(strings.ToLower(proxy), "https://") {
-				proxy = "https://" + proxy
-			}
-		} else {
-			if !strings.HasPrefix(strings.ToLower(proxy), "http://") {
-				proxy = "http://" + proxy
-			}
+		if !strings.HasPrefix(strings.ToLower(proxy), "http://") {
+			proxy = "http://" + proxy
 		}
 		proxyURL, err := url.Parse(proxy)
 		if err != nil {

--- a/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap_httpsproxy.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorProxyConfigMap_httpsproxy.yaml
@@ -196,8 +196,3 @@ data:
                   socket_address:
                     address: hostname
                     port_value: 1234
-        transport_socket:
-          name: envoy.transport_sockets.tls
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-            sni: hostname

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeProxyConfigMap_httpsproxy.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeProxyConfigMap_httpsproxy.yaml
@@ -190,8 +190,3 @@ data:
                   socket_address:
                     address: hostname
                     port_value: 1234
-        transport_socket:
-          name: envoy.transport_sockets.tls
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-            sni: hostname

--- a/drivers/storage/portworx/testspec/ccmGoRegisterProxyConfigMap_httpsproxy.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterProxyConfigMap_httpsproxy.yaml
@@ -194,8 +194,3 @@ data:
                   socket_address:
                     address: hostname
                     port_value: 1234
-        transport_socket:
-          name: envoy.transport_sockets.tls
-          typed_config:
-            "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-            sni: hostname

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -709,12 +709,6 @@ func GetPxProxyEnvVarValue(cluster *corev1.StorageCluster) (string, string) {
 	for _, env := range cluster.Spec.Env {
 		key, val := env.Name, env.Value
 		if key == EnvKeyPortworxHTTPSProxy {
-			// If http proxy is specified in https env var, treat it as a http proxy endpoint
-			if strings.HasPrefix(val, "http://") {
-				logrus.Warnf("using endpoint %s from environment variable %s as a http proxy endpoint instead",
-					val, EnvKeyPortworxHTTPSProxy)
-				return EnvKeyPortworxHTTPProxy, val
-			}
 			return EnvKeyPortworxHTTPSProxy, val
 		} else if key == EnvKeyPortworxHTTPProxy {
 			httpProxy = val

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -3484,14 +3484,8 @@ func CanAccessArcusRegisterEndpoint(
 
 	client := &http.Client{}
 	if proxy != "" {
-		if strings.Contains(strings.ToLower(proxy), "@") {
-			if !strings.HasPrefix(strings.ToLower(proxy), "https://") {
-				proxy = "https://" + proxy
-			}
-		} else {
-			if !strings.HasPrefix(strings.ToLower(proxy), "http://") {
-				proxy = "http://" + proxy
-			}
+		if !strings.HasPrefix(strings.ToLower(proxy), "http://") {
+			proxy = "http://" + proxy
 		}
 		proxyURL, err := url.Parse(proxy)
 		if err != nil {
@@ -3553,12 +3547,6 @@ func GetPxProxyEnvVarValue(cluster *corev1.StorageCluster) (string, string) {
 	for _, env := range cluster.Spec.Env {
 		key, val := env.Name, env.Value
 		if key == EnvKeyPortworxHTTPSProxy {
-			// If http proxy is specified in https env var, treat it as a http proxy endpoint
-			if strings.HasPrefix(val, "http://") {
-				logrus.Warnf("Using endpoint [%s] from environment variable [%s] as a http proxy endpoint instead",
-					val, EnvKeyPortworxHTTPSProxy)
-				return EnvKeyPortworxHTTPProxy, val
-			}
 			return EnvKeyPortworxHTTPSProxy, val
 		} else if key == EnvKeyPortworxHTTPProxy {
 			httpProxy = val


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The previous implementation of using basic auth for https proxy was based on a wrong assumption that this https proxy also needs to be SSL-enabled (with https:// prefix/protocol). 

Removing them because https proxy can also be non-SSL enabled (http://) and also no TLS context is required in envoy config for this case.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

