### PR TITLE
PWX-32976: Backport for 2.13.8

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -112,11 +112,11 @@ const (
 	stagingArcusRegisterProxyURL    = "register.staging-cloud-support.purestorage.com"
 
 	// Ports for telemetry components
-	defaultCCMListeningPort          = 9024
-	defaultCCMListeningPortForPXge30 = 9029
-	defaultCollectorPort             = 10000
-	defaultRegisterPort              = 12001
-	defaultPhonehomePort             = 12002
+	defaultCCMListeningPort            = 9024
+	defaultCCMListeningPortForPXge2138 = 9029
+	defaultCollectorPort               = 10000
+	defaultRegisterPort                = 12001
+	defaultPhonehomePort               = 12002
 
 	arcusPingInterval = 6 * time.Second
 	arcusPingRetry    = 5
@@ -1210,9 +1210,9 @@ func readConfigMapDataFromFile(
 func GetCCMListeningPort(cluster *corev1.StorageCluster) int {
 	defCCMPort := defaultCCMListeningPort
 
-	pxVer30, _ := version.NewVersion("3.0")
-	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
-		defCCMPort = defaultCCMListeningPortForPXge30
+	pxVer2138, _ := version.NewVersion("2.13.8")
+	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer2138) {
+		defCCMPort = defaultCCMListeningPortForPXge2138
 	}
 
 	startPort := pxutil.StartPort(cluster)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
In order for the telemetry port change to work on 2.13.8, we need to update the version check as in this PR and cherry-pick the change to newer op release branches (23.5.2 and 23.7.0)

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

