### PR TITLE
PWX-32976: need to set telemetry port to 9029 if px >= 2.13.8

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -112,11 +112,11 @@ const (
 	stagingArcusRegisterProxyURL    = "register.staging-cloud-support.purestorage.com"
 
 	// Ports for telemetry components
-	defaultCCMListeningPort          = 9024
-	defaultCCMListeningPortForPXge30 = 9029
-	defaultCollectorPort             = 10000
-	defaultRegisterPort              = 12001
-	defaultPhonehomePort             = 12002
+	defaultCCMListeningPort            = 9024
+	defaultCCMListeningPortForPXge2138 = 9029
+	defaultCollectorPort               = 10000
+	defaultRegisterPort                = 12001
+	defaultPhonehomePort               = 12002
 
 	arcusPingInterval = 6 * time.Second
 	arcusPingRetry    = 5
@@ -1210,9 +1210,9 @@ func readConfigMapDataFromFile(
 func GetCCMListeningPort(cluster *corev1.StorageCluster) int {
 	defCCMPort := defaultCCMListeningPort
 
-	pxVer30, _ := version.NewVersion("3.0")
-	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
-		defCCMPort = defaultCCMListeningPortForPXge30
+	pxVer2138, _ := version.NewVersion("2.13.8")
+	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer2138) {
+		defCCMPort = defaultCCMListeningPortForPXge2138
 	}
 
 	startPort := pxutil.StartPort(cluster)

--- a/drivers/storage/portworx/component/telemetry_test.go
+++ b/drivers/storage/portworx/component/telemetry_test.go
@@ -1,0 +1,49 @@
+package component
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockPxUtil struct {
+	mock.Mock
+}
+
+func (m *MockPxUtil) GetPortworxVersion(cluster *corev1.StorageCluster) *version.Version {
+	args := m.Called(cluster)
+	return args.Get(0).(*version.Version)
+}
+
+func (m *MockPxUtil) StartPort(cluster *corev1.StorageCluster) int {
+	args := m.Called(cluster)
+	return args.Int(0)
+}
+
+func TestGetCCMListeningPort(t *testing.T) {
+	// Create a mock pxutil instance
+	mockPxUtil := new(MockPxUtil)
+
+	// Set up expectations for GetPortworxVersion method
+	ver2138, _ := version.NewVersion("2.13.8")
+	mockPxUtil.On("GetPortworxVersion", mock.AnythingOfType("*v1.StorageCluster")).Return(ver2138)
+
+	// Set up expectations for StartPort method
+	mockPxUtil.On("StartPort", mock.AnythingOfType("*v1.StorageCluster")).Return(pxutil.DefaultStartPort)
+
+	// Create a sample StorageCluster instance
+	cluster := &corev1.StorageCluster{}
+
+	// Call the function being tested
+	listeningPort := GetCCMListeningPort(cluster)
+
+	// Define expected result
+	expectedPort := defaultCCMListeningPortForPXge2138
+
+	// Assert that the function returns the expected result
+	assert.Equal(t, expectedPort, listeningPort)
+}


### PR DESCRIPTION
* modified px version check

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We're backporting a change to 2.13.8 so that the default telemetry port changes to 9029 and porx can dynamically load and find the port value specified by operator from mounted ccm.properties file

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

