### PR TITLE
PWX-32825: Adjusting version triggers for px-3.0.1

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -55,7 +55,7 @@ var (
 	pxVer2_8, _    = version.NewVersion("2.8")
 	pxVer2_9_1, _  = version.NewVersion("2.9.1")
 	pxVer2_13_8, _ = version.NewVersion("2.13.8")
-	pxVer3_0_1, _  = version.NewVersion("3.0.1")
+	pxVer3_0, _    = version.NewVersion("3.0")
 )
 
 type volumeInfo struct {
@@ -302,9 +302,9 @@ func (p *portworx) GetStoragePodSpec(
 	}
 
 	if _, has := t.cluster.Annotations[pxutil.AnnotationIsPrivileged]; has {
-		if pxutil.GetPortworxVersion(cluster).LessThan(pxVer3_0_1) {
-			err = fmt.Errorf("failed to create pod spec: need portworx %s or higher to use annotation '%s'",
-				pxVer3_0_1, pxutil.AnnotationIsPrivileged)
+		if pxutil.GetPortworxVersion(cluster).LessThanOrEqual(pxVer3_0) {
+			err = fmt.Errorf("failed to create pod spec: need portworx higher than %s to use annotation '%s'",
+				pxVer3_0, pxutil.AnnotationIsPrivileged)
 			return v1.PodSpec{}, err
 		}
 	}
@@ -1040,7 +1040,7 @@ func (t *template) getArguments() []string {
 		args = append(args, "--log", t.cluster.Annotations[pxutil.AnnotationLogFile])
 	}
 	// for non-privileged and PKS, add shared mounts via parameters
-	if t.pxVersion.GreaterThanOrEqual(pxVer3_0_1) &&
+	if t.pxVersion.GreaterThan(pxVer3_0) &&
 		(!pxutil.IsPrivileged(t.cluster) || pxutil.IsPKS(t.cluster)) {
 		args = append(args,
 			"-v", "/var/lib/osd/pxns:/var/lib/osd/pxns:shared",
@@ -1158,7 +1158,7 @@ func (t *template) getEnvList() []v1.EnvVar {
 
 	if t.isPKS {
 		ev := "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi"
-		if t.pxVersion.GreaterThanOrEqual(pxVer3_0_1) {
+		if t.pxVersion.GreaterThan(pxVer3_0) {
 			ev = "rm -fr /var/lib/osd/driver"
 		}
 		envMap["PRE-EXEC"] = &v1.EnvVar{
@@ -1858,7 +1858,7 @@ func getDefaultVolumeInfoList(pxVersion *version.Version) []volumeInfo {
 func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 	list := make([]volumeInfo, 0)
 
-	if pxVersion.GreaterThanOrEqual(pxVer3_0_1) {
+	if pxVersion.GreaterThan(pxVer3_0) {
 		list = append(list, volumeInfo{
 			name:             "varlibosd",
 			hostPath:         "/var/lib/osd",

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2778,7 +2778,7 @@ func TestOpenshiftRuncPodSpec(t *testing.T) {
 
 	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "need portworx 3.0.1 or higher to use annotation '"+
+	assert.Contains(t, err.Error(), "need portworx higher than 3.0.0 to use annotation '"+
 		pxutil.AnnotationIsPrivileged+"'")
 
 	cluster.Spec.Image = "portworx/oci-monitor:3.0.1"
@@ -2808,6 +2808,15 @@ func TestOpenshiftRuncPodSpec(t *testing.T) {
 	for _, v := range actual.Containers[0].VolumeMounts {
 		assert.Nil(t, v.MountPropagation, "Wrong propagation on %v", v)
 	}
+
+	// PWX-32825 tweak the 3.0.1 version slightly -- should still evaluate the same
+	cluster.Spec.Image = "portworx/oci-monitor:3.0.1-ubuntu1604"
+	expected_3_0_1.Containers[0].Image = "docker.io/" + cluster.Spec.Image
+
+	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
+	require.NoError(t, err)
+
+	assertPodSpecEqual(t, expected_3_0_1, &actual)
 }
 
 func TestPodSpecForK3s(t *testing.T) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

ISSUE:
* our QA used image-override `3.0.1-ubuntu1604` -- and this BROKE the version-checks

```go
NewVersion("3.0.1-ubuntu1604").GreaterThanOrEqual("3.0.1")  // this evaluates as FALSE!!
```
* note, the "version with extension" (such as `3.0.1-ubuntu1604`), will evaluate similar like `3.0.1.1` (a version _higher_ than `3.0.1`)

FIX:
* as a fix, we're changing the `version.GreaterThanOrEqual("3.0.1")` into `version.GreaterThan("3.0")`

**Which issue(s) this PR fixes** (optional)
Closes # PWX-32825

**Special notes for your reviewer**:

