### PR TITLE
PWX-32976: need to set telemetry port to 9029 if px >= 2.13.8

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -106,11 +106,11 @@ const (
 	stagingArcusRegisterProxyURL    = "register.staging-cloud-support.purestorage.com"
 
 	// Ports for telemetry components
-	defaultCCMListeningPort          = 9024
-	defaultCCMListeningPortForPXge30 = 9029
-	defaultCollectorPort             = 10000
-	defaultRegisterPort              = 12001
-	defaultPhonehomePort             = 12002
+	defaultCCMListeningPort            = 9024
+	defaultCCMListeningPortForPXge2138 = 9029
+	defaultCollectorPort               = 10000
+	defaultRegisterPort                = 12001
+	defaultPhonehomePort               = 12002
 
 	arcusPingInterval = 6 * time.Second
 	arcusPingRetry    = 5
@@ -1179,9 +1179,9 @@ func readConfigMapDataFromFile(
 func getCCMListeningPort(cluster *corev1.StorageCluster) int {
 	defCCMPort := defaultCCMListeningPort
 
-	pxVer30, _ := version.NewVersion("3.0")
-	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
-		defCCMPort = defaultCCMListeningPortForPXge30
+	pxVer2138, _ := version.NewVersion("2.13.8")
+	if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer2138) {
+		defCCMPort = defaultCCMListeningPortForPXge2138
 	}
 
 	startPort := pxutil.StartPort(cluster)


### PR DESCRIPTION
* modified px version check

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We're backporting a change to 2.13.8 so that the default telemetry port changes to 9029 and porx can dynamically load and find the port value specified by operator from mounted ccm.properties file

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

