### PR TITLE
PWX-32976: need to mount ccm config for 2.13.8 as well

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -49,13 +49,14 @@ const (
 )
 
 var (
-	pxVer2_3_2, _ = version.NewVersion("2.3.2")
-	pxVer2_5_5, _ = version.NewVersion("2.5.5")
-	pxVer2_6, _   = version.NewVersion("2.6")
-	pxVer2_8, _   = version.NewVersion("2.8")
-	pxVer2_9_1, _ = version.NewVersion("2.9.1")
-	pxVer3_0, _   = version.NewVersion("3.0")
-	pxVer3_0_1, _ = version.NewVersion("3.0.1")
+	pxVer2_3_2, _  = version.NewVersion("2.3.2")
+	pxVer2_5_5, _  = version.NewVersion("2.5.5")
+	pxVer2_6, _    = version.NewVersion("2.6")
+	pxVer2_8, _    = version.NewVersion("2.8")
+	pxVer2_9_1, _  = version.NewVersion("2.9.1")
+	pxVer2_13_8, _ = version.NewVersion("2.13.8")
+	pxVer3_0, _    = version.NewVersion("3.0")
+	pxVer3_0_1, _  = version.NewVersion("3.0.1")
 )
 
 type volumeInfo struct {
@@ -1320,7 +1321,7 @@ func (t *template) getVolumeMounts() []v1.VolumeMount {
 	if t.cluster.Annotations != nil {
 		preFltCheck = strings.TrimSpace(strings.ToLower(t.cluster.Annotations[pxutil.AnnotationPreflightCheck]))
 	}
-	if t.pxVersion.GreaterThanOrEqual(pxVer3_0) && preFltCheck != "true" {
+	if t.pxVersion.GreaterThanOrEqual(pxVer2_13_8) && preFltCheck != "true" {
 		extensions = append(extensions, t.getTelemetryPhoneHomeVolumeInfoList)
 	}
 	for _, fn := range extensions {
@@ -1406,7 +1407,7 @@ func (t *template) getVolumes() []v1.Volume {
 	if t.cluster.Annotations != nil {
 		preFltCheck = strings.TrimSpace(strings.ToLower(t.cluster.Annotations[pxutil.AnnotationPreflightCheck]))
 	}
-	if t.pxVersion.GreaterThanOrEqual(pxVer3_0) && preFltCheck != "true" {
+	if t.pxVersion.GreaterThanOrEqual(pxVer2_13_8) && preFltCheck != "true" {
 		extensions = append(extensions, t.getTelemetryPhoneHomeVolumeInfoList)
 	}
 

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -55,7 +55,6 @@ var (
 	pxVer2_8, _    = version.NewVersion("2.8")
 	pxVer2_9_1, _  = version.NewVersion("2.9.1")
 	pxVer2_13_8, _ = version.NewVersion("2.13.8")
-	pxVer3_0, _    = version.NewVersion("3.0")
 	pxVer3_0_1, _  = version.NewVersion("3.0.1")
 )
 

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -3098,7 +3098,7 @@ func TestPodWithTelemetryCCMVolume(t *testing.T) {
 			Namespace: "kube-system",
 		},
 		Spec: corev1.StorageClusterSpec{
-			Image: "portworx/oci-monitor:2.8.0",
+			Image: "portworx/oci-monitor:2.13.7",
 			Monitoring: &corev1.MonitoringSpec{
 				Telemetry: &corev1.TelemetrySpec{
 					Enabled: true,
@@ -3139,7 +3139,7 @@ func TestPodWithTelemetryCCMVolume(t *testing.T) {
 	assert.False(t, hasCCMVol || hasCCMVolMount)
 
 	// Then upgrade the cluster to 3.0 and obtain the new pod spec
-	cluster.Spec.Image = "portworx/oci-monitor:3.0.0"
+	cluster.Spec.Image = "portworx/oci-monitor:2.13.8"
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
previous [PR](https://github.com/libopenstorage/operator/pull/1204) only updated the version check for shifting the port to 9029 when px is 2.13.8, but operator also needs to allow volume mount of ccm.properties file to porx container otherwise oci-mon won't be able to find it and copy to /etc/pwx for porx' diag calls

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

