### PR TITLE
PWX-33085, PWX-33086 : Add linux nodeaffinity for operator 

### DIFF
--- a/deploy/olm-catalog/portworx/23.7.1/portworx-certified.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/23.7.1/portworx-certified.clusterserviceversion.yaml
@@ -216,6 +216,10 @@ spec:
                         operator: In
                         values:
                         - portworx-operator
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                          - "linux"
                     topologyKey: kubernetes.io/hostname
               containers:
               - name: portworx-operator

--- a/deploy/olm-catalog/portworx/23.7.1/portworx-certified.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/23.7.1/portworx-certified.clusterserviceversion.yaml
@@ -216,10 +216,14 @@ spec:
                         operator: In
                         values:
                         - portworx-operator
-                      - key: kubernetes.io/os
-                        operator: In
-                        values:
-                          - "linux"
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                      - matchExpressions:
+                          - key: kubernetes.io/os
+                            operator: In
+                            values:
+                              - "linux"
                     topologyKey: kubernetes.io/hostname
               containers:
               - name: portworx-operator

--- a/deploy/olm-catalog/portworx/23.7.1/portworx-certified.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/23.7.1/portworx-certified.clusterserviceversion.yaml
@@ -216,15 +216,15 @@ spec:
                         operator: In
                         values:
                         - portworx-operator
+                    topologyKey: kubernetes.io/hostname
                 nodeAffinity:
                   requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                      - matchExpressions:
-                          - key: kubernetes.io/os
-                            operator: In
-                            values:
-                              - "linux"
-                    topologyKey: kubernetes.io/hostname
+                  - labelSelector:
+                      matchExpressions:
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                          - linux
               containers:
               - name: portworx-operator
                 image: docker.io/portworx/px-operator:23.7.1-dev

--- a/drivers/storage/portworx/component/windows.go
+++ b/drivers/storage/portworx/component/windows.go
@@ -34,6 +34,7 @@ const (
 
 type windows struct {
 	client             client.Client
+	k8sVersion         *version.Version
 	isCsiCreated       bool
 	isInstallerCreated bool
 	isWindowsNode      bool
@@ -41,11 +42,12 @@ type windows struct {
 
 func (w *windows) Initialize(
 	k8sClient client.Client,
-	_ version.Version,
+	k8sVersion version.Version,
 	scheme *runtime.Scheme,
 	recorder record.EventRecorder,
 ) {
 	w.client = k8sClient
+	w.k8sVersion = &k8sVersion
 }
 
 func (w *windows) Name() string {
@@ -68,7 +70,7 @@ func (w *windows) IsEnabled(cluster *corev1.StorageCluster) bool {
 	}
 
 	w.isWindowsNode = isWindowsNode(nodeList)
-	return w.isWindowsNode
+	return w.isWindowsNode && w.k8sVersion.GreaterThanOrEqual(k8s.K8sVer1_25)
 }
 
 func (w *windows) Reconcile(cluster *corev1.StorageCluster) error {


### PR DESCRIPTION
This PR fixes : 
1. https://portworx.atlassian.net/browse/PWX-33085
Operator pod is being scheduled randomly on linux or windows node. The pod should always be scheduled on linux node.

3. https://portworx.atlassian.net/browse/PWX-33086
Windows daemonset should be created for minimum k8s version 1.25 and RH 4.12

Tests done : 
1. Tested on cluster with 2 windows node
2. Tested on cluster with k8s version 1.24 and 1.25

