### PR TITLE
PWX-33087 : CsiWindowsDriver image is not populating is storagecluster desired images

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -3828,7 +3828,7 @@ spec:
                   csiLivenessProbe:
                     type: string
                     description: Desired image for Liveness probe.
-                  csiDriverWin:
+                  csiWindowsDriver:
                     type: string
                     description: Desired image for csi driver for windows.
                   csiDriverRegistrar:

--- a/deploy/olm-catalog/portworx/23.7.1/portworx-certified.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/23.7.1/portworx-certified.clusterserviceversion.yaml
@@ -210,21 +210,21 @@ spec:
               affinity:
                 podAntiAffinity:
                   requiredDuringSchedulingIgnoredDuringExecution:
-                  - labelSelector:
-                      matchExpressions:
-                      - key: name
-                        operator: In
-                        values:
-                        - portworx-operator
-                    topologyKey: kubernetes.io/hostname
+                    - labelSelector:
+                        matchExpressions:
+                          - key: name
+                            operator: In
+                            values:
+                              - portworx-operator
+                      topologyKey: kubernetes.io/hostname
                 nodeAffinity:
                   requiredDuringSchedulingIgnoredDuringExecution:
-                  - labelSelector:
-                      matchExpressions:
-                      - key: kubernetes.io/os
-                        operator: In
-                        values:
-                          - linux
+                    nodeSelectorTerms:
+                      - matchExpressions:
+                          - key: kubernetes.io/os
+                            operator: In
+                            values:
+                              - linux
               containers:
               - name: portworx-operator
                 image: docker.io/portworx/px-operator:23.7.1-dev

--- a/deploy/windows/px-csi-node-win.yaml
+++ b/deploy/windows/px-csi-node-win.yaml
@@ -79,23 +79,11 @@ spec:
               name: registration-dir
       dnsPolicy: ClusterFirst
       hostNetwork: true
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - windows
       priorityClassName: system-node-critical
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
-      tolerations:
-      - key: os
-        value: Windows
       volumes:
         - hostPath:
             path: 'C:\var\lib\kubelet\plugins_registry\'

--- a/drivers/storage/portworx/component/windows.go
+++ b/drivers/storage/portworx/component/windows.go
@@ -222,8 +222,8 @@ func (w *windows) getDesiredLivenessImage(cluster *corev1.StorageCluster) string
 
 func (w *windows) getDesiredInstallerImage(cluster *corev1.StorageCluster) string {
 	var imageName string
-	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.CsiWinDriver != "" {
-		imageName = cluster.Status.DesiredImages.CsiWinDriver
+	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.CsiWindowsDriver != "" {
+		imageName = cluster.Status.DesiredImages.CsiWindowsDriver
 	}
 	imageName = util.GetImageURN(cluster, imageName)
 	return imageName

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -92,7 +92,7 @@ type Release struct {
 	DynamicPlugin              string `yaml:"dynamicPlugin,omitempty"`
 	DynamicPluginProxy         string `yaml:"dynamicPluginProxy,omitempty"`
 	CsiLivenessProbe           string `yaml:"csiLivenessProbe,omitempty"`
-	CsiWinDriver               string `yaml:"csiWinDriver,omitempty"`
+	CsiWindowsDriver           string `yaml:"csiWindowsDriver,omitempty"`
 }
 
 // Version is the response structure from a versions source
@@ -285,7 +285,7 @@ func fillCSIDefaults(
 	rel.Components.CSISnapshotController = csiImages.SnapshotController
 	rel.Components.CSIHealthMonitorController = csiImages.HealthMonitorController
 	rel.Components.CsiLivenessProbe = csiImages.LivenessProbe
-	rel.Components.CsiWinDriver = csiImages.CsiDriverInstaller
+	rel.Components.CsiWindowsDriver = csiImages.CsiDriverInstaller
 }
 
 func fillPrometheusDefaults(

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -395,7 +395,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 				toUpdate.Status.DesiredImages.CSISnapshotter = release.Components.CSISnapshotter
 				toUpdate.Status.DesiredImages.CSIHealthMonitorController = release.Components.CSIHealthMonitorController
 				toUpdate.Status.DesiredImages.CsiLivenessProbe = release.Components.CsiLivenessProbe
-				toUpdate.Status.DesiredImages.CsiWinDriver = release.Components.CsiWinDriver
+				toUpdate.Status.DesiredImages.CsiWindowsDriver = release.Components.CsiWindowsDriver
 			}
 			if autoUpdateCSISnapshotController(toUpdate) &&
 				(toUpdate.Status.DesiredImages.CSISnapshotController == "" ||

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2191,8 +2191,8 @@ func TestStorageClusterDefaultsForWindows(t *testing.T) {
 
 	err := driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
-	require.Equal(t, cluster.Status.DesiredImages.CsiWinDriver, "docker.io/portworx/pxwincsidriver:v0.1")
-	require.Equal(t, cluster.Status.DesiredImages.CsiLivenessProbe, "registry.k8s.io/sig-storage/livenessprobe:v2.7.0")
+	require.Equal(t, cluster.Status.DesiredImages.CsiWindowsDriver, "docker.io/portworx/px-windows-csi-driver:v0.1")
+	require.Equal(t, cluster.Status.DesiredImages.CsiLivenessProbe, "registry.k8s.io/sig-storage/livenessprobe:v2.10.0")
 	require.Equal(t, cluster.Status.DesiredImages.CSIDriverRegistrar, "quay.io/k8scsi/driver-registrar:v1.2.3")
 
 }
@@ -8554,8 +8554,8 @@ func (m *fakeManifest) GetVersions(
 			TelemetryProxy:             "purestorage/envoy:1.2.3",
 			DynamicPlugin:              "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:         "nginxinc/nginx-unprivileged:1.23",
-			CsiLivenessProbe:           "registry.k8s.io/sig-storage/livenessprobe:v2.7.0",
-			CsiWinDriver:               "docker.io/portworx/pxwincsidriver:v0.1",
+			CsiLivenessProbe:           "registry.k8s.io/sig-storage/livenessprobe:v2.10.0",
+			CsiWindowsDriver:           "docker.io/portworx/px-windows-csi-driver:v0.1",
 		},
 	}
 	if m.k8sVersion != nil && m.k8sVersion.GreaterThanOrEqual(k8sutil.K8sVer1_22) {

--- a/drivers/storage/portworx/testspec/px-csi-node-win.yaml
+++ b/drivers/storage/portworx/testspec/px-csi-node-win.yaml
@@ -25,7 +25,7 @@ spec:
               value: 'unix://C:\\csi\\csi.sock'
           imagePullPolicy: IfNotPresent
           name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.7.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
           resources:
             limits:
               memory: 100Mi

--- a/drivers/storage/portworx/testspec/px-csi-node-win.yaml
+++ b/drivers/storage/portworx/testspec/px-csi-node-win.yaml
@@ -67,7 +67,6 @@ spec:
             timeoutSeconds: 30
           name: node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.3
-
           resources:
             limits:
               memory: 100Mi
@@ -99,9 +98,6 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 30
-      tolerations:
-        - key: os
-          value: Windows
       volumes:
         - hostPath:
             path: 'C:\var\lib\kubelet\plugins_registry\'

--- a/drivers/storage/portworx/testspec/px-csi-win-driver.yaml
+++ b/drivers/storage/portworx/testspec/px-csi-win-driver.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: portworx
       containers:
         - name: windowsinstaller
-          image: docker.io/portworx/pxwincsidriver:v0.1
+          image: docker.io/portworx/px-windows-csi-driver:v0.1
           imagePullPolicy: Always
           securityContext:
             windowsOptions:

--- a/drivers/storage/portworx/util/csi_generator.go
+++ b/drivers/storage/portworx/util/csi_generator.go
@@ -296,8 +296,8 @@ func (g *CSIGenerator) getSidecarContainerVersionsV1_0() *CSIImages {
 		Resizer:                 k8sutil.DefaultK8SRegistryPath + "/sig-storage/csi-resizer:v1.8.0",
 		SnapshotController:      snapshotControllerImage,
 		HealthMonitorController: k8sutil.DefaultK8SRegistryPath + "/sig-storage/csi-external-health-monitor-controller:v0.7.0",
-		LivenessProbe:           k8sutil.DefaultK8SRegistryPath + "/sig-storage/livenessprobe:v2.7.0",
-		CsiDriverInstaller:      "docker.io/portworx/pxwincsidriver:v0.1",
+		LivenessProbe:           k8sutil.DefaultK8SRegistryPath + "/sig-storage/livenessprobe:v2.10.0",
+		CsiDriverInstaller:      "docker.io/portworx/px-windows-csi-driver:v0.1",
 	}
 }
 

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1033,7 +1033,7 @@ func ApplyWindowsSettingsToPodSpec(podSpec *v1.PodSpec) {
 
 	toleration := v1.Toleration{
 		Key:   "os",
-		Value: WindowsOsName,
+		Value: "Windows",
 	}
 
 	podSpec.Tolerations = append(podSpec.Tolerations, toleration)

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -613,7 +613,7 @@ type ComponentImages struct {
 	DynamicPlugin              string `json:"dynamicPlugin,omitempty"`
 	DynamicPluginProxy         string `json:"dynamicPluginProxy,omitempty"`
 	CsiLivenessProbe           string `json:"csiLivenessProbe,omitempty"`
-	CsiWinDriver               string `json:"csiWinDriver,omitempty"`
+	CsiWindowsDriver           string `json:"csiWindowsDriver,omitempty"`
 }
 
 // Storage represents cluster storage details

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -1276,7 +1276,7 @@ func (h *Handler) handleCustomImageRegistry(cluster *corev1.StorageCluster) erro
 		DynamicPlugin:              h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.DynamicPlugin),
 		DynamicPluginProxy:         h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.DynamicPluginProxy),
 		CsiLivenessProbe:           h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.CsiLivenessProbe),
-		CsiWinDriver:               h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.CsiWinDriver),
+		CsiWindowsDriver:           h.removeCustomImageRegistry(cluster.Spec.CustomImageRegistry, cluster.Status.DesiredImages.CsiWindowsDriver),
 	}
 	cluster.Status.Version = pxutil.GetImageTag(cluster.Spec.Image)
 	return nil
@@ -1337,7 +1337,7 @@ func (h *Handler) createManifestConfigMap(cluster *corev1.StorageCluster) error 
 			DynamicPlugin:              cluster.Status.DesiredImages.DynamicPlugin,
 			DynamicPluginProxy:         cluster.Status.DesiredImages.DynamicPluginProxy,
 			CsiLivenessProbe:           cluster.Status.DesiredImages.CsiLivenessProbe,
-			CsiWinDriver:               cluster.Status.DesiredImages.CsiWinDriver,
+			CsiWindowsDriver:           cluster.Status.DesiredImages.CsiWindowsDriver,
 		},
 	}
 


### PR DESCRIPTION
This PR fixes : https://portworx.atlassian.net/browse/PWX-33087

1. Changed manifest WindowsCsiDriver tag to match with px-installer tag here : https://github.com/portworx/px-installer/pull/1848
2. Changed storagecluster CRD tag to keep it consistent

Bug fix :
1. Corrected format of nodeaffinity on CSV
2. Corrected toleration on windows pods from 'windows' to 'Windows'


Test : 
Verified on k8s 1.25.8 cluster

**Following is the status of STC :** 
status:
  clusterName: px-clusters
  desiredImages:
    autopilot: portworx/autopilot:1.3.8
    csiAttacher: docker.io/openstorage/csi-attacher:v1.2.1-1
    csiLivenessProbe: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
    csiNodeDriverRegistrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
    csiProvisioner: registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
    csiResizer: registry.k8s.io/sig-storage/csi-resizer:v1.8.0
    csiSnapshotController: registry.k8s.io/sig-storage/snapshot-controller:v6.2.2
    csiSnapshotter: registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
    csiWindowsDriver: docker.io/portworx/px-windows-csi-driver:v0.1
    dynamicPlugin: portworx/portworx-dynamic-plugin:1.1.0
    dynamicPluginProxy: nginxinc/nginx-unprivileged:1.23
    prometheus: quay.io/prometheus/prometheus:v2.35.0
    prometheusConfigReloader: quay.io/prometheus-operator/prometheus-config-reloader:v0.56.3
    prometheusOperator: quay.io/prometheus-operator/prometheus-operator:v0.56.3
    stork: openstorage/stork:23.7.0
  phase: Initializing
  storage: {}
  version: f5a2c6e_d46fecd