### PR TITLE
PWX-30455: mounts override fix

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1331,8 +1331,9 @@ func (t *template) getVolumeMounts() []v1.VolumeMount {
 
 func (t *template) mountsFromVolInfo(vols []volumeInfo) []v1.VolumeMount {
 	volumeMounts := make([]v1.VolumeMount, 0, len(vols))
-	mountPathSet := make(map[string]bool)
+	indexMap := make(map[string]int)
 	runPrivileged := pxutil.IsPrivileged(t.cluster)
+	idx := 0
 	for _, v := range vols {
 		volMount := v1.VolumeMount{
 			Name:             v.name,
@@ -1362,7 +1363,8 @@ func (t *template) mountsFromVolInfo(vols []volumeInfo) []v1.VolumeMount {
 		}
 		if volMount.MountPath != "" {
 			volumeMounts = append(volumeMounts, volMount)
-			mountPathSet[volMount.MountPath] = true
+			indexMap[volMount.MountPath] = idx
+			idx++
 		}
 	}
 
@@ -1375,16 +1377,24 @@ func (t *template) mountsFromVolInfo(vols []volumeInfo) []v1.VolumeMount {
 	}
 
 	for _, v := range t.cluster.Spec.Volumes {
-		if _, ok := mountPathSet[v.MountPath]; ok {
-			logrus.Warnf("Found mountPath conflict for volume %s at %s, volume will be ignored", v.Name, v.MountPath)
-			continue
-		}
-		volumeMounts = append(volumeMounts, v1.VolumeMount{
+		userVol := v1.VolumeMount{
 			Name:             pxutil.UserVolumeName(v.Name),
 			MountPath:        v.MountPath,
 			ReadOnly:         v.ReadOnly,
 			MountPropagation: v.MountPropagation,
-		})
+		}
+
+		if i, has := indexMap[v.MountPath]; !has {
+			volumeMounts = append(volumeMounts, userVol)
+			indexMap[v.MountPath] = idx
+			idx++
+		} else if i > len(volumeMounts) || volumeMounts[i].MountPath != v.MountPath {
+			// sanity check failed..
+			logrus.Errorf("INTERNAL ERROR -- invalid volume index (#%d %v)", i, v.MountPath)
+		} else {
+			logrus.Warnf("Replacing mountPath for volume %s at %s with %s", volumeMounts[i].Name, v.MountPath, v.Name)
+			volumeMounts[i] = userVol
+		}
 	}
 
 	return volumeMounts
@@ -1504,6 +1514,7 @@ func (t *template) getVolumes() []v1.Volume {
 		volumes = append(volumes, kvdbVolume)
 	}
 
+	// CHECKME: spec-mounts could override existing mounts, so we purge "dangling" host-mounts
 	for _, v := range t.cluster.Spec.Volumes {
 		volumes = append(volumes, v1.Volume{
 			Name:         pxutil.UserVolumeName(v.Name),

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -729,7 +729,7 @@ func getVolumeSpecs(
 			logrus.WithFields(logrus.Fields{
 				"name":      m.Name,
 				"mountPath": m.MountPath,
-			}).Warningf("found mountPath conflict when constructing StorageCluster from DaemonSet, volume will be ignored")
+			}).Warnf("found mountPath conflict when constructing StorageCluster from DaemonSet, volume will be ignored")
 			continue
 		}
 		volumeSpecMap[m.Name] = &corev1.VolumeSpec{


### PR DESCRIPTION
* custom mounts can now override the embedded (default) mounts

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The mount-overrides were previously just "dropped" with a warning.
* see https://github.com/libopenstorage/operator/pull/585 and https://github.com/libopenstorage/operator/commit/6c8adbad924ca6d7109b42848af22c75466fdbec

As a fix, the user-mounts (custom mounts) can _override_ the original mounts internal to operator.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-30455

This PR also replaces https://github.com/libopenstorage/operator/pull/1168

**Special notes for your reviewer**:

Testing notes:

**TEST**: StorageCluster modification using 2 custom-mounts with the same destination (`/var/cores`)

```yaml
apiVersion: core.libopenstorage.org/v1
kind: StorageCluster
spec:
  volumes:
  - hostPath:
      path: /mnt/px-cores
    mountPath: /var/cores
    name: px-cores
  - hostPath:
      path: /mnt/px-cores22
    mountPath: /var/cores
    name: px-cores22
```

**RESULT**: Portworx POD
* note, we have some excess host-paths, but this should be OK since they are not used by containers
* the portworx-container actually uses (overridden) `user-px-cores22` instead of default `diagsdump`

```yaml
apiVersion: v1
kind: Pod
spec:
  containers:
  - name: portworx
    volumeMounts:
    - mountPath: /var/cores
      name: user-px-cores22
    ...
  volumes:
  - hostPath:
      path: /var/cores
      type: ""
    name: diagsdump
  - hostPath:
      path: /mnt/px-cores
      type: ""
    name: user-px-cores
  - hostPath:
      path: /mnt/px-cores22
      type: ""
    name: user-px-cores22
```

**RESULT**: Actual `portworx.service` DID override the `/var/cores` mount --
* runC mounts via `jq .mounts /opt/pwx/oci/config.json` ::

```json
[
  {
    "destination": "/var/cores",
    "type": "bind",
    "source": "/mnt/px-cores22",
    "options": [
      "rbind",
      "rprivate"
    ]
  },
  ...
]
```

**RESULT**: Also...

```
# ls -al /mnt/px-cores22
total 360
drwxr-xr-x 4 root root   4096 Aug 23 00:23 .
drwxr-xr-x 4 root root   4096 Aug 22 21:56 ..
drw-r--r-- 2 root root   4096 Aug 22 21:57 .alerts
-rw-r--r-- 1 root root      0 Aug 22 21:58 pwx_fstrim.log
-rw-r--r-- 1 root root   1842 Aug 23 00:25 px_cache_mon.log
-rw-r--r-- 1 root root   1188 Aug 23 00:23 px_cache_mon_watch.log
-rw-r--r-- 1 root root    486 Aug 23 00:23 px_diag_watch.log
-rw-r--r-- 1 root root   2973 Aug 23 00:23 px_event_watch.log
-rw-r--r-- 1 root root 316884 Aug 23 00:25 px_exec_watch.log
-rw-r--r-- 1 root root    510 Aug 23 00:23 px_healthmon_watch.log
-rw-r--r-- 1 root root    960 Aug 23 00:23 px_info.log
-rw-r--r-- 1 root root    407 Aug 23 00:23 px_patch_fs.log
-rw-r--r-- 1 root root      0 Aug 22 21:57 px_reboot_diags.log
drwxr-xr-x 2 root root   4096 Aug 23 00:25 px_status
```
* note, this is normally the content of `/var/cores` directory, but dumped in `/mnt/px-cores22`
* this proves the mount-override worked OK