### PR TITLE
feat: Improve when CSI driver gets removed before unmount of the volumes on that node

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -24,7 +24,6 @@ import (
 	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/cloudstorage"
-	"github.com/libopenstorage/operator/pkg/depresolver"
 	"github.com/libopenstorage/operator/pkg/preflight"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
@@ -326,23 +325,6 @@ func (p *portworx) GetStoragePodSpec(
 	if pxutil.IsCSIEnabled(t.cluster) {
 		csiRegistrar := t.csiRegistrarContainer()
 		if csiRegistrar != nil {
-			p.depresolver = depresolver.New(
-				cluster.Spec.Kvdb.Endpoints,
-				"",
-				func(nodeName string) bool {
-					pods := &v1.PodList{}
-					err = p.k8sClient.List(context.Background(), pods, client.InNamespace(cluster.Namespace), client.HasLabels{
-						"name=portworx",
-					})
-					if nil != err {
-						logrus.Errorf("failed to get dependent portworx pods, err: %s", err)
-						return false
-					}
-					return pods.Size() == 0
-				})
-
-			go p.depresolver.Run()
-
 			podSpec.Containers = append(podSpec.Containers, *csiRegistrar)
 		}
 	}

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -29,6 +29,7 @@ import (
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/cloudprovider"
 	"github.com/libopenstorage/operator/pkg/cloudstorage"
+	"github.com/libopenstorage/operator/pkg/depresolver"
 	"github.com/libopenstorage/operator/pkg/preflight"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
@@ -62,6 +63,7 @@ type portworx struct {
 	scheme             *runtime.Scheme
 	recorder           record.EventRecorder
 	sdkConn            *grpc.ClientConn
+	depresolver        depresolver.IGraph
 	zoneToInstancesMap map[string]uint64
 	cloudProvider      string
 }

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -60,7 +60,9 @@ const (
 	// PortworxKVDBServiceName name of the Portworx KVDB Kubernetes service
 	PortworxKVDBServiceName = "portworx-kvdb-service"
 	// CSIRegistrarContainerName name of the Portworx CSI node driver registrar container
-	CSIRegistrarContainerName = "csi-node-driver-registrar"
+	CSINodeDriverRegistrarContainerName = "csi-node-driver-registrar"
+	// CSIDriverRegistrarContainerName name of the CSI driver registrar container
+	CSIDriverRegistrarContainerName = "csi-driver-registrar"
 	// TelemetryContainerName name of the Portworx telemetry container
 	TelemetryContainerName = "telemetry"
 	// PortworxRESTPortName name of the Portworx API port

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -843,7 +843,7 @@ func (c *Controller) deleteStorageCluster(
 		return err
 	}
 
-	if deleteFinalizerExists(cluster) {
+	if DeleteFinalizerExists(cluster) {
 		toDelete := cluster.DeepCopy()
 		deleteCondition, driverErr := c.Driver.DeleteStorage(toDelete)
 		if driverErr != nil {

--- a/pkg/controller/storagecluster/util.go
+++ b/pkg/controller/storagecluster/util.go
@@ -51,7 +51,7 @@ func historyName(clusterName, hash string) string {
 	return clusterName + "-" + hash
 }
 
-func deleteFinalizerExists(cluster *corev1.StorageCluster) bool {
+func DeleteFinalizerExists(cluster *corev1.StorageCluster) bool {
 	for _, finalizerName := range cluster.Finalizers {
 		if finalizerName == deleteFinalizerName {
 			return true

--- a/pkg/depresolver/dependency.go
+++ b/pkg/depresolver/dependency.go
@@ -1,0 +1,6 @@
+package depresolver
+
+// an empty array represents that it will wait for all other pods with portworx label
+const DefaultDependencies = `{
+	"px-csi-driver": ["*"]
+}`

--- a/pkg/depresolver/dependency_graph.go
+++ b/pkg/depresolver/dependency_graph.go
@@ -26,7 +26,7 @@ type IGraph interface {
 	Run()
 }
 
-type WildCardFunc func(nodeName string) bool
+type WildCardFunc func(namespace, nodeName string) bool
 
 type Graph struct {
 	k8sClientset *kubernetes.Clientset
@@ -39,7 +39,7 @@ type Graph struct {
 // Takes in yaml representation of the adjList in a json,
 // Failure to read the adjList or it's absence would resort to default adjacency list
 // The default adjacency list can also be treasted as an example for building your custom tree
-func New(endpoints []string, adjList string, wildcard WildCardFunc) IGraph {
+func New(adjList string, wildcard WildCardFunc) IGraph {
 	restConfig, err := rest.InClusterConfig()
 	if err != nil {
 		log.Fatalf("error getting cluster config: %v", err)
@@ -49,7 +49,7 @@ func New(endpoints []string, adjList string, wildcard WildCardFunc) IGraph {
 	if err != nil {
 		log.Fatalf("error getting rest cluster config: %v", err)
 	}
-	
+
 	g := &Graph{
 		k8sClientset: k8sClientset,
 		lock:         &sync.Mutex{},

--- a/pkg/depresolver/dependency_graph.go
+++ b/pkg/depresolver/dependency_graph.go
@@ -1,0 +1,124 @@
+package depresolver
+
+import (
+	"encoding/json"
+	"log"
+	"sync"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	wildcardToken = "*"
+)
+
+type Node struct {
+	Resolved     bool
+	Dependencies []string
+	ResolvedAt   time.Time
+}
+
+type IGraph interface {
+	IsResolved(nodeName string) bool
+	SetResolved(nodeName string)
+	Run()
+}
+
+type WildCardFunc func(nodeName string) bool
+
+type Graph struct {
+	k8sClientset *kubernetes.Clientset
+	namespace    string
+	lock         *sync.Mutex
+	graph        map[string]*Node
+	wildcard     WildCardFunc
+}
+
+// Takes in yaml representation of the adjList in a json,
+// Failure to read the adjList or it's absence would resort to default adjacency list
+// The default adjacency list can also be treasted as an example for building your custom tree
+func New(endpoints []string, adjList string, wildcard WildCardFunc) IGraph {
+	restConfig, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatalf("error getting cluster config: %v", err)
+	}
+
+	k8sClientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		log.Fatalf("error getting rest cluster config: %v", err)
+	}
+	
+	g := &Graph{
+		k8sClientset: k8sClientset,
+		lock:         &sync.Mutex{},
+		graph:        map[string]*Node{},
+		wildcard:     wildcard,
+	}
+
+	g.parse(adjList)
+
+	return g
+}
+
+func (g *Graph) parse(adjList string) (err error) {
+	if adjList == "" {
+		adjList = DefaultDependencies
+	}
+	adjListMap := map[string][]string{}
+
+	err = json.Unmarshal([]byte(adjList), &adjListMap)
+	if nil != err {
+		return
+	}
+
+	g.graph = make(map[string]*Node)
+
+	for nodeName, nodeAdj := range adjListMap {
+		g.graph[nodeName] = &Node{
+			Resolved:     false,
+			Dependencies: nodeAdj,
+		}
+	}
+
+	return
+}
+
+func (g *Graph) IsResolved(nodeName string) bool {
+	node, ok := g.graph[nodeName]
+	if !ok {
+		g.graph[nodeName] = &Node{
+			Dependencies: []string{},
+			Resolved:     true,
+			ResolvedAt:   time.Now(),
+		}
+		return true
+	}
+
+	for _, depName := range node.Dependencies {
+		if depName == wildcardToken {
+			return g.wildcard(nodeName)
+		}
+		if !g.IsResolved(depName) {
+			return false
+		}
+	}
+
+	node.Resolved = true
+
+	return node.Resolved
+}
+
+func (g *Graph) SetResolved(nodeName string) {
+	node, ok := g.graph[nodeName]
+	if !ok {
+		node = &Node{
+			Dependencies: []string{},
+		}
+
+		g.graph[nodeName] = node
+	}
+	node.Resolved = true
+	node.ResolvedAt = time.Now()
+}

--- a/pkg/depresolver/kv.go
+++ b/pkg/depresolver/kv.go
@@ -1,0 +1,80 @@
+package depresolver
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/portworx/kvdb"
+	"github.com/portworx/kvdb/consul"
+	e2 "github.com/portworx/kvdb/etcd/v2"
+	e3 "github.com/portworx/kvdb/etcd/v3"
+)
+
+var (
+	getKVDBVersion = kvdb.Version
+	newKVDB        = kvdb.New
+
+	DepresolverKvdbPrefix = "depresolver/"
+)
+
+func getKVDBClient(endpoints []string, opts map[string]string) (kvdb.Kvdb, error) {
+	var urlPrefix, kvdbType, kvdbName string
+	for i, url := range endpoints {
+		urlTokens := strings.Split(url, ":")
+		if i == 0 {
+			if urlTokens[0] == "etcd" {
+				kvdbType = "etcd"
+			} else if urlTokens[0] == "consul" {
+				kvdbType = "consul"
+			} else {
+				return nil, fmt.Errorf("unknown discovery endpoint : %v in %v", urlTokens[0], endpoints)
+			}
+		}
+
+		if urlTokens[1] == "http" {
+			urlPrefix = "http"
+			urlTokens[1] = ""
+		} else if urlTokens[1] == "https" {
+			urlPrefix = "https"
+			urlTokens[1] = ""
+		} else {
+			urlPrefix = "http"
+		}
+
+		kvdbURL := ""
+		for j, v := range urlTokens {
+			if j == 0 {
+				kvdbURL = urlPrefix
+			} else {
+				if v != "" {
+					kvdbURL = kvdbURL + ":" + v
+				}
+			}
+		}
+		endpoints[i] = kvdbURL
+	}
+
+	var kvdbVersion string
+	var err error
+	for i, url := range endpoints {
+		kvdbVersion, err = getKVDBVersion(kvdbType+"-kv", url, opts)
+		if err == nil {
+			break
+		} else if i == len(endpoints)-1 {
+			return nil, err
+		}
+	}
+
+	switch kvdbVersion {
+	case kvdb.ConsulVersion1:
+		kvdbName = consul.Name
+	case kvdb.EtcdBaseVersion:
+		kvdbName = e2.Name
+	case kvdb.EtcdVersion3:
+		kvdbName = e3.Name
+	default:
+		return nil, fmt.Errorf("unknown kvdb endpoint (%v) and version (%v) ", endpoints, kvdbVersion)
+	}
+
+	return newKVDB(kvdbName, DepresolverKvdbPrefix, endpoints, opts, nil)
+}

--- a/pkg/depresolver/watchdog.go
+++ b/pkg/depresolver/watchdog.go
@@ -1,0 +1,113 @@
+package depresolver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func (g *Graph) Run() {
+	done := make(chan struct{})
+	retryQueue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	handler := cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) {
+			pod, ok := obj.(*v1.Pod)
+			if !ok {
+				logrus.Errorf("watch returned non-pod object: %+v", obj)
+				return
+			}
+
+			if label, ok := pod.Labels["app"]; ok && g.IsResolved(label) {
+				err := g.k8sClientset.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+				if nil != err {
+					logrus.Errorf("depresolver failed to delete pod %s: %s", pod.Name, err)
+					retryQueue.Add(pod)
+					return
+				}
+			} else {
+				retryQueue.Add(pod)
+			}
+		},
+	}
+
+	listWatcher := cache.NewListWatchFromClient(
+		g.k8sClientset.RESTClient(),
+		"pods",
+		g.namespace,
+		fields.OneTermEqualSelector("metadata.deletionTimestamp", ""),
+	)
+
+	informer := cache.NewSharedInformer(
+		listWatcher,
+		&v1.Pod{},
+		time.Second,
+	)
+
+	informer.AddEventHandler(handler)
+
+	podKey := func(pod *v1.Pod) string {
+		return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+	}
+
+	queue := cache.NewFIFO(
+		func(obj interface{}) (key string, err error) {
+			pod, ok := obj.(*v1.Pod)
+			if !ok {
+				return
+			}
+
+			key = podKey(pod)
+			return
+		})
+
+	podController := cache.New(&cache.Config{
+		Queue:         queue,
+		ObjectType:    &v1.Pod{},
+		RetryOnError:  false,
+		ListerWatcher: listWatcher,
+		Process: func(obj interface{}) (err error) {
+			pod, ok := obj.(*v1.Pod)
+			if !ok {
+				err = fmt.Errorf("watch returned non-pod object: %+v", obj)
+				logrus.Errorln(err)
+				return
+			}
+
+			if label, ok := pod.Labels["app"]; ok {
+				if !g.IsResolved(label) {
+					queue.Add(pod)
+					return
+				}
+
+			}
+			err = g.k8sClientset.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
+			if nil != err {
+				err = fmt.Errorf("depresolver failed to delete pod %s: %s", pod.Name, err)
+				logrus.Errorln(err)
+				return
+			}
+			return
+		},
+		FullResyncPeriod: time.Second,
+	})
+
+	go podController.Run(done)
+
+	sigStop := make(chan os.Signal, 1)
+	signal.Notify(sigStop, syscall.SIGINT, syscall.SIGTERM)
+	<-sigStop
+	close(done)
+
+}

--- a/pkg/depresolver/watchdog.go
+++ b/pkg/depresolver/watchdog.go
@@ -29,7 +29,7 @@ func (g *Graph) Run() {
 				return
 			}
 
-			if label, ok := pod.Labels["app"]; ok && g.IsResolved(label) {
+			if label, ok := pod.Labels["app"]; ok && g.IsResolved(pod, label) {
 				err := g.k8sClientset.CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{})
 				if nil != err {
 					logrus.Errorf("depresolver failed to delete pod %s: %s", pod.Name, err)
@@ -86,7 +86,7 @@ func (g *Graph) Run() {
 			}
 
 			if label, ok := pod.Labels["app"]; ok {
-				if !g.IsResolved(label) {
+				if !g.IsResolved(pod, label) {
 					queue.Add(pod)
 					return
 				}

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -780,7 +780,7 @@ func (h *Handler) addCSISpec(cluster *corev1.StorageCluster, ds *appsv1.DaemonSe
 	csiEnabled := false
 	for _, c := range ds.Spec.Template.Spec.Containers {
 		switch c.Name {
-		case pxutil.CSIRegistrarContainerName:
+		case pxutil.CSINodeDriverRegistrarContainerName:
 			csiEnabled = true
 			cluster.Status.DesiredImages.CSINodeDriverRegistrar = c.Image
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve when CSI driver gets removed before unmount of the volumes on that node.
Add dependency resolver to protect sequence of deletion of kubernetes pods.

**Which issue(s) this PR fixes** (optional)
Closes #[PWX-32298](https://portworx.atlassian.net/browse/PWX-32298)



[PWX-32298]: https://portworx.atlassian.net/browse/PWX-32298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ