### PR TITLE
Downgrade package CSV

### DIFF
--- a/deploy/olm-catalog/portworx/portworx.package.yaml
+++ b/deploy/olm-catalog/portworx/portworx.package.yaml
@@ -1,7 +1,7 @@
 packageName: portworx-certified
 channels:
 - name: alpha
-  currentCSV: portworx-operator.v23.4.1
+  currentCSV: portworx-operator.v23.5.1
 - name: stable
-  currentCSV: portworx-operator.v23.4.1
+  currentCSV: portworx-operator.v23.5.1
 defaultChannel: stable


### PR DESCRIPTION
* upgrading to the "latest published" currentCSV: portworx-operator.v23.5.1

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Trying to work around the publication failure
* looks like RHEL is reporting that we're trying to "downgrade" their catalogs

> opm registry add...
> [generate-index : generate] Error: [add prunes bundle portworx-operator.v23.4.1 (image-registry.openshift-image-registry.svc:5000/operator-release/portworx-certified-bundle:23.4.1) from package portworx-certified, channel alpha: this may be due to incorrect channel head (portworx-operator.v23.5.1, skips/replaces [portworx-operator.v23.5.0]). Be aware that the head of the channel alpha where you are trying to add the portworx-operator.v23.4.1 is portworx-operator.v23.5.1. Upgrade graphs follows the Semantic Versioning 2.0.0 (https://semver.org/) which means that is not possible add new versions lower then the head of the channel, add prunes bundle portworx-operator.v23.4.1 (image-registry.openshift-image-registry.svc:5000/operator-release/portworx-certified-bundle:23.4.1) from package portworx-certified, channel stable: this may be due to incorrect channel head (portworx-operator.v23.5.1, skips/replaces [portworx-operator.v23.5.0]). Be aware that the head of the channel stable where you are trying to add the portworx-operator.v23.4.1 is portworx-operator.v23.5.1. Upgrade graphs follows the Semantic Versioning 2.0.0 (https://semver.org/) which means that is not possible add new versions lower then the head of the channel]

**Which issue(s) this PR fixes** (optional)
Closes # n/a

**Special notes for your reviewer**:

