### PR TITLE
PWX-33418: Compensate for porx-branch renaming

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -55,7 +55,7 @@ var (
 	pxVer2_8, _    = version.NewVersion("2.8")
 	pxVer2_9_1, _  = version.NewVersion("2.9.1")
 	pxVer2_13_8, _ = version.NewVersion("2.13.8")
-	pxVer3_0, _    = version.NewVersion("3.0")
+	pxVer3_0_1, _  = version.NewVersion("3.0.1")
 )
 
 type volumeInfo struct {
@@ -302,9 +302,9 @@ func (p *portworx) GetStoragePodSpec(
 	}
 
 	if _, has := t.cluster.Annotations[pxutil.AnnotationIsPrivileged]; has {
-		if pxutil.GetPortworxVersion(cluster).LessThanOrEqual(pxVer3_0) {
+		if pxutil.GetPortworxVersion(cluster).LessThanOrEqual(pxVer3_0_1) {
 			err = fmt.Errorf("failed to create pod spec: need portworx higher than %s to use annotation '%s'",
-				pxVer3_0, pxutil.AnnotationIsPrivileged)
+				pxVer3_0_1, pxutil.AnnotationIsPrivileged)
 			return v1.PodSpec{}, err
 		}
 	}
@@ -1040,7 +1040,7 @@ func (t *template) getArguments() []string {
 		args = append(args, "--log", t.cluster.Annotations[pxutil.AnnotationLogFile])
 	}
 	// for non-privileged and PKS, add shared mounts via parameters
-	if t.pxVersion.GreaterThan(pxVer3_0) &&
+	if t.pxVersion.GreaterThan(pxVer3_0_1) &&
 		(!pxutil.IsPrivileged(t.cluster) || pxutil.IsPKS(t.cluster)) {
 		args = append(args,
 			"-v", "/var/lib/osd/pxns:/var/lib/osd/pxns:shared",
@@ -1158,7 +1158,7 @@ func (t *template) getEnvList() []v1.EnvVar {
 
 	if t.isPKS {
 		ev := "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi"
-		if t.pxVersion.GreaterThan(pxVer3_0) {
+		if t.pxVersion.GreaterThan(pxVer3_0_1) {
 			ev = "rm -fr /var/lib/osd/driver"
 		}
 		envMap["PRE-EXEC"] = &v1.EnvVar{
@@ -1869,7 +1869,7 @@ func getDefaultVolumeInfoList(pxVersion *version.Version) []volumeInfo {
 func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 	list := make([]volumeInfo, 0)
 
-	if pxVersion.GreaterThan(pxVer3_0) {
+	if pxVersion.GreaterThan(pxVer3_0_1) {
 		list = append(list, volumeInfo{
 			name:             "varlibosd",
 			hostPath:         "/var/lib/osd",

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -2901,27 +2901,27 @@ func TestPKSPodSpec(t *testing.T) {
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 	assertPodSpecEqual(t, expected_2_9_1, &actual)
 
-	// check PKS when using px-3.0.1
+	// check PKS when using px-3.0.2
 
-	cluster.Spec.Image = "portworx/oci-monitor:3.0.1"
-	expected_3_0_1 := expected_2_9_1.DeepCopy()
-	expected_3_0_1.Containers[0].Image = "docker.io/" + cluster.Spec.Image
-	expected_3_0_1.Containers[0].Args = append(expected_3_0_1.Containers[0].Args,
+	cluster.Spec.Image = "portworx/oci-monitor:3.0.2"
+	expected_3_0_2 := expected_2_9_1.DeepCopy()
+	expected_3_0_2.Containers[0].Image = "docker.io/" + cluster.Spec.Image
+	expected_3_0_2.Containers[0].Args = append(expected_3_0_2.Containers[0].Args,
 		"-v", "/var/lib/osd/pxns:/var/lib/osd/pxns:shared",
 		"-v", "/var/lib/osd/mounts:/var/lib/osd/mounts:shared",
 	)
-	podSpecRemoveMount(expected_3_0_1, "varlibosd")
-	podSpecRemoveMount(expected_3_0_1, "pxlogs")
-	podSpecAddMount(expected_3_0_1, "varlibosd", "/var/vcap/store/lib/osd:/var/lib/osd")
-	podSpecRemoveEnv(expected_3_0_1, "PRE-EXEC")
-	expected_3_0_1.Containers[0].Env = append(expected_3_0_1.Containers[0].Env, v1.EnvVar{
+	podSpecRemoveMount(expected_3_0_2, "varlibosd")
+	podSpecRemoveMount(expected_3_0_2, "pxlogs")
+	podSpecAddMount(expected_3_0_2, "varlibosd", "/var/vcap/store/lib/osd:/var/lib/osd")
+	podSpecRemoveEnv(expected_3_0_2, "PRE-EXEC")
+	expected_3_0_2.Containers[0].Env = append(expected_3_0_2.Containers[0].Env, v1.EnvVar{
 		Name: "PRE-EXEC", Value: "rm -fr /var/lib/osd/driver",
 	})
 
 	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 
-	assertPodSpecEqual(t, expected_3_0_1, &actual)
+	assertPodSpecEqual(t, expected_3_0_2, &actual)
 }
 
 func TestOpenshiftRuncPodSpec(t *testing.T) {
@@ -2993,17 +2993,17 @@ func TestOpenshiftRuncPodSpec(t *testing.T) {
 
 	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "need portworx higher than 3.0.0 to use annotation '"+
+	assert.Contains(t, err.Error(), "need portworx higher than 3.0.1 to use annotation '"+
 		pxutil.AnnotationIsPrivileged+"'")
 
-	cluster.Spec.Image = "portworx/oci-monitor:3.0.1"
-	expected_3_0_1 := expected.DeepCopy()
-	expected_3_0_1.Containers[0].Image = "docker.io/" + cluster.Spec.Image
-	expected_3_0_1.Containers[0].Args = append(expected_3_0_1.Containers[0].Args,
+	cluster.Spec.Image = "portworx/oci-monitor:3.0.2"
+	expected_3_0_2 := expected.DeepCopy()
+	expected_3_0_2.Containers[0].Image = "docker.io/" + cluster.Spec.Image
+	expected_3_0_2.Containers[0].Args = append(expected_3_0_2.Containers[0].Args,
 		"-v", "/var/lib/osd/pxns:/var/lib/osd/pxns:shared",
 		"-v", "/var/lib/osd/mounts:/var/lib/osd/mounts:shared",
 	)
-	expected_3_0_1.Containers[0].SecurityContext = &v1.SecurityContext{
+	expected_3_0_2.Containers[0].SecurityContext = &v1.SecurityContext{
 		Privileged: boolPtr(false),
 		Capabilities: &v1.Capabilities{
 			Add: []v1.Capability{
@@ -3011,27 +3011,27 @@ func TestOpenshiftRuncPodSpec(t *testing.T) {
 			},
 		},
 	}
-	podSpecAddMount(expected_3_0_1, "varlibosd", "/var/lib/osd:/var/lib/osd")
-	podSpecRemoveEnv(expected_3_0_1, "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS")
+	podSpecAddMount(expected_3_0_2, "varlibosd", "/var/lib/osd:/var/lib/osd")
+	podSpecRemoveEnv(expected_3_0_2, "AUTO_NODE_RECOVERY_TIMEOUT_IN_SECS")
 
 	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
 	require.NoError(t, err)
 
-	assertPodSpecEqual(t, expected_3_0_1, &actual)
+	assertPodSpecEqual(t, expected_3_0_2, &actual)
 
 	require.Equal(t, 1, len(actual.Containers))
 	for _, v := range actual.Containers[0].VolumeMounts {
 		assert.Nil(t, v.MountPropagation, "Wrong propagation on %v", v)
 	}
 
-	// PWX-32825 tweak the 3.0.1 version slightly -- should still evaluate the same
-	cluster.Spec.Image = "portworx/oci-monitor:3.0.1-ubuntu1604"
-	expected_3_0_1.Containers[0].Image = "docker.io/" + cluster.Spec.Image
+	// PWX-32825 tweak the 3.0.2 version slightly -- should still evaluate the same
+	cluster.Spec.Image = "portworx/oci-monitor:3.0.2-ubuntu1604"
+	expected_3_0_2.Containers[0].Image = "docker.io/" + cluster.Spec.Image
 
 	actual, err = driver.GetStoragePodSpec(cluster, nodeName)
 	require.NoError(t, err)
 
-	assertPodSpecEqual(t, expected_3_0_1, &actual)
+	assertPodSpecEqual(t, expected_3_0_2, &actual)
 }
 
 func TestPodSpecForK3s(t *testing.T) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

A bunch of dev-branches got renamed on the `porx` project -- so we have to compensate the versions changes in operator code.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-33418

**Special notes for your reviewer**:

