### PR TITLE
PWX-33550: Op-int test name change

### DIFF
--- a/test/integration_test/basic_dmthin_test.go
+++ b/test/integration_test/basic_dmthin_test.go
@@ -169,7 +169,7 @@ var testDmthinCases = []types.TestCase{
 
 var testDmthinInstallFailedCases = []types.TestCase{
 	{
-		TestName: "TestStorageClusterDmthinWithoutPxStoreV2OptionInstallFailed",
+		TestName: "TestStorageClusterIncompatibleNodeDmthin",
 		TestSpec: func(t *testing.T) interface{} {
 			provider := cloud_provider.GetCloudProvider()
 			cluster := defaultDmthinSpec(t, false)
@@ -190,7 +190,7 @@ func TestStorageClusterDmthinWithoutPxStoreV2Option(t *testing.T) {
 	}
 }
 
-func TestStorageClusterDmthinWithoutPxStoreV2OptionInstallFailed(t *testing.T) {
+func TestStorageClusterIncompatibleNodeDmthin(t *testing.T) {
 	for _, testCase := range testDmthinInstallFailedCases {
 		testCase.RunTest(t)
 	}


### PR DESCRIPTION
    TestStorageClusterDmthinWithoutPxStoreV2OptionInstallFailed name
    conflicts with TestStorageClusterDmthinWithoutPxStoreV2Option and
    fails the job. Changing the name to TestStorageClusterIncompatibleNodeDmthin

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

