### PR TITLE
The `-rt_opts` handling cleanup

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -107,7 +107,8 @@ type template struct {
 
 func newTemplate(
 	cluster *corev1.StorageCluster,
-	nodeName string) (*template, error) {
+	nodeName string,
+) (*template, error) {
 	if cluster == nil {
 		return nil, fmt.Errorf("storage cluster cannot be empty")
 	}
@@ -1062,6 +1063,9 @@ func (t *template) getArguments() []string {
 		}
 	}
 	if len(rtOpts) > 0 {
+		sort.SliceStable(rtOpts, func(i, j int) bool {
+			return strings.Compare(rtOpts[i], rtOpts[j]) < 0
+		})
 		args = append(args, "-rt_opts", strings.Join(rtOpts, ","))
 	}
 

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1400,7 +1400,7 @@ func CleanupObject(obj client.Object) {
 
 // IsFreshInstall checks whether it's a fresh Portworx install
 func IsFreshInstall(cluster *corev1.StorageCluster) bool {
-	// To handle failures during fresh install e.g. validation falures,
+	// To handle failures during fresh install e.g. validation failures,
 	// extra check for px runtime states is added here to avoid unexpected behaviors
 	return cluster.Status.Phase == "" ||
 		cluster.Status.Phase == string(corev1.ClusterStateInit) ||


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The `rt_opts` (runtime options) were first stashed into a HashMap, then collected into an array before passing them on as the options to the OCI-Monitor

ISSUE:
* since we used the HashMap -> array, the entries in the array will be UNSORTED (sorted randomly)
* this is an issue, since changing the order of parameters passed to the OCI-Monitor can cause `portworx.service` restarts

FIX:
* as a fix, we are _sorting_ the runtime-options array, before adding them into the OCI-Monitor's arguments

**Which issue(s) this PR fixes** (optional)
Closes # (no ticket)

**Special notes for your reviewer**:

