### PR TITLE
PWX-33602 : Do not enable windows component if CSI is disabled

### DIFF
--- a/drivers/storage/portworx/component/windows.go
+++ b/drivers/storage/portworx/component/windows.go
@@ -70,7 +70,10 @@ func (w *windows) IsEnabled(cluster *corev1.StorageCluster) bool {
 	}
 
 	w.isWindowsNode = isWindowsNode(nodeList)
-	return w.isWindowsNode && w.k8sVersion.GreaterThanOrEqual(k8s.K8sVer1_25)
+	// enable if windows node is detected
+	// and k8s version of cluster is > 1.25.0
+	// and CSI is enabled in STC
+	return w.isWindowsNode && w.k8sVersion.GreaterThanOrEqual(k8s.K8sVer1_25) && pxutil.IsCSIEnabled(cluster)
 }
 
 func (w *windows) Reconcile(cluster *corev1.StorageCluster) error {


### PR DESCRIPTION
**Issue :** https://portworx.atlassian.net/browse/PWX-33602
When CSI is disabled, operator tries to create px-csi-node-win, px-csi-win-driver pods and px-csi-win-shared StorageClass, None of them should be created when CSI is disabled.

**Resolution:**
If CSI is disabled, windows component should be disabled.

**Tests done :** 
Installation with CSI enabled : px-csi-node-win, px-csi-win-driver pods were scheduled and in Running state, px-csi-win-shared StorageClass was created.

Installation with CSI disabled : px-csi-node-win, px-csi-win-driver pods daemonset were not created, px-csi-win-shared StorageClass was not created.
