### PR TITLE
PWX-31732: Add common label to all operator managed pods

### DIFF
--- a/deploy/ccm/metrics-collector-deployment.yaml
+++ b/deploy/ccm/metrics-collector-deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         role: realtime-metrics-collector
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       containers:
       - env:

--- a/deploy/windows/px-csi-node-win.yaml
+++ b/deploy/windows/px-csi-node-win.yaml
@@ -10,6 +10,7 @@ spec:
     metadata:
       labels:
         app: px-csi-node-win
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       containers:
         - args:

--- a/deploy/windows/px-csi-win-driver.yaml
+++ b/deploy/windows/px-csi-win-driver.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-win-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       serviceAccountName: portworx
       containers:

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -462,7 +462,6 @@ func (c *autopilot) createDeployment(
 		util.HasPullSecretChanged(cluster, existingDeployment.Spec.Template.Spec.ImagePullSecrets) ||
 		util.HasNodeAffinityChanged(cluster, existingDeployment.Spec.Template.Spec.Affinity) ||
 		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations)
-
 	if !c.isCreated || modified {
 		if err = k8sutil.CreateOrUpdateDeployment(c.k8sClient, targetDeployment, ownerRef); err != nil {
 			return err
@@ -486,6 +485,10 @@ func (c *autopilot) getAutopilotDeploymentSpec(
 		"tier": "control-plane",
 	}
 	templateLabels := map[string]string{
+		"name": "autopilot",
+		"tier": "control-plane",
+	}
+	selectorLabels := map[string]string{
 		"name": "autopilot",
 		"tier": "control-plane",
 	}
@@ -514,7 +517,7 @@ func (c *autopilot) getAutopilotDeploymentSpec(
 				},
 			},
 			Selector: &metav1.LabelSelector{
-				MatchLabels: templateLabels,
+				MatchLabels: selectorLabels,
 			},
 			Replicas: &replicas,
 			Template: v1.PodTemplateSpec{
@@ -605,6 +608,7 @@ func (c *autopilot) getAutopilotDeploymentSpec(
 	if cluster.Spec.Autopilot.Resources != nil {
 		deployment.Spec.Template.Spec.Containers[0].Resources = *cluster.Spec.Autopilot.Resources
 	}
+	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 
 	return deployment
 }

--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -522,10 +522,9 @@ func (c *csi) createDeployment(
 		util.HasSchedulerStateChanged(cluster, existingDeployment.Spec.Template.Spec.SchedulerName) ||
 		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations) ||
 		util.HaveTopologySpreadConstraintsChanged(updatedTopologySpreadConstraints,
-			existingDeployment.Spec.Template.Spec.TopologySpreadConstraints)
-	hasCSITopologyChanged(cluster, existingDeployment)
+			existingDeployment.Spec.Template.Spec.TopologySpreadConstraints) ||
+		hasCSITopologyChanged(cluster, existingDeployment)
 	if !c.isCreated || modified {
-
 		if err = k8sutil.CreateOrUpdateDeployment(c.k8sClient, deployment, ownerRef); err != nil {
 			return err
 		}

--- a/drivers/storage/portworx/component/csi.go
+++ b/drivers/storage/portworx/component/csi.go
@@ -64,6 +64,9 @@ var (
 	csiDeploymentTemplateLabels = map[string]string{
 		csiDeploymentAppLabel: "px-csi-driver",
 	}
+	csiDeploymentTemplateSelectorLabels = map[string]string{
+		csiDeploymentAppLabel: "px-csi-driver",
+	}
 )
 
 type csi struct {
@@ -501,11 +504,13 @@ func (c *csi) createDeployment(
 		)
 	}
 
-	updatedTopologySpreadConstraints, err := util.GetTopologySpreadConstraints(c.k8sClient, csiDeploymentTemplateLabels)
+	updatedTopologySpreadConstraints, err := util.GetTopologySpreadConstraints(c.k8sClient, csiDeploymentTemplateSelectorLabels)
 	if err != nil {
 		return err
 	}
 
+	deployment := getCSIDeploymentSpec(cluster, csiConfig, ownerRef, provisionerImage, attacherImage,
+		snapshotterImage, resizerImage, snapshotControllerImage, healthMonitorControllerImage, updatedTopologySpreadConstraints)
 	modified := provisionerImage != existingProvisionerImage ||
 		attacherImage != existingAttacherImage ||
 		snapshotterImage != existingSnapshotterImage ||
@@ -517,11 +522,10 @@ func (c *csi) createDeployment(
 		util.HasSchedulerStateChanged(cluster, existingDeployment.Spec.Template.Spec.SchedulerName) ||
 		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations) ||
 		util.HaveTopologySpreadConstraintsChanged(updatedTopologySpreadConstraints,
-			existingDeployment.Spec.Template.Spec.TopologySpreadConstraints) ||
-		hasCSITopologyChanged(cluster, existingDeployment)
+			existingDeployment.Spec.Template.Spec.TopologySpreadConstraints)
+	hasCSITopologyChanged(cluster, existingDeployment)
 	if !c.isCreated || modified {
-		deployment := getCSIDeploymentSpec(cluster, csiConfig, ownerRef, provisionerImage, attacherImage,
-			snapshotterImage, resizerImage, snapshotControllerImage, healthMonitorControllerImage, updatedTopologySpreadConstraints)
+
 		if err = k8sutil.CreateOrUpdateDeployment(c.k8sClient, deployment, ownerRef); err != nil {
 			return err
 		}
@@ -539,7 +543,7 @@ func (c *csi) findPreinstalledCSISnapshotController() error {
 	for _, pod := range podList.Items {
 		// Ignore csi pods deployed by operator
 		appLabel, ok := pod.Labels[csiDeploymentAppLabel]
-		if ok && appLabel == csiDeploymentTemplateLabels[csiDeploymentAppLabel] {
+		if ok && appLabel == csiDeploymentTemplateSelectorLabels[csiDeploymentAppLabel] {
 			continue
 		}
 		for _, container := range pod.Spec.Containers {
@@ -632,7 +636,7 @@ func getCSIDeploymentSpec(
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: csiDeploymentTemplateLabels,
+				MatchLabels: csiDeploymentTemplateSelectorLabels,
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -859,6 +863,7 @@ func getCSIDeploymentSpec(
 	if len(topologySpreadConstraints) != 0 {
 		deployment.Spec.Template.Spec.TopologySpreadConstraints = topologySpreadConstraints
 	}
+	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 
 	return deployment
 }
@@ -897,6 +902,7 @@ func (c *csi) createStatefulSet(
 		cluster.Status.DesiredImages.CSIAttacher,
 	)
 
+	statefulSet := getCSIStatefulSetSpec(cluster, csiConfig, ownerRef, provisionerImage, attacherImage)
 	modified := provisionerImage != existingProvisionerImage ||
 		attacherImage != existingAttacherImage ||
 		util.HasPullSecretChanged(cluster, existingSS.Spec.Template.Spec.ImagePullSecrets) ||
@@ -904,7 +910,6 @@ func (c *csi) createStatefulSet(
 		util.HaveTolerationsChanged(cluster, existingSS.Spec.Template.Spec.Tolerations)
 
 	if !c.isCreated || modified {
-		statefulSet := getCSIStatefulSetSpec(cluster, csiConfig, ownerRef, provisionerImage, attacherImage)
 		if err = k8sutil.CreateOrUpdateStatefulSet(c.k8sClient, statefulSet, ownerRef); err != nil {
 			return err
 		}

--- a/drivers/storage/portworx/component/grafana.go
+++ b/drivers/storage/portworx/component/grafana.go
@@ -267,6 +267,9 @@ func (c *grafana) getGrafanaDeploymentSpec(
 	templateLabels := map[string]string{
 		"app": "grafana",
 	}
+	selectorLabels := map[string]string{
+		"app": "grafana",
+	}
 
 	replicas := int32(1)
 	imagePullPolicy := pxutil.ImagePullPolicy(cluster)
@@ -280,7 +283,7 @@ func (c *grafana) getGrafanaDeploymentSpec(
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: templateLabels,
+				MatchLabels: selectorLabels,
 			},
 			Replicas: &replicas,
 			Template: v1.PodTemplateSpec{
@@ -360,6 +363,7 @@ func (c *grafana) getGrafanaDeploymentSpec(
 			}
 		}
 	}
+	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 
 	return deployment
 }

--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -3,8 +3,9 @@ package component
 import (
 	"context"
 	commonerrors "errors"
-	"github.com/libopenstorage/operator/drivers/storage/portworx/manifest"
 	"strings"
+
+	"github.com/libopenstorage/operator/drivers/storage/portworx/manifest"
 
 	version "github.com/hashicorp/go-version"
 	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
@@ -235,6 +236,7 @@ func (p *plugin) createDeployment(filename, deploymentName string, ownerRef *met
 	if deployment.Name == NginxDeploymentName {
 		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPluginProxyImage(cluster)
 	}
+	deployment.Spec.Template.ObjectMeta = k8s.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 
 	existingDeployment := &appsv1.Deployment{}
 	getErr := p.client.Get(

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -292,6 +292,7 @@ func getPortworxAPIDaemonSetSpec(
 			}
 		}
 	}
+	newDaemonSet.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(newDaemonSet.Spec.Template.ObjectMeta)
 
 	return newDaemonSet
 }

--- a/drivers/storage/portworx/component/portworx_proxy.go
+++ b/drivers/storage/portworx/component/portworx_proxy.go
@@ -336,6 +336,7 @@ func getPortworxProxyDaemonSetSpec(
 			}
 		}
 	}
+	newDaemonSet.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(newDaemonSet.Spec.Template.ObjectMeta)
 
 	return newDaemonSet
 }

--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -449,13 +449,13 @@ func (c *prometheus) createOperatorDeployment(
 		cluster.Status.DesiredImages.PrometheusOperator,
 	)
 
+	deployment := getPrometheusOperatorDeploymentSpec(cluster, ownerRef, imageName)
 	modified := existingImageName != imageName ||
 		util.HasPullSecretChanged(cluster, existingDeployment.Spec.Template.Spec.ImagePullSecrets) ||
 		util.HasNodeAffinityChanged(cluster, existingDeployment.Spec.Template.Spec.Affinity) ||
 		util.HaveTolerationsChanged(cluster, existingDeployment.Spec.Template.Spec.Tolerations)
 
 	if !c.isOperatorCreated || errors.IsNotFound(getErr) || modified {
-		deployment := getPrometheusOperatorDeploymentSpec(cluster, ownerRef, imageName)
 		if err := k8sutil.CreateOrUpdateDeployment(c.k8sClient, deployment, ownerRef); err != nil {
 			return err
 		}
@@ -473,6 +473,9 @@ func getPrometheusOperatorDeploymentSpec(
 	runAsNonRoot := true
 	runAsUser := int64(defaultRunAsUser)
 	labels := map[string]string{
+		"k8s-app": PrometheusOperatorDeploymentName,
+	}
+	selectorLabels := map[string]string{
 		"k8s-app": PrometheusOperatorDeploymentName,
 	}
 	configReloaderImageName := util.GetImageURN(
@@ -498,11 +501,11 @@ func getPrometheusOperatorDeploymentSpec(
 			Name:            PrometheusOperatorDeploymentName,
 			Namespace:       cluster.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			Labels:          labels,
+			Labels:          selectorLabels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: selectorLabels,
 			},
 			Replicas: &replicas,
 			Template: v1.PodTemplateSpec{
@@ -562,6 +565,7 @@ func getPrometheusOperatorDeploymentSpec(
 			}
 		}
 	}
+	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 
 	return deployment
 }

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -537,6 +537,7 @@ func (c *pvcController) getPVCControllerDeploymentSpec(
 	if len(topologySpreadConstraints) != 0 {
 		deployment.Spec.Template.Spec.TopologySpreadConstraints = topologySpreadConstraints
 	}
+	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 
 	return deployment
 }

--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -55,6 +55,10 @@ var (
 		"name": PVCDeploymentName,
 		"tier": "control-plane",
 	}
+	pvcControllerDeploymentSelectorLabels = map[string]string{
+		"name": PVCDeploymentName,
+		"tier": "control-plane",
+	}
 )
 
 type pvcController struct {
@@ -369,7 +373,7 @@ func (c *pvcController) createDeployment(
 		}
 	}
 
-	updatedTopologySpreadConstraints, err := util.GetTopologySpreadConstraints(c.k8sClient, pvcControllerDeploymentTemplateLabels)
+	updatedTopologySpreadConstraints, err := util.GetTopologySpreadConstraints(c.k8sClient, pvcControllerDeploymentSelectorLabels)
 	if err != nil {
 		return err
 	}
@@ -437,7 +441,7 @@ func (c *pvcController) getPVCControllerDeploymentSpec(
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: pvcControllerDeploymentTemplateLabels,
+				MatchLabels: pvcControllerDeploymentSelectorLabels,
 			},
 			Replicas: &replicas,
 			Strategy: appsv1.DeploymentStrategy{

--- a/drivers/storage/portworx/component/pxrepo.go
+++ b/drivers/storage/portworx/component/pxrepo.go
@@ -230,6 +230,7 @@ func (p *pxrepo) getPxRepoDeployment(
 			}
 		}
 	}
+	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 
 	return &deployment
 }

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -850,6 +850,7 @@ func (t *telemetry) createDeploymentTelemetryRegistration(
 	deployment.Namespace = cluster.Namespace
 	deployment.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	deployment.Spec.Template.Spec.ServiceAccountName = ServiceAccountNameTelemetry
+	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 	pxutil.ApplyStorageClusterSettingsToPodSpec(cluster, &deployment.Spec.Template.Spec)
 
 	existingDeployment := &appsv1.Deployment{}
@@ -923,6 +924,7 @@ func (t *telemetry) createDaemonSetTelemetryPhonehome(
 	daemonset.Namespace = cluster.Namespace
 	daemonset.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	daemonset.Spec.Template.Spec.ServiceAccountName = ServiceAccountNameTelemetry
+	daemonset.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(daemonset.Spec.Template.ObjectMeta)
 	pxutil.ApplyStorageClusterSettingsToPodSpec(cluster, &daemonset.Spec.Template.Spec)
 
 	if restart {
@@ -988,6 +990,7 @@ func (t *telemetry) createDeploymentTelemetryCollectorV2(
 	deployment.Namespace = cluster.Namespace
 	deployment.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	deployment.Spec.Template.Spec.ServiceAccountName = ServiceAccountNameTelemetry
+	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 	pxutil.ApplyStorageClusterSettingsToPodSpec(cluster, &deployment.Spec.Template.Spec)
 
 	existingDeployment := &appsv1.Deployment{}

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -414,6 +414,7 @@ func (t *telemetry) getCollectorDeployment(
 			},
 		},
 	}
+	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 
 	deployment.Namespace = cluster.Namespace
 	pxutil.ApplyStorageClusterSettingsToPodSpec(cluster, &deployment.Spec.Template.Spec)

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -296,7 +296,10 @@ func (t *telemetry) getCollectorDeployment(
 	}
 
 	replicas := int32(1)
-	labels := map[string]string{
+	selectorLabels := map[string]string{
+		"role": "realtime-metrics-collector",
+	}
+	templateLabels := map[string]string{
 		"role": "realtime-metrics-collector",
 	}
 	runAsUser := int64(1111)
@@ -312,9 +315,9 @@ func (t *telemetry) getCollectorDeployment(
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
-			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Selector: &metav1.LabelSelector{MatchLabels: selectorLabels},
 			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				ObjectMeta: metav1.ObjectMeta{Labels: templateLabels},
 				Spec: v1.PodSpec{
 					ServiceAccountName: CollectorServiceAccountName,
 					Containers: []v1.Container{

--- a/drivers/storage/portworx/component/windows.go
+++ b/drivers/storage/portworx/component/windows.go
@@ -153,6 +153,7 @@ func (w *windows) createDaemonSet(filename, daemonsetName, nameSpace string, clu
 	if ownerRef != nil {
 		daemonSet.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 	}
+	daemonSet.Spec.Template.ObjectMeta = k8s.AddManagedByOperatorLabel(daemonSet.Spec.Template.ObjectMeta)
 
 	for i, container := range daemonSet.Spec.Template.Spec.Containers {
 		var image string

--- a/drivers/storage/portworx/testspec/autopilotDeployment.yaml
+++ b/drivers/storage/portworx/testspec/autopilotDeployment.yaml
@@ -31,6 +31,7 @@ spec:
       labels:
         name: autopilot
         tier: control-plane
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       containers:
       - command:

--- a/drivers/storage/portworx/testspec/ccmGoCollectorDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorDeployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         role: realtime-metrics-collector
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSet.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSet.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         name: px-telemetry-phonehome
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSetDefaultPort.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSetDefaultPort.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       labels:
         name: px-telemetry-phonehome
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       labels:
         role: px-telemetry-registration
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_14.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentAlphaDisabledK8s_1_16.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithPKS.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithPKS.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizerAndOldDriver_1.0.yaml
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         app: px-csi-driver
     spec:
       serviceAccountName: px-csi

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1.0.yaml
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         app: px-csi-driver
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1_17.yaml
+++ b/drivers/storage/portworx/testspec/csiDeploymentWithResizer_1_17.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s116.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_with_topology.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s120_without_snapcontroller.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
+++ b/drivers/storage/portworx/testspec/csiDeployment_1.0_k8s123.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/grafanaDeployment.yaml
+++ b/drivers/storage/portworx/testspec/grafanaDeployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         app: grafana
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/lighthouseDeployment.yaml
+++ b/drivers/storage/portworx/testspec/lighthouseDeployment.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         tier: px-web-console
     spec:
       initContainers:

--- a/drivers/storage/portworx/testspec/metricsCollectorDeployment.yaml
+++ b/drivers/storage/portworx/testspec/metricsCollectorDeployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       labels:
         role: realtime-metrics-collector
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       affinity:
         nodeAffinity:

--- a/drivers/storage/portworx/testspec/nginx-deployment.yaml
+++ b/drivers/storage/portworx/testspec/nginx-deployment.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         name: px-plugin-proxy
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       volumes:
         - name: px-plugin-proxy-conf

--- a/drivers/storage/portworx/testspec/openshift_runc.yaml
+++ b/drivers/storage/portworx/testspec/openshift_runc.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/pks.yaml
+++ b/drivers/storage/portworx/testspec/pks.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/pks_2.9.1.yaml
+++ b/drivers/storage/portworx/testspec/pks_2.9.1.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/plugin-deployment.yaml
+++ b/drivers/storage/portworx/testspec/plugin-deployment.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         app: px-plugin
         app.kubernetes.io/name: px-plugin
         app.kubernetes.io/instance: px-plugin

--- a/drivers/storage/portworx/testspec/portworxAPIDaemonSet.yaml
+++ b/drivers/storage/portworx/testspec/portworxAPIDaemonSet.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx-api
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodCustomPort.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
+++ b/drivers/storage/portworx/testspec/portworxPodEnvOverride.yaml
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/prometheusInstanceWithAlertManager.yaml
+++ b/drivers/storage/portworx/testspec/prometheusInstanceWithAlertManager.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: kube-test
 spec:
   replicas: 1
+  podMetadata:
+    labels:
+      operator.libopenstorage.org/managed-by: portworx
   logLevel: debug
   serviceAccountName: px-prometheus
   image: quay.io/prometheus/prometheus:v1.2.3

--- a/drivers/storage/portworx/testspec/prometheusInstanceWithRemoteWriteEndpoint.yaml
+++ b/drivers/storage/portworx/testspec/prometheusInstanceWithRemoteWriteEndpoint.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   replicas: 1
   logLevel: debug
+  podMetadata:
+    labels:
+      operator.libopenstorage.org/managed-by: portworx
   serviceAccountName: px-prometheus
   image: quay.io/prometheus/prometheus:v1.2.3
   serviceMonitorSelector:

--- a/drivers/storage/portworx/testspec/prometheusOperatorDeployment.yaml
+++ b/drivers/storage/portworx/testspec/prometheusOperatorDeployment.yaml
@@ -13,6 +13,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         k8s-app: px-prometheus-operator
     spec:
       containers:

--- a/drivers/storage/portworx/testspec/prometheusOperatorDeployment_v0.50.0.yaml
+++ b/drivers/storage/portworx/testspec/prometheusOperatorDeployment_v0.50.0.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         k8s-app: px-prometheus-operator
     spec:
       containers:

--- a/drivers/storage/portworx/testspec/pvcControllerDeployment.yaml
+++ b/drivers/storage/portworx/testspec/pvcControllerDeployment.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         name: portworx-pvc-controller
         tier: control-plane
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       containers:
       - command:

--- a/drivers/storage/portworx/testspec/px-csi-node-win.yaml
+++ b/drivers/storage/portworx/testspec/px-csi-node-win.yaml
@@ -11,6 +11,7 @@ spec:
     metadata:
       labels:
         app: px-csi-node-win
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       containers:
         - args:

--- a/drivers/storage/portworx/testspec/px-csi-node-win.yaml
+++ b/drivers/storage/portworx/testspec/px-csi-node-win.yaml
@@ -10,6 +10,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         app: px-csi-node-win
         operator.libopenstorage.org/managed-by: portworx
     spec:

--- a/drivers/storage/portworx/testspec/px-csi-win-driver.yaml
+++ b/drivers/storage/portworx/testspec/px-csi-win-driver.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         app: px-csi-win-driver
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       serviceAccountName: portworx
       containers:

--- a/drivers/storage/portworx/testspec/px-csi-win-driver.yaml
+++ b/drivers/storage/portworx/testspec/px-csi-win-driver.yaml
@@ -11,6 +11,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         app: px-csi-win-driver
         operator.libopenstorage.org/managed-by: portworx
     spec:

--- a/drivers/storage/portworx/testspec/pxProxyDaemonSet.yaml
+++ b/drivers/storage/portworx/testspec/pxProxyDaemonSet.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx-proxy
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/px_csi_0.3.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_0.3.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/px_csi_1.0.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_1.0.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/px_disable_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_disable_telemetry.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs.yaml
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_ca.yaml
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_cert.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_cert.yaml
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_certs_without_key.yaml
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
+++ b/drivers/storage/portworx/testspec/px_kvdb_without_certs.yaml
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/px_master.yaml
+++ b/drivers/storage/portworx/testspec/px_master.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
+++ b/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
@@ -12,6 +12,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry-with-location.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/px_telemetry.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
+++ b/drivers/storage/portworx/testspec/px_telemetry_with_proxy.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/runc.yaml
+++ b/drivers/storage/portworx/testspec/runc.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       affinity:

--- a/drivers/storage/portworx/testspec/runc_2.9.1.yaml
+++ b/drivers/storage/portworx/testspec/runc_2.9.1.yaml
@@ -14,6 +14,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         name: portworx
     spec:
       hostNetwork: true

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -37,6 +37,11 @@ const (
 	// the custom registry, there is a list of hardcoded common registries, however the list
 	// may not be complete, users can use this annotation to add more.
 	AnnotationCommonImageRegistries = OperatorPrefix + "/common-image-registries"
+	// OperatorLabelManagedByKey is a label key that is added to any object that is
+	// managed the Portworx operator.
+	OperatorLabelManagedByKey = OperatorPrefix + "/managed-by"
+	// OperatorLabelManagedByValue indicates that the object is managed by portworx.
+	OperatorLabelManagedByValue = "portworx"
 )
 
 const (

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -1386,8 +1386,9 @@ func TestStoragePodGetsScheduled(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				constants.LabelKeyClusterName: cluster.Name,
-				constants.LabelKeyDriverName:  driverName,
+				constants.LabelKeyClusterName:       cluster.Name,
+				constants.LabelKeyDriverName:        driverName,
+				constants.OperatorLabelManagedByKey: constants.OperatorLabelManagedByValue,
 			},
 			Annotations: make(map[string]string),
 		},
@@ -1500,8 +1501,9 @@ func TestStoragePodGetsScheduledK8s1_24(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				constants.LabelKeyClusterName: cluster.Name,
-				constants.LabelKeyDriverName:  driverName,
+				constants.LabelKeyClusterName:       cluster.Name,
+				constants.LabelKeyDriverName:        driverName,
+				constants.OperatorLabelManagedByKey: constants.OperatorLabelManagedByValue,
 			},
 			Annotations: make(map[string]string),
 		},
@@ -1884,8 +1886,9 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "test-ns",
 			Labels: map[string]string{
-				constants.LabelKeyClusterName: cluster.Name,
-				constants.LabelKeyDriverName:  driverName,
+				constants.LabelKeyClusterName:       cluster.Name,
+				constants.LabelKeyDriverName:        driverName,
+				constants.OperatorLabelManagedByKey: constants.OperatorLabelManagedByValue,
 			},
 		},
 		Spec: expectedPodSpec,

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1369,6 +1369,7 @@ func (c *Controller) CreatePodTemplate(
 		},
 		Spec: podSpec,
 	}
+	newTemplate.Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 
 	if !pxutil.IsPrivileged(cluster) {
 		// turn off AppArmor?

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1063,7 +1063,6 @@ func (c *Controller) syncNodes(
 			go func(idx int) {
 				defer createWait.Done()
 				nodeName := nodesNeedingStoragePods[idx]
-				podTemplates[idx].Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 				err := c.podControl.CreatePods(
 					context.TODO(),
 					cluster.Namespace,
@@ -1363,10 +1362,12 @@ func (c *Controller) CreatePodTemplate(
 	k8s.AddOrUpdateStoragePodTolerations(&podSpec)
 
 	podSpec.NodeName = node.Name
+	labels := c.StorageClusterSelectorLabels(cluster)
+	labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 	newTemplate := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   cluster.Namespace,
-			Labels:      c.StorageClusterSelectorLabels(cluster),
+			Labels:      labels,
 			Annotations: make(map[string]string),
 		},
 		Spec: podSpec,
@@ -1586,9 +1587,10 @@ func (c *Controller) createStorageNode(
 
 // StorageClusterSelectorLabels returns the selector labels for child objects of given storagecluster
 func (c *Controller) StorageClusterSelectorLabels(cluster *corev1.StorageCluster) map[string]string {
-	clusterLabels := c.Driver.GetSelectorLabels()
-	if clusterLabels == nil {
-		clusterLabels = make(map[string]string)
+	driverLabels := c.Driver.GetSelectorLabels()
+	clusterLabels := make(map[string]string)
+	for k, v := range driverLabels {
+		clusterLabels[k] = v
 	}
 	clusterLabels[constants.LabelKeyClusterName] = cluster.Name
 	clusterLabels[constants.LabelKeyDriverName] = c.Driver.String()

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1063,6 +1063,7 @@ func (c *Controller) syncNodes(
 			go func(idx int) {
 				defer createWait.Done()
 				nodeName := nodesNeedingStoragePods[idx]
+				podTemplates[idx].Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 				err := c.podControl.CreatePods(
 					context.TODO(),
 					cluster.Namespace,
@@ -1248,6 +1249,7 @@ func (c *Controller) createPodTemplateForNodeGroup(
 		if err != nil {
 			return err
 		}
+
 		*nodesNeedingStoragePods = append(*nodesNeedingStoragePods, node.Name)
 		*podTemplates = append(*podTemplates, podTemplate.DeepCopy())
 		delete(remainingNodes, node.Name)
@@ -1369,7 +1371,6 @@ func (c *Controller) CreatePodTemplate(
 		},
 		Spec: podSpec,
 	}
-	newTemplate.Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 
 	if !pxutil.IsPrivileged(cluster) {
 		// turn off AppArmor?

--- a/pkg/controller/storagecluster/stork.go
+++ b/pkg/controller/storagecluster/stork.go
@@ -85,6 +85,11 @@ var (
 		"component": "scheduler",
 		"name":      storkSchedDeploymentName,
 	}
+	storkSchedulerDeploymentPodLabels = map[string]string{
+		"tier":      "control-plane",
+		"component": "scheduler",
+		"name":      storkSchedDeploymentName,
+	}
 	storkSchedulerDeploymentSelectorLabels = map[string]string{
 		"tier":      "control-plane",
 		"component": "scheduler",
@@ -1047,7 +1052,7 @@ func getStorkSchedDeploymentSpec(
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   storkSchedDeploymentName,
-					Labels: storkSchedulerDeploymentLabels,
+					Labels: storkSchedulerDeploymentPodLabels,
 				},
 				Spec: v1.PodSpec{
 					ServiceAccountName: storkSchedServiceAccountName,

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -2636,7 +2636,7 @@ func TestStorkSchedulerWithMissingLabelsFromSelector(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, schedDeployment.Spec.Selector.MatchLabels, 3)
 	require.Equal(t, storkSchedDeploymentName, schedDeployment.Spec.Selector.MatchLabels["name"])
-	require.Len(t, schedDeployment.Spec.Template.Labels, 3)
+	require.Len(t, schedDeployment.Spec.Template.Labels, 4)
 	require.Equal(t, storkSchedDeploymentName, schedDeployment.Spec.Template.Labels["name"])
 
 	// TestCase: Set selector to empty and check the resource version

--- a/pkg/controller/storagecluster/testspec/storkDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkDeployment.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         name: stork
         tier: control-plane
+        operator.libopenstorage.org/managed-by: portworx
     spec:
       containers:
       - command:

--- a/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedDeployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         component: scheduler
         tier: control-plane
         name: stork-scheduler

--- a/pkg/controller/storagecluster/testspec/storkSchedKubeSchedConfigDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedKubeSchedConfigDeployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         component: scheduler
         tier: control-plane
         name: stork-scheduler

--- a/pkg/controller/storagecluster/testspec/storkSchedVersionedDeployment.yaml
+++ b/pkg/controller/storagecluster/testspec/storkSchedVersionedDeployment.yaml
@@ -22,6 +22,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         component: scheduler
         tier: control-plane
         name: stork-scheduler

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -376,6 +376,12 @@ func (c *Controller) syncStorage(
 				}
 			}
 
+			value, present := podCopy.Annotations[constants.OperatorLabelManagedByKey]
+			if !present || value != constants.OperatorLabelManagedByValue {
+				podCopy.Annotations[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
+				updateNeeded = true
+			}
+
 			if updateNeeded {
 				// TODO: get latest pod to update
 				if err := c.client.Update(context.TODO(), podCopy); err != nil {
@@ -413,9 +419,10 @@ func (c *Controller) createKVDBPod(
 
 func (c *Controller) kvdbPodLabels(cluster *corev1.StorageCluster) map[string]string {
 	return map[string]string{
-		constants.LabelKeyClusterName: cluster.Name,
-		constants.LabelKeyDriverName:  c.Driver.String(),
-		constants.LabelKeyKVDBPod:     constants.LabelValueTrue,
+		constants.LabelKeyClusterName:       cluster.Name,
+		constants.LabelKeyDriverName:        c.Driver.String(),
+		constants.LabelKeyKVDBPod:           constants.LabelValueTrue,
+		constants.OperatorLabelManagedByKey: constants.OperatorLabelManagedByValue,
 	}
 }
 

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -376,9 +376,12 @@ func (c *Controller) syncStorage(
 				}
 			}
 
-			value, present := podCopy.Annotations[constants.OperatorLabelManagedByKey]
+			value, present := podCopy.Labels[constants.OperatorLabelManagedByKey]
 			if !present || value != constants.OperatorLabelManagedByValue {
-				podCopy.Annotations[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
+				if podCopy.Labels == nil {
+					podCopy.Labels = make(map[string]string)
+				}
+				podCopy.Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 				updateNeeded = true
 			}
 

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1504,6 +1504,13 @@ func CreateOrUpdatePrometheus(
 		}
 	}
 
+	if prometheus.Spec.PodMetadata == nil {
+		prometheus.Spec.PodMetadata = &monitoringv1.EmbeddedObjectMetadata{}
+	}
+	if prometheus.Spec.PodMetadata.Labels == nil {
+		prometheus.Spec.PodMetadata.Labels = make(map[string]string)
+	}
+	prometheus.Spec.PodMetadata.Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 	if modified || len(prometheus.OwnerReferences) > len(existingPrometheus.OwnerReferences) {
 		prometheus.ResourceVersion = existingPrometheus.ResourceVersion
 		logrus.Infof("Updating Prometheus %s/%s", prometheus.Namespace, prometheus.Name)
@@ -1579,6 +1586,13 @@ func CreateOrUpdateAlertManager(
 		}
 	}
 
+	if alertManager.Spec.PodMetadata == nil {
+		alertManager.Spec.PodMetadata = &monitoringv1.EmbeddedObjectMetadata{}
+	}
+	if alertManager.Spec.PodMetadata.Labels == nil {
+		alertManager.Spec.PodMetadata.Labels = make(map[string]string)
+	}
+	alertManager.Spec.PodMetadata.Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 	if modified || len(alertManager.OwnerReferences) > len(existingAlertManager.OwnerReferences) {
 		alertManager.ResourceVersion = existingAlertManager.ResourceVersion
 		logrus.Infof("Updating AlertManager %s/%s", alertManager.Namespace, alertManager.Name)
@@ -2252,4 +2266,12 @@ func AppendObjectList(k8sClient client.Client, namespace string, list client.Obj
 	}
 
 	return nil
+}
+
+func AddManagedByOperatorLabel(om metav1.ObjectMeta) metav1.ObjectMeta {
+	if om.Labels == nil {
+		om.Labels = make(map[string]string)
+	}
+	om.Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
+	return om
 }

--- a/test/integration_test/testspec/metricsCollectorDeployment.yaml
+++ b/test/integration_test/testspec/metricsCollectorDeployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       labels:
+        operator.libopenstorage.org/managed-by: portworx
         role: realtime-metrics-collector
     spec:
       affinity:


### PR DESCRIPTION
**What this PR does / why we need it**:
* Adds common label to all managed pods:
`operator.libopenstorage.org/managed-by=portworx`

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
```
$ Every 2.0s: kubectl -n kube-system get pods -l operator.libopenstorage.org/managed-by=portworx grant-dev-vm: Tue Sep 12 20:02:19 2023

NAME                                                    READY   STATUS    RESTARTS   AGE
autopilot-7dc954b87-8kg2n                               1/1     Running   0          12m
portworx-api-2h9gw                                      1/1     Running   0          12m
portworx-api-jv85b                                      1/1     Running   0          12m
portworx-api-vj7vz                                      1/1     Running   0          12m
portworx-kvdb-cts85                                     1/1     Running   0          8m34s
portworx-kvdb-nvxsq                                     1/1     Running   0          8m33s
portworx-kvdb-x522v                                     1/1     Running   0          8m34s
prometheus-px-prometheus-0                              2/2     Running   0          12m
px-cluster-30d5fad9-3f00-425f-a3de-2b9d133bb03a-78nr7   2/2     Running   0          12m
px-cluster-30d5fad9-3f00-425f-a3de-2b9d133bb03a-9mnvl   2/2     Running   0          12m
px-cluster-30d5fad9-3f00-425f-a3de-2b9d133bb03a-lkfq8   2/2     Running   0          12m
px-csi-ext-858b485b46-fjkg8                             4/4     Running   0          12m
px-csi-ext-858b485b46-krtxx                             4/4     Running   0          12m
px-csi-ext-858b485b46-zj7wg                             4/4     Running   0          12m
px-grafana-56db67c454-q5p98                             1/1     Running   0          23s
px-prometheus-operator-68fd4567f-658r4                  1/1     Running   0          12m
px-telemetry-metrics-collector-5b8748bb5d-mdf5k         2/2     Running   0          8m32s
px-telemetry-phonehome-599lf                            2/2     Running   0          8m32s
px-telemetry-phonehome-sstpq                            2/2     Running   0          8m32s
px-telemetry-phonehome-wgp2r                            2/2     Running   0          8m32s
px-telemetry-registration-7f78788bcb-qgb52              2/2     Running   0          8m32s
stork-f6d68b474-5v5hp                                   1/1     Running   0          12m
stork-f6d68b474-ccsjv                                   1/1     Running   0          12m
stork-f6d68b474-rj225                                   1/1     Running   0          12m
stork-scheduler-6699f6d469-47zjq                        1/1     Running   0          12m
stork-scheduler-6699f6d469-4shd2                        1/1     Running   0          12m
stork-scheduler-6699f6d469-qqrrq                        1/1     Running   0          12m

```
