### PR TITLE
PWX-33374:Set Security context for OCP before pre-flight is launched.

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -98,7 +98,7 @@ func (p *portworx) Init(
 	return nil
 }
 
-func EnableSecurityContextForValidate(recorder record.EventRecorder, cluster *corev1.StorageCluster) error {
+func createSecurityContextForValidate(recorder record.EventRecorder, cluster *corev1.StorageCluster) error {
 	if secComp, exists := component.Get(component.SCCComponentName); exists {
 		if secComp.IsEnabled(cluster) {
 			err := secComp.Reconcile(cluster)
@@ -156,7 +156,7 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 		return nil
 	}
 
-	if err := EnableSecurityContextForValidate(p.recorder, cluster); err != nil {
+	if err := createSecurityContextForValidate(p.recorder, cluster); err != nil {
 		setClusterCondition(corev1.ClusterConditionStatusFailed, err.Error())
 		deletePreflight()
 		return err

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -236,7 +236,7 @@ func TestValidate(t *testing.T) {
 	err = k8sClient.Create(context.TODO(), crd)
 	require.NoError(t, err)
 
-	err = EnableSecurityContextForValidate(recorder, cluster)
+	err = createSecurityContextForValidate(recorder, cluster)
 	require.NoError(t, err)
 
 	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Preflight running in a custom namespace (portworx) failed to start in OCP on a fresh cluster due to OCP security setting missing for the custom namespace.   The setting where missing because they where not being applied until the pre-install of the storage cluster which was done after pre-flight was run.   So now we are installing the security setting during pre-flight also to make sure they exist.
 
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-33374
**Special notes for your reviewer**:

