### PR TITLE
PWX-32952 : Update nginx image to nginx-unprivileged:1.25

### DIFF
--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -54,7 +54,7 @@ const (
 
 	// default dynamic plugin images
 	DefaultDynamicPluginImage      = "portworx/portworx-dynamic-plugin:1.1.0"
-	DefaultDynamicPluginProxyImage = "nginxinc/nginx-unprivileged:1.23"
+	DefaultDynamicPluginProxyImage = "nginxinc/nginx-unprivileged:1.25"
 
 	defaultManifestRefreshInterval = 3 * time.Hour
 )

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -42,7 +42,7 @@ func TestManifestWithNewerPortworxVersion(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
-			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -83,7 +83,7 @@ func TestManifestWithNewerPortworxVersionAndConfigMapPresent(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
-			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
 		},
 	}
 
@@ -176,7 +176,7 @@ func TestManifestWithOlderPortworxVersion(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
-			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -269,7 +269,7 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
-			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -352,7 +352,7 @@ func TestManifestWithoutPortworxVersion(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
-			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
 		},
 	}
 	cluster := &corev1.StorageCluster{

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -207,7 +207,7 @@ func TestValidate(t *testing.T) {
 	preFlighter := NewPreFlighter(cluster, k8sClient, podSpec)
 	require.NotNil(t, preFlighter)
 
-	/// Create preflighter podSpec
+	// / Create preflighter podSpec
 	preflightDSCheck, err := preFlighter.CreatePreFlightDaemonsetSpec(clusterRef)
 	require.NoError(t, err)
 	require.NotNil(t, preflightDSCheck)
@@ -2579,7 +2579,7 @@ func TestStorageClusterDefaultsForPlugin(t *testing.T) {
 	err := driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 	require.Equal(t, cluster.Status.DesiredImages.DynamicPlugin, "portworx/portworx-dynamic-plugin:1.1.0")
-	require.Equal(t, cluster.Status.DesiredImages.DynamicPluginProxy, "nginxinc/nginx-unprivileged:1.23")
+	require.Equal(t, cluster.Status.DesiredImages.DynamicPluginProxy, "nginxinc/nginx-unprivileged:1.25")
 }
 
 func TestStorageClusterDefaultsForWindows(t *testing.T) {
@@ -10436,7 +10436,7 @@ func (m *fakeManifest) GetVersions(
 			TelemetryProxy:             "purestorage/envoy:1.2.3",
 			PxRepo:                     "portworx/px-repo:" + compVersion,
 			DynamicPlugin:              "portworx/portworx-dynamic-plugin:1.1.0",
-			DynamicPluginProxy:         "nginxinc/nginx-unprivileged:1.23",
+			DynamicPluginProxy:         "nginxinc/nginx-unprivileged:1.25",
 			CsiLivenessProbe:           "docker.io/portworx/livenessprobe:v2.10.0-windows",
 			CsiWindowsDriver:           "docker.io/portworx/px-windows-csi-driver:23.8.0",
 			CsiWindowsNodeRegistrar:    "docker.io/portworx/csi-node-driver-registrar:v2.8.0-windows",

--- a/drivers/storage/portworx/testspec/nginx-deployment.yaml
+++ b/drivers/storage/portworx/testspec/nginx-deployment.yaml
@@ -21,7 +21,7 @@ spec:
             secretName: px-plugin-proxy
       containers:
         - name: nginx
-          image: docker.io/nginxinc/nginx-unprivileged:1.23
+          image: docker.io/nginxinc/nginx-unprivileged:1.25
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Fixes https://portworx.atlassian.net/browse/PWX-32952
Tested dynamic plugin feature with image nginx-unprivileged:1.23 on OCP cluster