### PR TITLE
PWX-30455 (op-23.10.0): mounts override fix (#1226)

### DIFF
--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -684,7 +684,7 @@ func TestStcMountsAndOverrides(t *testing.T) {
 		mk("journalmount2", "/var/log", "/var/log", true, propNil),
 	}
 
-	testVols := getCommonVolumeList(pxutil.MinimumPxVersionAutoTLS)
+	testVols := getCommonVolumeList(pxVer2_13_8)
 	for i := range testVols {
 		testVols[i].pks = nil
 	}

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -258,6 +258,8 @@ var (
 	MinimumPxVersionCCMGO, _ = version.NewVersion("2.12")
 	// MinimumPxVersionMetricsCollector minimum PX version to install metrics collector
 	MinimumPxVersionMetricsCollector, _ = version.NewVersion("2.9.1")
+	// MinimumPxVersionAutoTLS is a minimal PX version that supports "auto-TLS" setup
+	MinimumPxVersionAutoTLS, _ = version.NewVersion("4.0.0")
 
 	// ConfigMapNameRegex regex of configMap.
 	ConfigMapNameRegex = regexp.MustCompile("[^a-zA-Z0-9]+")

--- a/pkg/migration/generate.go
+++ b/pkg/migration/generate.go
@@ -729,7 +729,7 @@ func getVolumeSpecs(
 			logrus.WithFields(logrus.Fields{
 				"name":      m.Name,
 				"mountPath": m.MountPath,
-			}).Warningf("found mountPath conflict when constructing StorageCluster from DaemonSet, volume will be ignored")
+			}).Warnf("found mountPath conflict when constructing StorageCluster from DaemonSet, volume will be ignored")
 			continue
 		}
 		volumeSpecMap[m.Name] = &corev1.VolumeSpec{


### PR DESCRIPTION
* custom mounts can now override the embedded (default) mounts

Signed-off-by: Zoran Rajic <zox@portworx.com>

Manually fixed Conflicts:
	drivers/storage/portworx/deployment_test.go

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

this is a cherry-pick of https://github.com/libopenstorage/operator/pull/1226 into `px-rel-23.10.0` branch

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-30455 (op-23.10.0)

**Special notes for your reviewer**:

