### PR TITLE
PWX-33843: enable windows component if enable-windows annotation is true

### DIFF
--- a/drivers/storage/portworx/component/windows.go
+++ b/drivers/storage/portworx/component/windows.go
@@ -73,7 +73,9 @@ func (w *windows) IsEnabled(cluster *corev1.StorageCluster) bool {
 	// enable if windows node is detected
 	// and k8s version of cluster is > 1.25.0
 	// and CSI is enabled in STC
-	return w.isWindowsNode && w.k8sVersion.GreaterThanOrEqual(k8s.K8sVer1_25) && pxutil.IsCSIEnabled(cluster)
+	return pxutil.IsWindowsEnabled(cluster) && pxutil.IsCSIEnabled(cluster) &&
+		w.isWindowsNode && w.k8sVersion.GreaterThanOrEqual(k8s.K8sVer1_25)
+
 }
 
 func (w *windows) Reconcile(cluster *corev1.StorageCluster) error {

--- a/drivers/storage/portworx/component/windows.go
+++ b/drivers/storage/portworx/component/windows.go
@@ -73,6 +73,7 @@ func (w *windows) IsEnabled(cluster *corev1.StorageCluster) bool {
 	// enable if windows node is detected
 	// and k8s version of cluster is > 1.25.0
 	// and CSI is enabled in STC
+	// and portworx.io/enable-windows annotation is set to true in STC
 	return pxutil.IsWindowsEnabled(cluster) && pxutil.IsCSIEnabled(cluster) &&
 		w.isWindowsNode && w.k8sVersion.GreaterThanOrEqual(k8s.K8sVer1_25)
 

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -16422,9 +16422,6 @@ func TestWindowsComponentInstallAndUninstall(t *testing.T) {
 			Labels: map[string]string{
 				"kubernetes.io/os": "windows",
 			},
-			Annotations: map[string]string{
-				"portworx.io/enable-windows": "true",
-			},
 		},
 	}
 
@@ -16439,6 +16436,9 @@ func TestWindowsComponentInstallAndUninstall(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
 			Namespace: "kube-system",
+			Annotations: map[string]string{
+				"portworx.io/enable-windows": "true",
+			},
 		},
 		Spec: corev1.StorageClusterSpec{
 			Image: "px/image:2.10.0",

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -160,6 +160,8 @@ const (
 	AnnotationServerTLSMinVersion = pxAnnotationPrefix + "/tls-min-version"
 	// AnnotationServerTLSCipherSuites sets up TLS-servers w/ requested cipher suites
 	AnnotationServerTLSCipherSuites = pxAnnotationPrefix + "/tls-cipher-suites"
+	// AnnotationEnableWindows annotation indicates whether cluster has windows nodes
+	AnnotationEnableWindows = pxAnnotationPrefix + "/enable-windows"
 
 	// EnvKeyPXImage key for the environment variable that specifies Portworx image
 	EnvKeyPXImage = "PX_IMAGE"
@@ -377,6 +379,12 @@ func IsVsphere(cluster *corev1.StorageCluster) bool {
 func IsPrivileged(cluster *corev1.StorageCluster) bool {
 	enabled, err := strconv.ParseBool(cluster.Annotations[AnnotationIsPrivileged])
 	return err != nil || enabled
+}
+
+// IsPrivileged returns true "privileged" annotation is MISSING, or NOT set to FALSE
+func IsWindowsEnabled(cluster *corev1.StorageCluster) bool {
+	enabled, err := strconv.ParseBool(cluster.Annotations[AnnotationEnableWindows])
+	return err == nil && enabled
 }
 
 // GetCloudProvider returns the cloud provider string


### PR DESCRIPTION
**What this PR does / why we need it**:
To enable windows component if **portworx.io/enable-windows** annotation is set to true. The windows feature should be controlled by the feature flag.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-33843



