### PR TITLE
Add env check to set pure provider and enable pre-flight for pure pro…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,7 @@ DOCK_BUILD_CNT	:= golang:1.20
 
 docker-build:
 	@echo "Building using docker"
-	docker run --rm -v $(shell pwd):/go/src/github.com/libopenstorage/operator $(DOCK_BUILD_CNT) \
+	docker run --rm --privileged=true -v $(shell pwd):/go/src/github.com/libopenstorage/operator $(DOCK_BUILD_CNT) \
 		/bin/bash -c "cd /go/src/github.com/libopenstorage/operator; make vendor-update all test integration-test"
 
 deploy:

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -650,6 +650,11 @@ func TestValidatePure(t *testing.T) {
 	err = driver.Validate(cluster)
 	require.NoError(t, err)
 	require.Contains(t, cluster.Annotations[pxutil.AnnotationMiscArgs], "-T px-storev2")
+
+	actual, err := driver.GetStoragePodSpec(cluster, "testNode")
+	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
+	require.Contains(t, strings.Join(actual.Containers[0].Args, " "), "-cloud_provider pure")
+
 	require.NotEmpty(t, recorder.Events)
 	<-recorder.Events // Pop first event which is Default telemetry enabled event
 	require.Contains(t, <-recorder.Events,

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -553,6 +553,109 @@ func TestValidateVsphere(t *testing.T) {
 	require.Contains(t, *cluster.Spec.CloudStorage.SystemMdDeviceSpec, DefCmetaVsphere)
 }
 
+func TestValidatePure(t *testing.T) {
+	driver := portworx{}
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+	}
+
+	labels := map[string]string{
+		"name": pxPreFlightDaemonSetName,
+	}
+
+	// force vsphere
+	env := make([]v1.EnvVar, 1)
+	env[0].Name = "PURE_FLASHARRAY_SAN_TYPE"
+	env[0].Value = "ISCSI"
+	cluster.Spec.Env = env
+
+	clusterRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	preflightDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pxPreFlightDaemonSetName,
+			Namespace:       cluster.Namespace,
+			Labels:          labels,
+			UID:             types.UID("preflight-ds-uid"),
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
+
+	checks := []corev1.CheckResult{
+		{
+			Type:    "status",
+			Reason:  "oci-mon: pre-flight completed",
+			Success: true,
+		},
+	}
+
+	status := corev1.NodeStatus{
+		Checks: checks,
+	}
+
+	storageNode := &corev1.StorageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "node-1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Status: status,
+	}
+
+	preFlightPod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "preflight-1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{UID: preflightDS.UID}},
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "portworx",
+					Ready: true,
+				},
+			},
+		},
+	}
+
+	cluster.Spec.CloudStorage = &corev1.CloudStorageSpec{}
+
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	k8sClient := testutil.FakeK8sClient(preflightDS)
+
+	err := k8sClient.Create(context.TODO(), preFlightPod1)
+	require.NoError(t, err)
+
+	preflightDS.Status.DesiredNumberScheduled = int32(1)
+	err = k8sClient.Status().Update(context.TODO(), preflightDS)
+	require.NoError(t, err)
+
+	recorder := record.NewFakeRecorder(100)
+	err = driver.Init(k8sClient, runtime.NewScheme(), recorder)
+	require.NoError(t, err)
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	err = k8sClient.Create(context.TODO(), storageNode)
+	require.NoError(t, err)
+
+	err = driver.Validate(cluster)
+	require.NoError(t, err)
+	require.Contains(t, cluster.Annotations[pxutil.AnnotationMiscArgs], "-T px-storev2")
+	require.NotEmpty(t, recorder.Events)
+	<-recorder.Events // Pop first event which is Default telemetry enabled event
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v %s", v1.EventTypeNormal, util.PassPreFlight, "Enabling PX-StoreV2"))
+}
+
 func TestGetSelectorLabels(t *testing.T) {
 	driver := portworx{}
 	expectedLabels := map[string]string{"name": pxutil.DriverName}

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -373,6 +373,16 @@ func IsVsphere(cluster *corev1.StorageCluster) bool {
 	return false
 }
 
+// IsPure true if VSPHERE_VCENTER is present in the spec
+func IsPure(cluster *corev1.StorageCluster) bool {
+	for _, env := range cluster.Spec.Env {
+		if env.Name == "PURE_FLASHARRAY_SAN_TYPE" && len(env.Value) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // IsPrivileged returns true "privileged" annotation is MISSING, or NOT set to FALSE
 func IsPrivileged(cluster *corev1.StorageCluster) bool {
 	enabled, err := strconv.ParseBool(cluster.Annotations[AnnotationIsPrivileged])
@@ -383,6 +393,10 @@ func IsPrivileged(cluster *corev1.StorageCluster) bool {
 func GetCloudProvider(cluster *corev1.StorageCluster) string {
 	if IsVsphere(cluster) {
 		return cloudops.Vsphere
+	}
+
+	if IsPure(cluster) {
+		return cloudops.Pure
 	}
 
 	if len(preflight.Instance().ProviderName()) > 0 {

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -373,7 +373,7 @@ func IsVsphere(cluster *corev1.StorageCluster) bool {
 	return false
 }
 
-// IsPure true if VSPHERE_VCENTER is present in the spec
+// IsPure true if PURE_FLASHARRAY_SAN_TYPE is present in the spec
 func IsPure(cluster *corev1.StorageCluster) bool {
 	for _, env := range cluster.Spec.Env {
 		if env.Name == "PURE_FLASHARRAY_SAN_TYPE" && len(env.Value) > 0 {

--- a/pkg/preflight/utils.go
+++ b/pkg/preflight/utils.go
@@ -17,7 +17,8 @@ func IsGKE() bool {
 // RequiresCheck returns whether a preflight check is needed based on the platform
 func RequiresCheck() bool {
 	return Instance().ProviderName() == string(cloudops.AWS) ||
-		Instance().ProviderName() == string(cloudops.Vsphere)
+		Instance().ProviderName() == string(cloudops.Vsphere) ||
+		Instance().ProviderName() == string(cloudops.Pure)
 }
 
 // RunningOnCloud checks whether portworx is running on cloud


### PR DESCRIPTION
…vide.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Have pre-flight run when we have a pure provider.   Check for variable `PURE_FLASHARRAY_SAN_TYPE` which gets added by our spec gen we choose Pure.

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-33992

**Special notes for your reviewer**:
Unit test output:

go test -v -coverprofile=profile.out -covermode=atomic -coverpkg=github.com/libopenstorage/operator/drivers/st\
orage/portworx/... github.com/libopenstorage/operator/drivers/storage/portworx -run TestValidatePure$
orage/portworx/... github.com/libopenstorage/operator/drivers/storage/portworx -run TestValidatePure$
=== RUN   TestValidatePure
time="2023-09-26T18:39:47Z" level=info msg="Using default max version"
time="2023-09-26T18:39:47Z" level=info msg="Using default max version"
time="2023-09-26T18:39:47Z" level=info msg="telemetry registration endpoint register.cloud-support.purestorage.com is accessible on cluster px-cluster"
time="2023-09-26T18:39:47Z" level=info msg="telemetry will be enabled by default"
time="2023-09-26T18:39:47Z" level=info msg="Using version extracted from image name: 2.10.0"
time="2023-09-26T18:39:47Z" level=info msg="Using version extracted from image name: 2.10.0"
time="2023-09-26T18:39:47Z" level=info msg="Using version extracted from image name: 2.10.0"
time="2023-09-26T18:39:47Z" level=info msg="Using version extracted from image name: 2.10.0"
time="2023-09-26T18:39:47Z" level=info msg="Using version extracted from image name: 2.10.0"
time="2023-09-26T18:39:47Z" level=info msg="Using version extracted from image name: 2.10.0"
time="2023-09-26T18:39:47Z" level=info msg="Using version extracted from image name: 2.10.0"
time="2023-09-26T18:39:47Z" level=info msg="Using version extracted from image name: 2.10.0"
time="2023-09-26T18:39:47Z" level=info msg="Creating kube-test/px-pre-flight ServiceAccount"
time="2023-09-26T18:39:47Z" level=info msg="Creating px-pre-flight ClusterRole"
time="2023-09-26T18:39:47Z" level=info msg="Creating px-pre-flight ClusterRoleBinding"
time="2023-09-26T18:39:47Z" level=info msg="Using version extracted from image name: 2.10.0"
time="2023-09-26T18:39:47Z" level=info msg="runPreFlight: daemonset already exists"
time="2023-09-26T18:39:47Z" level=info msg="Pre-flight status running time: 2562047h47m16.854775807s"
time="2023-09-26T18:39:47Z" level=info msg="Pre-flight Status: Completed [1] InProgress [0] Total Pods [1]"
time="2023-09-26T18:39:47Z" level=info msg="pre-flight: Completed [1] In Progress [0] Total [1]"
time="2023-09-26T18:39:47Z" level=info msg="pre-flight: checks completed..."
time="2023-09-26T18:39:47Z" level=info msg="pre-flight: process pre-flight results..."
time="2023-09-26T18:39:47Z" level=info msg="pre-flight: process pre-flight results..."
time="2023-09-26T18:39:47Z" level=info msg="storageNode[node-1]: []v1.CheckResult{v1.CheckResult{Type:\"status\", Reason:\"oci-mon: pre-flight completed\", Success:true}} "
time="2023-09-26T18:39:47Z" level=info msg="Enabling PX-StoreV2"
time="2023-09-26T18:39:47Z" level=info msg="pre-flight: done..."
time="2023-09-26T18:39:47Z" level=info msg="pre-flight: cleaning pre-flight ds..."
time="2023-09-26T18:39:47Z" level=info msg="Deleting kube-test/px-pre-flight ServiceAccount"
time="2023-09-26T18:39:47Z" level=info msg="Deleting px-pre-flight ClusterRole"
time="2023-09-26T18:39:47Z" level=info msg="Deleting px-pre-flight ClusterRoleBinding"
time="2023-09-26T18:39:47Z" level=info msg="Deleting kube-test/px-pre-flight DaemonSet"
--- PASS: TestValidatePure (0.18s)
PASS
        github.com/libopenstorage/operator/drivers/storage/portworx     coverage: 29.2% of statements in github.com/libopenstorage/operator/drivers/storage/portworx/...
        github.com/libopenstorage/operator/drivers/storage/portworx/component   coverage: 5.4% of statements in github.com/libopenstorage/operator/drivers/storage/portworx/\
...
        github.com/libopenstorage/operator/drivers/storage/portworx/manifest    coverage: 1.5% of statements in github.com/libopenstorage/operator/drivers/storage/portworx/\
...
        github.com/libopenstorage/operator/drivers/storage/portworx/util        coverage: 22.0% of statements in github.com/libopenstorage/operator/drivers/storage/portworx\
/...
ok      github.com/libopenstorage/operator/drivers/storage/portworx     0.264s  coverage: 29.2% of statements in github.com/libopenstorage/operator/drivers/storage/portworx\
/...
