### PR TITLE
PWX-34085: Add correct default metadata device (size=64) when pre-fli…

### DIFF
--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -656,6 +656,7 @@ func TestValidatePure(t *testing.T) {
 	actual, err := driver.GetStoragePodSpec(cluster, "testNode")
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 	require.Contains(t, strings.Join(actual.Containers[0].Args, " "), "-cloud_provider pure")
+	require.Contains(t, strings.Join(actual.Containers[0].Args, " "), "-metadata size=64")
 
 	require.NotEmpty(t, recorder.Events)
 	<-recorder.Events // Pop first event which is Default telemetry enabled event

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -661,6 +661,7 @@ func TestValidatePure(t *testing.T) {
 	<-recorder.Events // Pop first event which is Default telemetry enabled event
 	require.Contains(t, <-recorder.Events,
 		fmt.Sprintf("%v %v %s", v1.EventTypeNormal, util.PassPreFlight, "Enabling PX-StoreV2"))
+	require.Contains(t, *cluster.Spec.CloudStorage.SystemMdDeviceSpec, DefCmetaPure)
 
 	// Below just validate that changing the PURE_FLASHARRAY_SAN_TYPE value will still set the
 	// -cloud_provider param correctly.

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -656,7 +656,7 @@ func TestValidatePure(t *testing.T) {
 	actual, err := driver.GetStoragePodSpec(cluster, "testNode")
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
 	require.Contains(t, strings.Join(actual.Containers[0].Args, " "), "-cloud_provider pure")
-	require.Contains(t, strings.Join(actual.Containers[0].Args, " "), "-metadata size=64")
+	require.Contains(t, strings.Join(actual.Containers[0].Args, " "), "-metadata "+DefCmetaPure)
 
 	require.NotEmpty(t, recorder.Events)
 	<-recorder.Events // Pop first event which is Default telemetry enabled event

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -37,6 +37,8 @@ const (
 	DefCmetaAWS = "type=gp3,size=64"
 	// DefCmetaVsphere default metadata cloud device for DMthin Vsphere
 	DefCmetaVsphere = "type=eagerzeroedthick,size=64"
+	// DefCmetaPure default metadata cloud device for DMthin Pure
+	DefCmetaPure = "size=64"
 )
 
 // PreFlightPortworx provides a set of APIs to uninstall portworx
@@ -367,6 +369,8 @@ func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
 		cmetaData := DefCmetaAWS
 		if pxutil.IsVsphere(u.cluster) {
 			cmetaData = DefCmetaVsphere
+		} else if pxutil.IsPure(u.cluster) {
+			cmetaData = DefCmetaPure
 		}
 		u.cluster.Spec.CloudStorage.SystemMdDeviceSpec = &cmetaData
 	}


### PR DESCRIPTION
…ght is running with provider pure.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
When pre-flight was being run with pure provider the default metadata device was incorrect.   Make change to return the correct device value, ie size=64.

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-34085
**Special notes for your reviewer**:
Testing:  Updated the unit test to check the updated spec for the correct device.
