### PR TITLE
PWX-33990: Test for deployment selector labels instead of template

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -4432,7 +4432,7 @@ func validatePodTopologySpreadConstraints(deployment *appsv1.Deployment, timeout
 		if err != nil {
 			return nil, true, fmt.Errorf("failed to get deployment %s/%s", deployment.Namespace, deployment.Name)
 		}
-		expectedConstraints, err := util.GetTopologySpreadConstraintsFromNodes(nodeList, existingDeployment.Spec.Template.Labels)
+		expectedConstraints, err := util.GetTopologySpreadConstraintsFromNodes(nodeList, existingDeployment.Spec.Selector.MatchLabels)
 		if err != nil {
 			return nil, true, fmt.Errorf("failed to get expected pod topology spread constraints from %s/%s deployment template",
 				deployment.Namespace, deployment.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
Test was expecting the deployment labels to match the topology constraints, but this is not always correct.

**Which issue(s) this PR fixes** (optional)
PWX-33990

**Special notes for your reviewer**:
Test failure - 

Expected:

expected constraints: [{MaxSkew:1 TopologyKey:topology.kubernetes.io/region WhenUnsatisfiable:ScheduleAnyway LabelSelector:&LabelSelector{MatchLabels:map[string]string{name: portworx-pvc-controller,operator.libopenstorage.org/managed-by: portworx,tier: control-plane,},MatchExpressions:[]LabelSelectorRequirement{},} MinDomains:<nil> NodeAffinityPolicy:<nil> NodeTaintsPolicy:<nil> MatchLabelKeys:[]}]

Actual:

actual constraints:   [{MaxSkew:1 TopologyKey:topology.kubernetes.io/region WhenUnsatisfiable:ScheduleAnyway LabelSelector:&LabelSelector{MatchLabels:map[string]string{name: portworx-pvc-controller,tier: control-plane,},MatchExpressions:[]LabelSelectorRequirement{},} MinDomains:<nil> NodeAffinityPolicy:<nil> NodeTaintsPolicy:<nil> MatchLabelKeys:[]}]}
