### PR TITLE
PWX-31915: kvdb-api pod extended cleanup

### DIFF
--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -253,8 +253,9 @@ func (c *Controller) syncKVDB(
 		if p.Spec.NodeName == storageNode.Name {
 			// Let's delete the pod so that a new one will be created.
 			reason := strings.ToLower(p.Status.Reason)
-			if reason == "outofpods" || reason == "evicted" || reason == "terminated" {
-				logrus.Warningf("Found pod with %s status, will delete it: %+v", p.Status.Reason, p)
+			if reason == "outofpods" || reason == "evicted" || reason == "terminated" || reason == "nodeshutdown" {
+				logrus.Warningf("Found pod %s/%s with %s status, will delete it: %+v",
+					p.Namespace, p.Name, p.Status.Reason, p)
 				err = coreops.Instance().DeletePod(p.Name, p.Namespace, false)
 				if err != nil {
 					return err

--- a/pkg/controller/storagenode/storagenode_test.go
+++ b/pkg/controller/storagenode/storagenode_test.go
@@ -760,6 +760,7 @@ func TestReconcileKVDBOddSatusPodCleanup(t *testing.T) {
 		{"kvdb-term1", "Terminated", "Pod was terminated in response to imminent node shutdown."},
 		{"kvdb-evict2", "Evicted", "..."},
 		{"kvdb-out3", "OutOfPods", "..."},
+		{"kvdb-fail4", "NodeShutdown", "Pod Pod was rejected as the node is shutting down."},
 	}
 	for i, td := range testPodsData {
 		_, err := coreops.Instance().CreatePod(&v1.Pod{
@@ -785,7 +786,7 @@ func TestReconcileKVDBOddSatusPodCleanup(t *testing.T) {
 	// verify we got 3 quirky kvdb-pods
 	podList, err := coreops.Instance().GetPods(cluster.Namespace, kvdbPodLabs)
 	require.NoError(t, err)
-	require.Len(t, podList.Items, 3)
+	require.Len(t, podList.Items, len(testPodsData))
 
 	podNode2 := v1.PodSpec{
 		NodeName: testKVDBNode2,


### PR DESCRIPTION
* will explicitly remove also the failed-due-node-shutdown PODs

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is the extension of https://github.com/libopenstorage/operator/pull/1106 fix

ISSUE:
* turns out we can encounter other PODs stuck in "weird states" -- that will require explicit cleanup
* if such PODs are left in the system, they can interfere with the OCP upgrades

POD-status details:

```
Status:           Failed
Reason:           NodeShutdown
Message:          Pod Pod was rejected as the node is shutting down.
```

**Which issue(s) this PR fixes** (optional)
Closes # PWX-31915

**Special notes for your reviewer**:

Note that we still haven't reproduced the original issue --
* we know that it is linked to the OCP upgrade, where OCP will  cordon and restart a K8s-node (also replace K8s and OS binaries/directories/kernel/...) -- and
* this can cause PODs to get "orphaned" and stop being handled / garbage-collected by the K8s API-server