### PR TITLE
PWX-32670: Vsphere preflight should not run on PKS

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -9058,6 +9058,110 @@ func TestDoesTelemetryMatch(t *testing.T) {
 	}
 }
 
+func TestShouldPreflightRun(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+	}
+
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient := testutil.FakeK8sClient(cluster)
+	recorder := record.NewFakeRecorder(10)
+	controller := Controller{
+		client:            k8sClient,
+		Driver:            driver,
+		recorder:          recorder,
+		kubernetesVersion: k8sVersion,
+	}
+
+	// TestCase: aws cloud provider with image < 3.0
+	fakeK8sNodes := &v1.NodeList{Items: []v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Spec: v1.NodeSpec{ProviderID: "aws://node-id-1"}},
+	}}
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset(fakeK8sNodes)))
+
+	cluster.Spec.Image = "portworx/oci-image:2.9.0"
+
+	err := preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	require.Equal(t, string(cloudops.AWS), pxutil.GetCloudProvider(cluster)) // Make sure aws
+
+	driver.EXPECT().UpdateDriver(gomock.Any())
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.False(t, preflightShouldRun(cluster))
+
+	// Reset preflight for other tests
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	// TestCase: aws cloud provider with image >= 3.0
+	cluster.Spec.Image = "portworx/oci-image:3.0.0"
+
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	driver.EXPECT().UpdateDriver(gomock.Any())
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.True(t, preflightShouldRun(cluster))
+
+	// Reset preflight for other tests
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	// TestCase: Vsphere cloud provider with image = 3.0
+	cluster.Spec.Image = "portworx/oci-image:3.0.0"
+
+	// force vsphere
+	env := make([]v1.EnvVar, 1)
+	env[0].Name = "VSPHERE_VCENTER"
+	env[0].Value = "some.vcenter.server.com"
+	cluster.Spec.Env = env
+
+	require.Equal(t, string(cloudops.Vsphere), pxutil.GetCloudProvider(cluster)) // Make sure Vsphere
+
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	driver.EXPECT().UpdateDriver(gomock.Any())
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.False(t, preflightShouldRun(cluster))
+
+	// Reset preflight for other tests
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	// TestCase: Vsphere cloud provider with image >= 3.1
+	cluster.Spec.Image = "portworx/oci-image:3.1.0"
+
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	driver.EXPECT().UpdateDriver(gomock.Any())
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.True(t, preflightShouldRun(cluster))
+
+	// Reset preflight for other tests
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+}
+
 func TestEKSPreflightCheck(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -9081,6 +9081,7 @@ func TestShouldPreflightRun(t *testing.T) {
 	}
 
 	// TestCase: aws cloud provider with image < 3.0
+	logrus.Infof("check aws cloud w/PX < 3.0...")
 	fakeK8sNodes := &v1.NodeList{Items: []v1.Node{
 		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Spec: v1.NodeSpec{ProviderID: "aws://node-id-1"}},
 	}}
@@ -9098,12 +9099,14 @@ func TestShouldPreflightRun(t *testing.T) {
 	err = controller.setStorageClusterDefaults(cluster)
 	require.NoError(t, err)
 	require.False(t, preflightShouldRun(cluster))
+	logrus.Infof("aws cloud w/PX < 3.0, preflight will not run")
 
 	// Reset preflight for other tests
 	err = preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
 
 	// TestCase: aws cloud provider with image >= 3.0
+	logrus.Infof("check aws cloud w/PX >= 3.0...")
 	cluster.Spec.Image = "portworx/oci-image:3.0.0"
 
 	err = preflight.InitPreflightChecker(k8sClient)
@@ -9114,13 +9117,15 @@ func TestShouldPreflightRun(t *testing.T) {
 	err = controller.setStorageClusterDefaults(cluster)
 	require.NoError(t, err)
 	require.True(t, preflightShouldRun(cluster))
+	logrus.Infof("aws cloud w/PX >= 3.0, preflight will run")
 
 	// Reset preflight for other tests
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	err = preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
 
-	// TestCase: Vsphere cloud provider with image = 3.0
+	// TestCase: Vsphere cloud provider with image <= 3.0
+	logrus.Infof("check vsphere cloud w/PX <= 3.0...")
 	cluster.Spec.Image = "portworx/oci-image:3.0.0"
 
 	// force vsphere
@@ -9139,12 +9144,14 @@ func TestShouldPreflightRun(t *testing.T) {
 	err = controller.setStorageClusterDefaults(cluster)
 	require.NoError(t, err)
 	require.False(t, preflightShouldRun(cluster))
+	logrus.Infof("vshpere cloud w/PX <= 3.0, preflight will not run")
 
 	// Reset preflight for other tests
 	err = preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
 
 	// TestCase: Vsphere cloud provider with image >= 3.1
+	logrus.Infof("check vsphere cloud w/PX >= 3.1...")
 	cluster.Spec.Image = "portworx/oci-image:3.1.0"
 
 	err = preflight.InitPreflightChecker(k8sClient)
@@ -9155,11 +9162,139 @@ func TestShouldPreflightRun(t *testing.T) {
 	err = controller.setStorageClusterDefaults(cluster)
 	require.NoError(t, err)
 	require.True(t, preflightShouldRun(cluster))
+	logrus.Infof("vshpere cloud w/PX >= 3.1, preflight will run")
 
 	// Reset preflight for other tests
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	err = preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
+
+	// TestCase: Pure cloud provider with image <= 3.0
+	logrus.Infof("check Pure cloud w/PX <= 3.0...")
+	cluster.Spec.Image = "portworx/oci-image:3.0.0"
+
+	// force Pure
+	env = make([]v1.EnvVar, 1)
+	env[0].Name = "PURE_FLASHARRAY_SAN_TYPE"
+	env[0].Value = "FC"
+	cluster.Spec.Env = env
+
+	require.Equal(t, string(cloudops.Pure), pxutil.GetCloudProvider(cluster)) // Make sure Pure
+
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	driver.EXPECT().UpdateDriver(gomock.Any())
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.False(t, preflightShouldRun(cluster))
+	logrus.Infof("Pure cloud w/PX <= 3.0, preflight will not run")
+
+	// Reset preflight for other tests
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	// TestCase: Pure cloud provider with image >= 3.1
+	logrus.Infof("check Pure cloud w/PX >= 3.1...")
+	cluster.Spec.Image = "portworx/oci-image:3.1.0"
+
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	driver.EXPECT().UpdateDriver(gomock.Any())
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.True(t, preflightShouldRun(cluster))
+	logrus.Infof("Pure cloud w/PX >= 3.1, preflight will run")
+
+	// Reset preflight for other tests
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	// TestCase: Azure cloud provider with image <= 3.0
+	logrus.Infof("check Azure cloud w/PX <= 3.0...")
+	fakeK8sNodes = &v1.NodeList{Items: []v1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Spec: v1.NodeSpec{ProviderID: "azure://node-id-1"}},
+	}}
+
+	versionClient := fakek8sclient.NewSimpleClientset(fakeK8sNodes)
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &kversion.Info{
+		GitVersion: "v1.26.5",
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+	k8sClient = testutil.FakeK8sClient(fakeK8sNodes)
+
+	cluster.Spec.Image = "portworx/oci-image:3.0.0"
+
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	c := preflight.Instance()
+	require.Equal(t, cloudops.Azure, c.ProviderName()) // Make sure Pure
+
+	driver.EXPECT().UpdateDriver(gomock.Any())
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.False(t, preflightShouldRun(cluster))
+	logrus.Infof("Azure cloud w/PX <= 3.0, preflight will not run")
+
+	// Reset preflight for other tests
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	// TestCase: Azure cloud provider with image >= 3.1
+	logrus.Infof("check Azure cloud w/PX >= 3.1...")
+	cluster.Spec.Image = "portworx/oci-image:3.1.0"
+
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	driver.EXPECT().UpdateDriver(gomock.Any())
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.True(t, preflightShouldRun(cluster))
+	logrus.Infof("Pure Azure w/PX >= 3.1, preflight will run")
+
+	// Reset preflight for other tests
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+
+	// TestCase: Vsphere cloud provider with PKS and image >= 3.1
+	logrus.Infof("check vsphere cloud with PKS and PX >= 3.1...")
+	cluster.Spec.Image = "portworx/oci-image:3.1.0"
+
+	env = make([]v1.EnvVar, 1)
+	env[0].Name = "VSPHERE_VCENTER"
+	env[0].Value = "some.vcenter.server.com"
+	cluster.Spec.Env = env
+
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	k8sClient = testutil.FakeK8sClient(cluster)
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: preflight.PksSystemNamespace,
+		},
+	}
+	_, err = coreops.Instance().CreateNamespace(ns)
+	require.NoError(t, err)
+
+	err = preflight.InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+	require.True(t, preflight.IsPKS())
+
+	driver.EXPECT().UpdateDriver(gomock.Any())
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any())
+	err = controller.setStorageClusterDefaults(cluster)
+	require.NoError(t, err)
+	require.False(t, preflightShouldRun(cluster))
+	logrus.Infof("vsphere cloud with PKS and PX >= 3.1 will not run")
+
 }
 
 func TestEKSPreflightCheck(t *testing.T) {

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -741,6 +741,25 @@ func (c *Controller) miscCleanUp(cluster *corev1.StorageCluster) error {
 	return nil
 }
 
+func preflightShouldRun(cluster *corev1.StorageCluster) bool {
+	pxVer30, _ := version.NewVersion("3.0")
+	pxVer31, _ := version.NewVersion("3.1")
+
+	// Preflight should only run freshInstall and if the PX version is 3.0.0 and above
+	if pxutil.IsFreshInstall(cluster) {
+		if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
+			if !pxutil.IsVsphere(cluster) {
+				return true
+			}
+			// Vsphere only supported on 3.1.0
+			if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer31) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (c *Controller) syncStorageCluster(
 	cluster *corev1.StorageCluster,
 ) error {
@@ -760,9 +779,7 @@ func (c *Controller) syncStorageCluster(
 			cluster.Namespace, cluster.Name, err)
 	}
 
-	pxVer30, _ := version.NewVersion("3.0")
-	// Preflight should only run freshInstall and if the PX version is 3.0.0 and above
-	if pxutil.IsFreshInstall(cluster) && pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
+	if preflightShouldRun(cluster) {
 		// If preflight failed, or previous check failed, reconcile would stop here until issues got resolved
 		if err := c.runPreflightCheck(cluster); err != nil {
 			return fmt.Errorf("preflight check failed for StorageCluster %v/%v: %v", cluster.Namespace, cluster.Name, err)

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -748,10 +748,15 @@ func preflightShouldRun(cluster *corev1.StorageCluster) bool {
 	// Preflight should only run freshInstall and if the PX version is 3.0.0 and above
 	if pxutil.IsFreshInstall(cluster) {
 		if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer30) {
-			if !pxutil.IsVsphere(cluster) {
+			if !pxutil.IsVsphere(cluster) && !pxutil.IsPure(cluster) && !preflight.IsAzure() {
 				return true
 			}
-			// Vsphere only supported on 3.1.0
+
+			// Don't run Vsphere w/PKS
+			if pxutil.IsVsphere(cluster) && preflight.IsPKS() {
+				return false
+			}
+			// Vsphere, Pure & Azure only supported on 3.1.0
 			if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer31) {
 				return true
 			}

--- a/pkg/preflight/pks.go
+++ b/pkg/preflight/pks.go
@@ -1,0 +1,11 @@
+package preflight
+
+const (
+	pksDistribution = "gke"
+	// PksSystemNamespace PKS system namespace
+	PksSystemNamespace = "pks-system"
+)
+
+type pks struct {
+	checker
+}

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -93,6 +93,10 @@ func InitPreflightChecker(client client.Client) error {
 		instance = &gce{
 			checker: *c,
 		}
+	} else if IsPKS() {
+		instance = &pks{
+			checker: *c,
+		}
 	}
 
 	return nil
@@ -117,6 +121,15 @@ func getCloudProviderName() (string, error) {
 	return "", nil
 }
 
+func nameSpaceExists(ns string) bool {
+	if len(ns) == 0 {
+		return false
+	}
+
+	_, err := coreops.Instance().GetNamespace(ns)
+	return err == nil
+}
+
 func getK8sDistributionName() (string, error) {
 	k8sVersion, err := coreops.Instance().GetVersion()
 	if err != nil {
@@ -129,6 +142,11 @@ func getK8sDistributionName() (string, error) {
 	} else if strings.Contains(strings.ToLower(k8sVersion.String()), gkeDistribution) {
 		return gkeDistribution, nil
 	}
+
+	if nameSpaceExists(PksSystemNamespace) {
+		return pksDistribution, nil
+	}
+
 	// TODO: detect other k8s distribution names
 	return "", nil
 }

--- a/pkg/preflight/preflight_test.go
+++ b/pkg/preflight/preflight_test.go
@@ -114,4 +114,19 @@ func TestDefaultProviders(t *testing.T) {
 	err = c.CheckCloudDrivePermission(cluster)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "env variable AWS_ZONE is not set")
+
+	// TestCase: init PKS cloud Provider
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	k8sClient := testutil.FakeK8sClient(cluster)
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: PksSystemNamespace,
+		},
+	}
+	_, err = coreops.Instance().CreateNamespace(ns)
+	require.NoError(t, err)
+
+	err = InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+	require.True(t, IsPKS())
 }

--- a/pkg/preflight/utils.go
+++ b/pkg/preflight/utils.go
@@ -14,6 +14,16 @@ func IsGKE() bool {
 	return Instance().ProviderName() == string(cloudops.GCE) && Instance().K8sDistributionName() == gkeDistribution
 }
 
+// IsGKE returns whether the cloud environment is running PKS
+func IsPKS() bool {
+	return Instance().K8sDistributionName() == pksDistribution
+}
+
+// IsAzure returns whether the cloud environment is running on Azure
+func IsAzure() bool {
+	return Instance().ProviderName() == string(cloudops.Azure)
+}
+
 // RequiresCheck returns whether a preflight check is needed based on the platform
 func RequiresCheck() bool {
 	return Instance().ProviderName() == string(cloudops.AWS) ||


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Prevent preflight from running when using Vsphere and PKS.   Also preflight should only run on Vsphere, Pure, Azure if PX image is >=3.1.0  
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-32670
**Special notes for your reviewer**:
Added UTs however and validated this manually verified that with this change pre-flight does not run when using PKS on Vsphere.