### PR TITLE
PWX-33374:Set Security context for OCP before pre-flight is launched.…

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -91,6 +91,22 @@ func (p *portworx) Init(
 	return nil
 }
 
+func createSecurityContextForValidate(recorder record.EventRecorder, cluster *corev1.StorageCluster) error {
+	if secComp, exists := component.Get(component.SCCComponentName); exists {
+		if secComp.IsEnabled(cluster) {
+			err := secComp.Reconcile(cluster)
+			if ce, ok := err.(*component.Error); ok &&
+				ce.Code() == component.ErrCritical {
+				return fmt.Errorf("pre-flight: %s component setup failed: %v", secComp.Name(), err)
+			} else if err != nil {
+				msg := fmt.Sprintf("pre-flight: failed to setup %s. %v", secComp.Name(), err)
+				k8sutil.WarningEvent(recorder, cluster, util.FailedComponentReason, msg)
+			}
+		}
+	}
+	return nil
+}
+
 func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 
 	condition := &corev1.ClusterCondition{
@@ -131,6 +147,12 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 		logrus.Infof(condition.Message)
 		deletePreflight()
 		return nil
+	}
+
+	if err := createSecurityContextForValidate(p.recorder, cluster); err != nil {
+		setClusterCondition(corev1.ClusterConditionStatusFailed, err.Error())
+		deletePreflight()
+		return err
 	}
 
 	// Start the pre-flight container. The pre-flight checks at this time are specific to enabling DMthin

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	version "github.com/hashicorp/go-version"
+	ocp_secv1 "github.com/openshift/api/security/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -219,6 +220,33 @@ func TestValidate(t *testing.T) {
 		}
 	}
 	require.NoError(t, errChk)
+
+	// Check OCP Security component setting function
+	expectedSCC := testutil.GetExpectedSCC(t, "portworxSCC.yaml")
+	scc := &ocp_secv1.SecurityContextConstraints{}
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NotNil(t, err)
+
+	expectedPxRestrictedSCC := testutil.GetExpectedSCC(t, "portworxRestrictedSCC.yaml")
+	pxRestrictedSCC := &ocp_secv1.SecurityContextConstraints{}
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NotNil(t, err)
+
+	// Install with SCC enabled
+	crd := testutil.GetExpectedCRDV1(t, "sccCrd.yaml")
+	err = k8sClient.Create(context.TODO(), crd)
+	require.NoError(t, err)
+
+	err = createSecurityContextForValidate(recorder, cluster)
+	require.NoError(t, err)
+
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedSCC, scc)
+
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedSCC, scc)
 }
 
 func TestValidateCheckFailure(t *testing.T) {


### PR DESCRIPTION
… (#1264)

* PWX-33374:Set Security context for OCP before pre-flight is launched.



* PWX-33374: Remove the run-once attempt cond.  This is did not work accross node-wipes and also is not necessary.    Handle critical error from security component reconcile.



* PWX-33374: Change function name to represent what the function does.



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

