### PR TITLE
PWX-32670: Vsphere preflight should not run on PKS (#1284)

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -746,7 +746,14 @@ func preflightShouldRun(cluster *corev1.StorageCluster) bool {
 			}
 			// Vsphere only supported on 3.1.0
 			if clusterPXver.GreaterThanOrEqual(pxVer31) {
-				return true
+				// Don't run Vsphere w/PKS
+				if pxutil.IsVsphere(cluster) && preflight.IsPKS() {
+					return false
+				}
+				// Vsphere, Pure & Azure only supported on 3.1.0
+				if pxutil.GetPortworxVersion(cluster).GreaterThanOrEqual(pxVer31) {
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/preflight/pks.go
+++ b/pkg/preflight/pks.go
@@ -1,0 +1,11 @@
+package preflight
+
+const (
+	pksDistribution = "gke"
+	// PksSystemNamespace PKS system namespace
+	PksSystemNamespace = "pks-system"
+)
+
+type pks struct {
+	checker
+}

--- a/pkg/preflight/preflight.go
+++ b/pkg/preflight/preflight.go
@@ -93,6 +93,10 @@ func InitPreflightChecker(client client.Client) error {
 		instance = &gce{
 			checker: *c,
 		}
+	} else if IsPKS() {
+		instance = &pks{
+			checker: *c,
+		}
 	}
 
 	return nil
@@ -117,6 +121,15 @@ func getCloudProviderName() (string, error) {
 	return "", nil
 }
 
+func nameSpaceExists(ns string) bool {
+	if len(ns) == 0 {
+		return false
+	}
+
+	_, err := coreops.Instance().GetNamespace(ns)
+	return err == nil
+}
+
 func getK8sDistributionName() (string, error) {
 	k8sVersion, err := coreops.Instance().GetVersion()
 	if err != nil {
@@ -129,6 +142,11 @@ func getK8sDistributionName() (string, error) {
 	} else if strings.Contains(strings.ToLower(k8sVersion.String()), gkeDistribution) {
 		return gkeDistribution, nil
 	}
+
+	if nameSpaceExists(PksSystemNamespace) {
+		return pksDistribution, nil
+	}
+
 	// TODO: detect other k8s distribution names
 	return "", nil
 }

--- a/pkg/preflight/preflight_test.go
+++ b/pkg/preflight/preflight_test.go
@@ -114,4 +114,19 @@ func TestDefaultProviders(t *testing.T) {
 	err = c.CheckCloudDrivePermission(cluster)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "env variable AWS_ZONE is not set")
+
+	// TestCase: init PKS cloud Provider
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	k8sClient := testutil.FakeK8sClient(cluster)
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: PksSystemNamespace,
+		},
+	}
+	_, err = coreops.Instance().CreateNamespace(ns)
+	require.NoError(t, err)
+
+	err = InitPreflightChecker(k8sClient)
+	require.NoError(t, err)
+	require.True(t, IsPKS())
 }

--- a/pkg/preflight/utils.go
+++ b/pkg/preflight/utils.go
@@ -14,6 +14,16 @@ func IsGKE() bool {
 	return Instance().ProviderName() == string(cloudops.GCE) && Instance().K8sDistributionName() == gkeDistribution
 }
 
+// IsGKE returns whether the cloud environment is running PKS
+func IsPKS() bool {
+	return Instance().K8sDistributionName() == pksDistribution
+}
+
+// IsAzure returns whether the cloud environment is running on Azure
+func IsAzure() bool {
+	return Instance().ProviderName() == string(cloudops.Azure)
+}
+
 // RequiresCheck returns whether a preflight check is needed based on the platform
 func RequiresCheck() bool {
 	return Instance().ProviderName() == string(cloudops.AWS) ||


### PR DESCRIPTION
* PWX-34238: Vsphere Preflight should only run on PX image 3.1.0 and above.



* PWX-32670: Detect PKS env using namespace, don't run Vsphere preflight if PKS.  Also don't run pre-flight on Vsphere, pure & Azure unless PX ver >= 3.1.0



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Prevent preflight from running when using Vsphere and PKS.  Also Vsphere preflight will only run if PX image is >=3.1.0.  Did not pull in the Pure or Azure checks... they were removed.

Special notes for your reviewer:
Ran UTs for tests

**Which issue(s) this PR fixes** (optional)
Closes #. PWX-32670
