### PR TITLE
PWX-31625: Turning off PVC-Controller on OpenShift

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -16304,6 +16304,83 @@ func TestIsVersionSupportedForUnsupportedVersionOpenshift(t *testing.T) {
 
 }
 
+// test if PVC-Controler gets enabled on various configs
+func TestCheckPVCControllerEnablement(t *testing.T) {
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: component.ClusterOperatorVersion,
+			APIResources: []metav1.APIResource{
+				{
+					Kind: component.ClusterOperatorKind,
+				},
+			},
+		},
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{},
+	}
+	pvcContoller, has := component.Get(component.PVCControllerComponentName)
+	require.True(t, has)
+	require.NotNil(t, pvcContoller)
+
+	// check enablement by namespace
+	cluster.Namespace = "portworx"
+	assert.True(t, pvcContoller.IsEnabled(cluster))
+	cluster.Namespace = "kube-system"
+	assert.False(t, pvcContoller.IsEnabled(cluster))
+
+	// check enablement by `portworx.io/pvc-controller` annotation
+	testData1 := []struct {
+		annotation string
+		expect     bool
+	}{
+		{"false", false},
+		{"true", true},
+		{"", false},
+		{"~~unparseable~~", false},
+	}
+	for i, td := range testData1 {
+		cluster.Annotations = map[string]string{"portworx.io/pvc-controller": td.annotation}
+		res := pvcContoller.IsEnabled(cluster)
+		assert.Equal(t, td.expect, res,
+			"Failed expectation for test #%d / %v", i+1, td)
+	}
+
+	// check PVC-enablement for various clouds
+	testData2 := []struct {
+		annotationKey string
+		annotationVal string
+		expect        bool
+	}{
+		{"portworx.io/is-openshift", "true", false},
+		{"portworx.io/is-iks", "true", false},
+		{"portworx.io/is-pks", "true", true},
+		{"portworx.io/is-gke", "true", true},
+		{"portworx.io/is-oke", "true", true},
+		{"portworx.io/is-aks", "true", true},
+		{"portworx.io/is-eks", "true", true},
+		{"", "", false},
+	}
+	for i, td := range testData2 {
+		cluster.Annotations = make(map[string]string)
+		if td.annotationKey != "" {
+			cluster.Annotations[td.annotationKey] = td.annotationVal
+		}
+		res := pvcContoller.IsEnabled(cluster)
+		assert.Equal(t, td.expect, res,
+			"Failed expectation for test #%d / %v", i+1, td)
+	}
+}
+
 func TestPluginInstallAndUninstall(t *testing.T) {
 	versionClient := fakek8sclient.NewSimpleClientset()
 	versionClient.Resources = []*metav1.APIResourceList{


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

We got complaints that the PX deployments on OpenShift spin up `portworx-pvc-controller-XXX` PODs
* apparently, in vSphere deployments, this results in spamming vSphere/vCenter with storage tasks

FIX:
* as a fix, we're changing the defaults in which configs will we set up PVC-controller
  - we'll SKIP setting up the PVC-controller in OpenShift distros  (unless explicitly turned on via `portworx.io/pvc-controller: "true"`)
* also adding a targeted unit-test

**Which issue(s) this PR fixes** (optional)
Closes # PWX-31625

**Special notes for your reviewer**:

Some manual test results:
* confirmed generic Kubernetes deployment in "portworx" namespace still NEEDS PVC-controller when using in-tree driver
   - without the PVC-controller, the PVC never gets assigned to the application POD, and POD never starts
* identical deployment tested on OCP 4.12 / vSphere -- woks OK
   - PVCs get bound+started correctly, even without the PVC-controller component