### PR TITLE
PWX-34393 (23.10.0): Updating baseline image  (#1299)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,4 +292,4 @@ clean: clean-release-manifest clean-bundle
 	@rm -rf $(BIN)
 	@go clean -i $(PKGS)
 	@echo "Deleting image "$(OPERATOR_IMG)
-	@docker rmi -f $(OPERATOR_IMG)
+	@docker rmi -f $(OPERATOR_IMG) registry.access.redhat.com/ubi8-minimal:latest

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,10 +1,8 @@
-FROM registry.access.redhat.com/ubi8-minimal:8.7-1085
+FROM registry.access.redhat.com/ubi8-minimal:latest
 
-RUN microdnf update
-RUN microdnf --enablerepo=rhel-7-server-rpms \
--y update-minimal --security --sec-severity=Important --sec-severity=Critical;\
-microdnf clean all
-RUN microdnf install -y tar
+RUN microdnf clean all && \
+    microdnf install -y tar && \
+    microdnf clean all
 
 USER nobody
 


### PR DESCRIPTION
Squashed commit of the following:

commit 0662fb8b63686f3285066bb36ff3bb57c2623ff5
Author: Zoran Rajic <zox@portworx.com>
Date:   Tue Oct 17 14:22:27 2023 -0700

    Dockerfile `RUN` fixup

commit d28642c8f231c2694e4517c438aedf8995b115de
Author: Zoran Rajic <zox@portworx.com>
Date:   Tue Oct 17 13:30:38 2023 -0700

    PWX-34393: JUpdating baseline image

    Signed-off-by: Zoran Rajic <zox@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1299 into `px-rel-23.10.0` image

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-34393 (23.10.0)

**Special notes for your reviewer**:

