### PR TITLE
PWX-34391: fix concurrent map panic

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/preflight"
 	"github.com/libopenstorage/operator/pkg/util"
 	"github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
 )
 
@@ -1160,9 +1161,10 @@ func testStoragelessNodesDisaggregatedMode(t *testing.T, expectedValue uint32, s
 	recorder := record.NewFakeRecorder(10)
 
 	controller := Controller{
-		client:   k8sClient,
-		Driver:   driver,
-		recorder: recorder,
+		client:      k8sClient,
+		Driver:      driver,
+		recorder:    recorder,
+		nodeInfoMap: maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	driver.EXPECT().UpdateDriver(gomock.Any()).MinTimes(1)
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
@@ -1267,9 +1269,10 @@ func TestDisaggregatedMissingLabels(t *testing.T) {
 	recorder := record.NewFakeRecorder(10)
 
 	controller := Controller{
-		client:   k8sClient,
-		Driver:   driver,
-		recorder: recorder,
+		client:      k8sClient,
+		Driver:      driver,
+		recorder:    recorder,
+		nodeInfoMap: maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().UpdateDriver(gomock.Any()).MinTimes(1)
@@ -1330,8 +1333,9 @@ func testClusterDefaultsMaxStorageNodesPerZone(t *testing.T, expectedValue uint3
 	k8sClient, _ := getK8sClientWithNodesZones(t, totalNodes, zones, cluster)
 
 	controller := Controller{
-		client: k8sClient,
-		Driver: driver,
+		client:      k8sClient,
+		Driver:      driver,
+		nodeInfoMap: maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	driver.EXPECT().UpdateDriver(gomock.Any()).MinTimes(1)
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
@@ -1516,7 +1520,7 @@ func TestFailureDuringStorkInstallation(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -1564,7 +1568,7 @@ func TestFailureDuringDriverPreInstall(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -1610,7 +1614,7 @@ func TestStorageClusterFailedSyncObjectModified(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -1656,7 +1660,7 @@ func TestStoragePodsShouldNotBeScheduledIfDisabled(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -1797,7 +1801,7 @@ func TestStoragePodGetsScheduled(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	expectedPodSpec := v1.PodSpec{
@@ -1912,7 +1916,7 @@ func TestStoragePodGetsScheduledK8s1_24(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	expectedPodSpec := v1.PodSpec{
@@ -2011,7 +2015,7 @@ func TestStorageNodeGetsCreated(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
@@ -2300,7 +2304,7 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	expectedPodSpec := v1.PodSpec{
@@ -2437,7 +2441,7 @@ func TestFailedStoragePodsGetRemoved(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2540,7 +2544,7 @@ func TestExtraStoragePodsGetRemoved(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2668,7 +2672,7 @@ func TestStoragePodsAreRemovedIfDisabled(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2762,7 +2766,7 @@ func TestStoragePodFailureDueToNodeSelectorNotMatch(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2858,7 +2862,7 @@ func TestStoragePodSchedulingWithTolerations(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2999,7 +3003,7 @@ func TestFailureDuringPodTemplateCreation(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3091,7 +3095,7 @@ func TestFailureDuringCreateDeletePods(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3172,7 +3176,7 @@ func TestTimeoutFailureDuringCreatePods(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3223,7 +3227,7 @@ func TestUpdateClusterStatusFromDriver(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3285,7 +3289,7 @@ func TestUpdateClusterStatusErrorFromDriver(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3341,7 +3345,7 @@ func TestFailedPreInstallFromDriver(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3398,7 +3402,7 @@ func TestUpdateDriverWithInstanceInformation(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	expectedDriverInfo := &storage.UpdateDriverInfo{
@@ -3542,7 +3546,7 @@ func TestGarbageCollection(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3634,7 +3638,7 @@ func TestDeleteStorageClusterWithoutFinalizers(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3716,7 +3720,7 @@ func TestDeleteStorageClusterWithFinalizers(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3876,7 +3880,7 @@ func TestDeleteStorageClusterShouldDeleteStork(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -4010,7 +4014,7 @@ func TestDeleteStorageClusterShouldRemoveMigrationLabels(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -4086,7 +4090,7 @@ func TestRollingUpdateWithMinReadySeconds(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -4192,7 +4196,7 @@ func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -4342,7 +4346,7 @@ func TestUpdateStorageClusterBasedOnStorageNodeStatuses(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	var storageNodes []*storageapi.StorageNode
@@ -4559,7 +4563,7 @@ func TestUpdateStorageClusterWithOpenshiftUpgrade(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -4696,7 +4700,7 @@ func TestUpdateStorageClusterShouldNotExceedMaxUnavailable(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -4906,7 +4910,7 @@ func TestUpdateStorageClusterWithPercentageMaxUnavailable(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -5070,7 +5074,7 @@ func TestUpdateStorageClusterWithInvalidMaxUnavailableValue(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5136,7 +5140,7 @@ func TestUpdateStorageClusterWhenDriverReportsPodNotUpdated(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5204,7 +5208,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItDoesNotHaveAnyHash(t *testing.T
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5266,7 +5270,7 @@ func TestUpdateStorageClusterImagePullSecret(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5375,7 +5379,7 @@ func TestUpdateStorageClusterCustomImageRegistry(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5482,7 +5486,7 @@ func TestUpdateStorageClusterKvdbSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5602,7 +5606,7 @@ func TestUpdateStorageClusterResourceRequirements(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5718,7 +5722,7 @@ func TestUpdateStorageClusterCloudStorageSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5991,7 +5995,7 @@ func TestUpdateStorageClusterStorageSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6217,7 +6221,7 @@ func TestUpdateStorageClusterNetworkSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6310,7 +6314,7 @@ func TestUpdateStorageClusterEnvVariables(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6405,7 +6409,7 @@ func TestUpdateStorageClusterRuntimeOptions(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6497,7 +6501,7 @@ func TestUpdateStorageClusterVolumes(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6760,7 +6764,7 @@ func TestUpdateStorageClusterSecretsProvider(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6851,7 +6855,7 @@ func TestUpdateStorageClusterStartPort(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6945,7 +6949,7 @@ func TestUpdateStorageClusterCSISpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -7120,7 +7124,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -7587,7 +7591,7 @@ func TestUpdateStorageClusterK8sNodeChanges(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -7682,7 +7686,7 @@ func TestUpdateStorageClusterShouldNotRestartPodsForSomeOptions(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -7850,7 +7854,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItsHistoryHasInvalidSpec(t *testi
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -7933,7 +7937,7 @@ func TestUpdateStorageClusterSecurity(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -8129,7 +8133,7 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -8328,7 +8332,7 @@ func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -8478,7 +8482,7 @@ func TestUpdateClusterShouldHandleHashCollisions(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	fakeClient := fake.NewSimpleClientset()
@@ -8652,7 +8656,7 @@ func TestUpdateClusterShouldDedupRevisionsAnywhereInHistory(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -8800,7 +8804,7 @@ func TestHistoryCleanup(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -8961,7 +8965,7 @@ func TestNodeShouldRunStoragePod(t *testing.T) {
 		client:      k8sClient,
 		podControl:  podControl,
 		recorder:    recorder,
-		nodeInfoMap: make(map[string]*k8s.NodeInfo),
+		nodeInfoMap: maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	// TestCase: machine for node is being deleted
@@ -8969,11 +8973,11 @@ func TestNodeShouldRunStoragePod(t *testing.T) {
 	k8sNode.Annotations = map[string]string{
 		constants.AnnotationClusterAPIMachine: "m2",
 	}
-	controller.nodeInfoMap[k8sNode.Name] = &k8s.NodeInfo{
+	controller.nodeInfoMap.Store(k8sNode.Name, &k8s.NodeInfo{
 		NodeName:             k8sNode.Name,
 		LastPodCreationTime:  time.Now().Add(-time.Hour),
 		CordonedRestartDelay: constants.DefaultCordonedRestartDelay,
-	}
+	})
 
 	shouldRun, shouldContinueRunning, err := controller.nodeShouldRunStoragePod(k8sNode, cluster)
 	require.NoError(t, err)
@@ -9183,6 +9187,7 @@ func TestDoesTelemetryMatch(t *testing.T) {
 			podControl:        podControl,
 			recorder:          recorder,
 			kubernetesVersion: k8sVersion,
+			nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 		}
 
 		driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -9414,8 +9419,9 @@ func TestPreflightStorageNodeCreation(t *testing.T) {
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 
 	controller := Controller{
-		client: k8sClient,
-		Driver: driver,
+		client:      k8sClient,
+		Driver:      driver,
+		nodeInfoMap: maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	storageNodeNames := func(storageNodes *corev1.StorageNodeList) []string {
@@ -9909,9 +9915,10 @@ func TestGetDefaultMaxStorageNodesPerZone(t *testing.T) {
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 
 	controller := Controller{
-		client:   k8sClient,
-		Driver:   driver,
-		recorder: recorder,
+		client:      k8sClient,
+		Driver:      driver,
+		recorder:    recorder,
+		nodeInfoMap: maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	var nodeList v1.NodeList

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
 	"github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 )
@@ -85,7 +86,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -408,7 +409,7 @@ func TestStorkSchedulerK8SVersions(t *testing.T) {
 			client:            k8sClient,
 			Driver:            driver,
 			kubernetesVersion: k8sVersion,
-			nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+			nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 		}
 
 		driverEnvs := map[string]*v1.EnvVar{
@@ -542,7 +543,7 @@ func TestStorkWithoutImage(t *testing.T) {
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
 		recorder:          recorder,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -593,7 +594,7 @@ func TestStorkWithDesiredImage(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -651,7 +652,7 @@ func TestStorkImageChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -712,7 +713,7 @@ func TestStorkArgumentsChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -789,7 +790,7 @@ func TestStorkEnvVarsChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -878,7 +879,7 @@ func TestStorkCustomRegistryChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -1011,7 +1012,7 @@ func TestStorkCustomRepoRegistryChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -1143,7 +1144,7 @@ func TestStorkImagePullSecretChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -1287,7 +1288,7 @@ func TestStorkTolerationsChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -1474,7 +1475,7 @@ func TestStorkNodeAffinityChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -1616,7 +1617,7 @@ func TestStorkVolumesChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -1775,7 +1776,7 @@ func TestStorkAndStorkSchedulerResources(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -1873,7 +1874,7 @@ func TestStorkCPUChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -1937,7 +1938,7 @@ func TestStorkSchedulerCPUChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2005,7 +2006,7 @@ func TestStorkInvalidCPU(t *testing.T) {
 		Driver:            driver,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -2050,7 +2051,7 @@ func TestStorkSchedulerInvalidCPU(t *testing.T) {
 		Driver:            driver,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2100,7 +2101,7 @@ func TestStorkSchedulerRollbackImageChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2166,7 +2167,7 @@ func TestStorkSchedulerImageWithNewerK8sVersion(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -2287,7 +2288,7 @@ func TestStorkSchedulerRollbackCommandChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2351,7 +2352,7 @@ func TestStorkInstallWithImagePullPolicy(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2413,7 +2414,7 @@ func TestStorkInstallWithHostNetwork(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2494,7 +2495,7 @@ func TestStorkWithConfigReconciliationDisabled(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2596,7 +2597,7 @@ func TestStorkSchedulerWithMissingLabelsFromSelector(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2687,7 +2688,7 @@ func TestDisableStork(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2824,7 +2825,7 @@ func TestRemoveStork(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2961,7 +2962,7 @@ func TestStorkDriverNotImplemented(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("", fmt.Errorf("not supported"))
@@ -3048,7 +3049,7 @@ func TestStorkAndSchedulerDeploymentWithPodTopologySpreadConstraints(t *testing.
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -3130,7 +3131,7 @@ func TestStorkAndSchedulerDeploymentWithoutPodTopologySpreadConstraints(t *testi
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -7,12 +7,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
-	"github.com/libopenstorage/operator/drivers/storage"
-	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/constants"
-	"github.com/libopenstorage/operator/pkg/util"
-	"github.com/libopenstorage/operator/pkg/util/k8s"
-	"github.com/libopenstorage/operator/pkg/util/maps"
 	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
@@ -35,6 +29,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
 	"github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 )
 
 const (

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -7,6 +7,12 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/libopenstorage/operator/drivers/storage"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/util"
+	"github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
@@ -57,7 +63,7 @@ type Controller struct {
 	recorder record.EventRecorder
 	ctrl     controller.Controller
 	// Node to NodeInfo map
-	nodeInfoMap map[string]*k8s.NodeInfo
+	nodeInfoMap maps.SyncMap[string, *k8s.NodeInfo]
 }
 
 // Init initialize the storage storagenode controller
@@ -65,7 +71,7 @@ func (c *Controller) Init(mgr manager.Manager) error {
 	c.client = mgr.GetClient()
 	c.scheme = mgr.GetScheme()
 	c.recorder = mgr.GetEventRecorderFor(ControllerName)
-	c.nodeInfoMap = make(map[string]*k8s.NodeInfo)
+	c.nodeInfoMap = maps.MakeSyncMap[string, *k8s.NodeInfo]()
 
 	var err error
 	// Create a new controller
@@ -299,15 +305,15 @@ func (c *Controller) syncKVDB(
 				return err
 			}
 
-			nodeInfo, ok := c.nodeInfoMap[storageNode.Name]
+			nodeInfo, ok := c.nodeInfoMap.Load(storageNode.Name)
 			if ok {
 				nodeInfo.LastPodCreationTime = time.Now()
 			} else {
-				c.nodeInfoMap[storageNode.Name] = &k8s.NodeInfo{
+				c.nodeInfoMap.Store(storageNode.Name, &k8s.NodeInfo{
 					NodeName:             storageNode.Name,
 					LastPodCreationTime:  time.Now(),
 					CordonedRestartDelay: constants.DefaultCordonedRestartDelay,
-				}
+				})
 			}
 		}
 	} else { // delete pods if present

--- a/pkg/util/k8s/node.go
+++ b/pkg/util/k8s/node.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 )
 
 /*
@@ -50,10 +51,10 @@ func IsNodeBeingDeleted(node *v1.Node, cl client.Client) (bool, error) {
 // within the delay, exponential backoff is applied here.
 func IsPodRecentlyCreatedAfterNodeCordoned(
 	node *v1.Node,
-	nodeInfoMap map[string]*NodeInfo,
+	nodeInfoMap maps.SyncMap[string, *NodeInfo],
 	cluster *corev1.StorageCluster,
 ) bool {
-	nodeInfo, ok := nodeInfoMap[node.Name]
+	nodeInfo, ok := nodeInfoMap.Load(node.Name)
 	// The pod has never been created
 	if !ok || nodeInfo == nil {
 		return false

--- a/pkg/util/maps/syncmap.go
+++ b/pkg/util/maps/syncmap.go
@@ -1,0 +1,69 @@
+package maps
+
+import (
+	"sync"
+)
+
+// SyncMap is simplified implementation of Golang's sync.Map (see https://pkg.go.dev/sync#Map)
+// - should be more appropriate for "smaller parallelism" (i.e. less than 4 parallel CPU cores -access)
+type SyncMap[K comparable, V any] interface {
+	Load(key K) (V, bool)
+	LoadUnchecked(key K) V
+	Delete(key K)
+	Store(key K, value V)
+	Range(fn func(key K, value V) bool)
+}
+
+type syncMap[K comparable, V any] struct {
+	sync.RWMutex
+	internal map[K]V
+}
+
+// MakeSyncMap creates a new instance of a SyncMap
+func MakeSyncMap[K comparable, V any]() SyncMap[K, V] {
+	return &syncMap[K, V]{
+		internal: make(map[K]V),
+	}
+}
+
+// Loads retrieves an element out of the map
+func (m *syncMap[K, V]) Load(key K) (V, bool) {
+	m.RLock()
+	defer m.RUnlock()
+	result, ok := m.internal[key]
+	return result, ok
+}
+
+// LoadUnchecked retrieves an element out of the map.
+// -note, if element does not exist, equivalent of nil/0 is returned.
+func (m *syncMap[K, V]) LoadUnchecked(key K) V {
+	result, _ := m.Load(key)
+	return result
+}
+
+// Delete removes an element from the map
+func (m *syncMap[K, V]) Delete(key K) {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.internal, key)
+}
+
+// Store puts an element into the map
+func (m *syncMap[K, V]) Store(key K, value V) {
+	m.Lock()
+	defer m.Unlock()
+	m.internal[key] = value
+}
+
+// Range is used to enumerate the elements of the map.
+// - if cb callback func returns false, the enumeration is interrupted
+func (m *syncMap[K, V]) Range(cb func(key K, value V) bool) {
+	m.RLock()
+	defer m.RUnlock()
+
+	for k, v := range m.internal {
+		if !cb(k, v) {
+			break
+		}
+	}
+}

--- a/pkg/util/maps/syncmap_test.go
+++ b/pkg/util/maps/syncmap_test.go
@@ -3,7 +3,52 @@ package maps
 import (
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
+
+func TestBasicSyncMap(t *testing.T) {
+	m := MakeSyncMap[string, int]()
+
+	m.Store("a", 1)
+	m.Store("b", 2)
+	m.Store("c", 3)
+
+	x, has := m.Load("b")
+	assert.True(t, has)
+	assert.Equal(t, 2, x)
+
+	x, has = m.Load("z")
+	assert.False(t, has)
+	assert.Equal(t, 0, x)
+
+	x = m.LoadUnchecked("c")
+	assert.Equal(t, 3, x)
+
+	m.Store("b", 99)
+	x, has = m.Load("b")
+	assert.True(t, has)
+	assert.Equal(t, 99, x)
+
+	m.Delete("c")
+
+	x, has = m.Load("c")
+	assert.False(t, has)
+	assert.Equal(t, 0, x)
+
+	x = m.LoadUnchecked("c")
+	assert.Equal(t, 0, x)
+
+	m.Range(func(key string, value int) bool {
+		if key != "a" && key != "b" {
+			t.Errorf("Invalid key %v", key)
+		}
+		if value != 1 && value != 99 {
+			t.Errorf("Invalid value %v", value)
+		}
+		return true
+	})
+}
 
 // TestMapConcurrentPutGet_DEMO demonstrates panic when regular map is used
 func TestMapConcurrentPutGet_DEMO(t *testing.T) {
@@ -36,6 +81,7 @@ func TestMapConcurrentPutGet(t *testing.T) {
 		}
 	}()
 	time.Sleep(time.Second)
+	// note -- if no panic, test has suceeded
 }
 
 // TestMapConcurrentPutEnumerate_DEMO demonstrates panic when regular map is used
@@ -75,4 +121,5 @@ func TestMapConcurrentPutEnumerate(t *testing.T) {
 		}
 	}()
 	time.Sleep(time.Second)
+	// note -- if no panic, test has suceeded
 }

--- a/pkg/util/maps/syncmap_test.go
+++ b/pkg/util/maps/syncmap_test.go
@@ -1,0 +1,78 @@
+package maps
+
+import (
+	"testing"
+	"time"
+)
+
+// TestMapConcurrentPutGet_DEMO demonstrates panic when regular map is used
+func TestMapConcurrentPutGet_DEMO(t *testing.T) {
+	t.Skip("DISABLED -- this demo-test causes PANIC / fatal error: concurrent map writes")
+	var m = make(map[string]string)
+	go func() {
+		for {
+			_ = m["x"]
+		}
+	}()
+	go func() {
+		for {
+			m["y"] = "foo"
+		}
+	}()
+	time.Sleep(time.Second)
+}
+
+// TestMapConcurrentPutGet tests concurrent Put/Get access
+func TestMapConcurrentPutGet(t *testing.T) {
+	m := MakeSyncMap[string, string]()
+	go func() {
+		for {
+			m.Load("x")
+		}
+	}()
+	go func() {
+		for {
+			m.Store("y", "foo")
+		}
+	}()
+	time.Sleep(time.Second)
+}
+
+// TestMapConcurrentPutEnumerate_DEMO demonstrates panic when regular map is used
+func TestMapConcurrentPutEnumerate_DEMO(t *testing.T) {
+	t.Skip("DISABLED -- this demo-test causes PANIC / fatal error: concurrent map writes")
+	var m = make(map[string]string)
+	go func() {
+		for {
+			for range m {
+				_ = m["x"]
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	}()
+	go func() {
+		for {
+			m["y"] = "foo"
+		}
+	}()
+	time.Sleep(time.Second)
+}
+
+func TestMapConcurrentPutEnumerate(t *testing.T) {
+	m := MakeSyncMap[string, string]()
+	go func() {
+		for {
+			m.Range(func(key, value string) bool {
+				m.Load("x")
+				return true
+			})
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	go func() {
+		for {
+			m.Store("y", "foo")
+		}
+	}()
+	time.Sleep(time.Second)
+}


### PR DESCRIPTION
* add simple SyncMap implementation
* fixed UTs

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

We have hit `fatal error: concurrent map read and map write` issue on `Controller.nodeInfoMap`  (see [PWX-34391](https://portworx.atlassian.net/browse/PWX-34391))

As a fix, adding a simplified implementation of `RWMutex`-protected map w/ golang-generics
* note, this map is used sporadically in the production code -- but quite extensively across the unit-tests  (so, lot more changes in the UT-code)
* also, on a small concurrency (i.e. less than 4 parallel goroutines), this locked-map should be faster compared to golang's [sync.Map](https://pkg.go.dev/sync#Map)

**Which issue(s) this PR fixes** (optional)
Closes # PWX-34391

**Special notes for your reviewer**:



[PWX-34391]: https://portworx.atlassian.net/browse/PWX-34391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ