### PR TITLE
PWX-34391 (master): fix concurrent map panic (#1303)

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -53,6 +53,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/preflight"
 	"github.com/libopenstorage/operator/pkg/util"
 	"github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 	coreops "github.com/portworx/sched-ops/k8s/core"
@@ -1091,7 +1092,7 @@ func TestFailureDuringStorkInstallation(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -1139,7 +1140,7 @@ func TestFailureDuringDriverPreInstall(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -1185,7 +1186,7 @@ func TestStorageClusterFailedSyncObjectModified(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -1231,7 +1232,7 @@ func TestStoragePodsShouldNotBeScheduledIfDisabled(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -1372,7 +1373,7 @@ func TestStoragePodGetsScheduled(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	expectedPodSpec := v1.PodSpec{
@@ -1487,7 +1488,7 @@ func TestStoragePodGetsScheduledK8s1_24(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	expectedPodSpec := v1.PodSpec{
@@ -1586,7 +1587,7 @@ func TestStorageNodeGetsCreated(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
@@ -1870,7 +1871,7 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	expectedPodSpec := v1.PodSpec{
@@ -2005,7 +2006,7 @@ func TestFailedStoragePodsGetRemoved(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2108,7 +2109,7 @@ func TestExtraStoragePodsGetRemoved(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2236,7 +2237,7 @@ func TestStoragePodsAreRemovedIfDisabled(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2331,7 +2332,7 @@ func TestStoragePodFailureDueToNodeSelectorNotMatch(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2428,7 +2429,7 @@ func TestStoragePodSchedulingWithTolerations(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2569,7 +2570,7 @@ func TestFailureDuringPodTemplateCreation(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2661,7 +2662,7 @@ func TestFailureDuringCreateDeletePods(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2742,7 +2743,7 @@ func TestTimeoutFailureDuringCreatePods(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2793,7 +2794,7 @@ func TestUpdateClusterStatusFromDriver(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2855,7 +2856,7 @@ func TestUpdateClusterStatusErrorFromDriver(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2911,7 +2912,7 @@ func TestFailedPreInstallFromDriver(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -2968,7 +2969,7 @@ func TestUpdateDriverWithInstanceInformation(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	expectedDriverInfo := &storage.UpdateDriverInfo{
@@ -3112,7 +3113,7 @@ func TestGarbageCollection(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3203,7 +3204,7 @@ func TestDeleteStorageClusterWithoutFinalizers(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3285,7 +3286,7 @@ func TestDeleteStorageClusterWithFinalizers(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3449,7 +3450,7 @@ func TestDeleteStorageClusterShouldSetTelemetryCertOwnerRef(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3547,7 +3548,7 @@ func TestDeleteStorageClusterShouldDeleteStork(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3680,7 +3681,7 @@ func TestDeleteStorageClusterShouldRemoveMigrationLabels(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -3755,7 +3756,7 @@ func TestRollingUpdateWithMinReadySeconds(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -3861,7 +3862,7 @@ func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -4014,7 +4015,7 @@ func TestUpdateStorageClusterBasedOnStorageNodeStatuses(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	var storageNodes []*storageapi.StorageNode
@@ -4231,7 +4232,7 @@ func TestUpdateStorageClusterWithOpenshiftUpgrade(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -4368,7 +4369,7 @@ func TestUpdateStorageClusterShouldNotExceedMaxUnavailable(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -4578,7 +4579,7 @@ func TestUpdateStorageClusterWithPercentageMaxUnavailable(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -4742,7 +4743,7 @@ func TestUpdateStorageClusterWithInvalidMaxUnavailableValue(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -4808,7 +4809,7 @@ func TestUpdateStorageClusterWhenDriverReportsPodNotUpdated(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -4876,7 +4877,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItDoesNotHaveAnyHash(t *testing.T
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -4938,7 +4939,7 @@ func TestUpdateStorageClusterImagePullSecret(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5047,7 +5048,7 @@ func TestUpdateStorageClusterCustomImageRegistry(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5154,7 +5155,7 @@ func TestUpdateStorageClusterKvdbSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5274,7 +5275,7 @@ func TestUpdateStorageClusterResourceRequirements(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5390,7 +5391,7 @@ func TestUpdateStorageClusterCloudStorageSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5663,7 +5664,7 @@ func TestUpdateStorageClusterStorageSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5889,7 +5890,7 @@ func TestUpdateStorageClusterNetworkSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -5982,7 +5983,7 @@ func TestUpdateStorageClusterEnvVariables(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6077,7 +6078,7 @@ func TestUpdateStorageClusterRuntimeOptions(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6169,7 +6170,7 @@ func TestUpdateStorageClusterVolumes(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6432,7 +6433,7 @@ func TestUpdateStorageClusterSecretsProvider(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6523,7 +6524,7 @@ func TestUpdateStorageClusterStartPort(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6617,7 +6618,7 @@ func TestUpdateStorageClusterCSISpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6792,7 +6793,7 @@ func TestUpdateCloudStorageClusterNodeSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -6942,7 +6943,7 @@ func TestUpdateStorageClusterNodeSpec(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -7382,7 +7383,7 @@ func TestUpdateStorageClusterK8sNodeChanges(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -7477,7 +7478,7 @@ func TestUpdateStorageClusterShouldNotRestartPodsForSomeOptions(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -7645,7 +7646,7 @@ func TestUpdateStorageClusterShouldRestartPodIfItsHistoryHasInvalidSpec(t *testi
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -7728,7 +7729,7 @@ func TestUpdateStorageClusterSecurity(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -8039,7 +8040,7 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -8238,7 +8239,7 @@ func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -8388,7 +8389,7 @@ func TestUpdateClusterShouldHandleHashCollisions(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	fakeClient := fake.NewSimpleClientset()
@@ -8562,7 +8563,7 @@ func TestUpdateClusterShouldDedupRevisionsAnywhereInHistory(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -8710,7 +8711,7 @@ func TestHistoryCleanup(t *testing.T) {
 		podControl:        podControl,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
 
@@ -8870,7 +8871,7 @@ func TestNodeShouldRunStoragePod(t *testing.T) {
 		client:      k8sClient,
 		podControl:  podControl,
 		recorder:    recorder,
-		nodeInfoMap: make(map[string]*k8s.NodeInfo),
+		nodeInfoMap: maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	// TestCase: machine for node is being deleted
@@ -8878,11 +8879,11 @@ func TestNodeShouldRunStoragePod(t *testing.T) {
 	k8sNode.Annotations = map[string]string{
 		constants.AnnotationClusterAPIMachine: "m2",
 	}
-	controller.nodeInfoMap[k8sNode.Name] = &k8s.NodeInfo{
+	controller.nodeInfoMap.Store(k8sNode.Name, &k8s.NodeInfo{
 		NodeName:             k8sNode.Name,
 		LastPodCreationTime:  time.Now().Add(-time.Hour),
 		CordonedRestartDelay: constants.DefaultCordonedRestartDelay,
-	}
+	})
 
 	shouldRun, shouldContinueRunning, err := controller.nodeShouldRunStoragePod(k8sNode, cluster)
 	require.NoError(t, err)
@@ -9092,6 +9093,7 @@ func TestDoesTelemetryMatch(t *testing.T) {
 			podControl:        podControl,
 			recorder:          recorder,
 			kubernetesVersion: k8sVersion,
+			nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 		}
 
 		driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -9322,8 +9324,9 @@ func TestPreflightStorageNodeCreation(t *testing.T) {
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 
 	controller := Controller{
-		client: k8sClient,
-		Driver: driver,
+		client:      k8sClient,
+		Driver:      driver,
+		nodeInfoMap: maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	storageNodeNames := func(storageNodes *corev1.StorageNodeList) []string {

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -63,6 +63,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/preflight"
 	"github.com/libopenstorage/operator/pkg/util"
 	"github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 )
 
 const (
@@ -112,7 +113,7 @@ type Controller struct {
 	isStorkSchedDeploymentCreated bool
 	ctrl                          controller.Controller
 	// Node to NodeInfo map
-	nodeInfoMap map[string]*k8s.NodeInfo
+	nodeInfoMap maps.SyncMap[string, *k8s.NodeInfo]
 }
 
 // Init initialize the storage cluster controller
@@ -121,7 +122,7 @@ func (c *Controller) Init(mgr manager.Manager) error {
 	c.client = mgr.GetClient()
 	c.scheme = mgr.GetScheme()
 	c.recorder = mgr.GetEventRecorderFor(ControllerName)
-	c.nodeInfoMap = make(map[string]*k8s.NodeInfo)
+	c.nodeInfoMap = maps.MakeSyncMap[string, *k8s.NodeInfo]()
 
 	// Create a new controller
 	c.ctrl, err = controller.New(ControllerName, mgr, controller.Options{Reconciler: c})
@@ -1102,15 +1103,15 @@ func (c *Controller) syncNodes(
 					errCh <- err
 				} else {
 					// Pod created, store nodeInfo into the map, reset creation time if exists
-					nodeInfo, ok := c.nodeInfoMap[nodeName]
+					nodeInfo, ok := c.nodeInfoMap.Load(nodeName)
 					if ok {
 						nodeInfo.LastPodCreationTime = time.Now()
 					} else {
-						c.nodeInfoMap[nodeName] = &k8s.NodeInfo{
+						c.nodeInfoMap.Store(nodeName, &k8s.NodeInfo{
 							NodeName:             nodeName,
 							LastPodCreationTime:  time.Now(),
 							CordonedRestartDelay: constants.DefaultCordonedRestartDelay,
-						}
+						})
 					}
 					if errors.IsTimeout(err) {
 						// TODO

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/constants"
 	"github.com/libopenstorage/operator/pkg/util"
 	"github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 )
@@ -85,7 +86,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -408,7 +409,7 @@ func TestStorkSchedulerK8SVersions(t *testing.T) {
 			client:            k8sClient,
 			Driver:            driver,
 			kubernetesVersion: k8sVersion,
-			nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+			nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 		}
 
 		driverEnvs := map[string]*v1.EnvVar{
@@ -542,7 +543,7 @@ func TestStorkWithoutImage(t *testing.T) {
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
 		recorder:          recorder,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -593,7 +594,7 @@ func TestStorkWithDesiredImage(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -651,7 +652,7 @@ func TestStorkImageChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -712,7 +713,7 @@ func TestStorkArgumentsChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -804,7 +805,7 @@ func TestStorkEnvVarsChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -893,7 +894,7 @@ func TestStorkCustomRegistryChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -1026,7 +1027,7 @@ func TestStorkCustomRepoRegistryChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -1158,7 +1159,7 @@ func TestStorkImagePullSecretChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -1302,7 +1303,7 @@ func TestStorkTolerationsChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -1489,7 +1490,7 @@ func TestStorkNodeAffinityChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -1632,7 +1633,7 @@ func TestStorkVolumesChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -1791,7 +1792,7 @@ func TestStorkAndStorkSchedulerResources(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -1889,7 +1890,7 @@ func TestStorkCPUChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -1953,7 +1954,7 @@ func TestStorkSchedulerCPUChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2021,7 +2022,7 @@ func TestStorkInvalidCPU(t *testing.T) {
 		Driver:            driver,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -2066,7 +2067,7 @@ func TestStorkSchedulerInvalidCPU(t *testing.T) {
 		Driver:            driver,
 		recorder:          recorder,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2116,7 +2117,7 @@ func TestStorkSchedulerRollbackImageChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2182,7 +2183,7 @@ func TestStorkSchedulerImageWithNewerK8sVersion(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("pxd", nil).AnyTimes()
@@ -2303,7 +2304,7 @@ func TestStorkSchedulerRollbackCommandChange(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2367,7 +2368,7 @@ func TestStorkInstallWithImagePullPolicy(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2429,7 +2430,7 @@ func TestStorkInstallWithHostNetwork(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2510,7 +2511,7 @@ func TestStorkWithConfigReconciliationDisabled(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2613,7 +2614,7 @@ func TestStorkSchedulerWithMissingLabelsFromSelector(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2704,7 +2705,7 @@ func TestDisableStork(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2841,7 +2842,7 @@ func TestRemoveStork(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -2978,7 +2979,7 @@ func TestStorkDriverNotImplemented(t *testing.T) {
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driver.EXPECT().GetStorkDriverName().Return("", fmt.Errorf("not supported"))
@@ -3065,7 +3066,7 @@ func TestStorkAndSchedulerDeploymentWithPodTopologySpreadConstraints(t *testing.
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{
@@ -3147,7 +3148,7 @@ func TestStorkAndSchedulerDeploymentWithoutPodTopologySpreadConstraints(t *testi
 		client:            k8sClient,
 		Driver:            driver,
 		kubernetesVersion: k8sVersion,
-		nodeInfoMap:       make(map[string]*k8s.NodeInfo),
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 	}
 
 	driverEnvs := map[string]*v1.EnvVar{

--- a/pkg/util/k8s/node.go
+++ b/pkg/util/k8s/node.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 )
 
 /*
@@ -50,10 +51,10 @@ func IsNodeBeingDeleted(node *v1.Node, cl client.Client) (bool, error) {
 // within the delay, exponential backoff is applied here.
 func IsPodRecentlyCreatedAfterNodeCordoned(
 	node *v1.Node,
-	nodeInfoMap map[string]*NodeInfo,
+	nodeInfoMap maps.SyncMap[string, *NodeInfo],
 	cluster *corev1.StorageCluster,
 ) bool {
-	nodeInfo, ok := nodeInfoMap[node.Name]
+	nodeInfo, ok := nodeInfoMap.Load(node.Name)
 	// The pod has never been created
 	if !ok || nodeInfo == nil {
 		return false

--- a/pkg/util/maps/syncmap.go
+++ b/pkg/util/maps/syncmap.go
@@ -1,0 +1,69 @@
+package maps
+
+import (
+	"sync"
+)
+
+// SyncMap is simplified implementation of Golang's sync.Map (see https://pkg.go.dev/sync#Map)
+// - should be more appropriate for "smaller parallelism" (i.e. less than 4 parallel CPU cores -access)
+type SyncMap[K comparable, V any] interface {
+	Load(key K) (V, bool)
+	LoadUnchecked(key K) V
+	Delete(key K)
+	Store(key K, value V)
+	Range(fn func(key K, value V) bool)
+}
+
+type syncMap[K comparable, V any] struct {
+	sync.RWMutex
+	internal map[K]V
+}
+
+// MakeSyncMap creates a new instance of a SyncMap
+func MakeSyncMap[K comparable, V any]() SyncMap[K, V] {
+	return &syncMap[K, V]{
+		internal: make(map[K]V),
+	}
+}
+
+// Loads retrieves an element out of the map
+func (m *syncMap[K, V]) Load(key K) (V, bool) {
+	m.RLock()
+	defer m.RUnlock()
+	result, ok := m.internal[key]
+	return result, ok
+}
+
+// LoadUnchecked retrieves an element out of the map.
+// -note, if element does not exist, equivalent of nil/0 is returned.
+func (m *syncMap[K, V]) LoadUnchecked(key K) V {
+	result, _ := m.Load(key)
+	return result
+}
+
+// Delete removes an element from the map
+func (m *syncMap[K, V]) Delete(key K) {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.internal, key)
+}
+
+// Store puts an element into the map
+func (m *syncMap[K, V]) Store(key K, value V) {
+	m.Lock()
+	defer m.Unlock()
+	m.internal[key] = value
+}
+
+// Range is used to enumerate the elements of the map.
+// - if cb callback func returns false, the enumeration is interrupted
+func (m *syncMap[K, V]) Range(cb func(key K, value V) bool) {
+	m.RLock()
+	defer m.RUnlock()
+
+	for k, v := range m.internal {
+		if !cb(k, v) {
+			break
+		}
+	}
+}

--- a/pkg/util/maps/syncmap_test.go
+++ b/pkg/util/maps/syncmap_test.go
@@ -1,0 +1,125 @@
+package maps
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicSyncMap(t *testing.T) {
+	m := MakeSyncMap[string, int]()
+
+	m.Store("a", 1)
+	m.Store("b", 2)
+	m.Store("c", 3)
+
+	x, has := m.Load("b")
+	assert.True(t, has)
+	assert.Equal(t, 2, x)
+
+	x, has = m.Load("z")
+	assert.False(t, has)
+	assert.Equal(t, 0, x)
+
+	x = m.LoadUnchecked("c")
+	assert.Equal(t, 3, x)
+
+	m.Store("b", 99)
+	x, has = m.Load("b")
+	assert.True(t, has)
+	assert.Equal(t, 99, x)
+
+	m.Delete("c")
+
+	x, has = m.Load("c")
+	assert.False(t, has)
+	assert.Equal(t, 0, x)
+
+	x = m.LoadUnchecked("c")
+	assert.Equal(t, 0, x)
+
+	m.Range(func(key string, value int) bool {
+		if key != "a" && key != "b" {
+			t.Errorf("Invalid key %v", key)
+		}
+		if value != 1 && value != 99 {
+			t.Errorf("Invalid value %v", value)
+		}
+		return true
+	})
+}
+
+// TestMapConcurrentPutGet_DEMO demonstrates panic when regular map is used
+func TestMapConcurrentPutGet_DEMO(t *testing.T) {
+	t.Skip("DISABLED -- this demo-test causes PANIC / fatal error: concurrent map writes")
+	var m = make(map[string]string)
+	go func() {
+		for {
+			_ = m["x"]
+		}
+	}()
+	go func() {
+		for {
+			m["y"] = "foo"
+		}
+	}()
+	time.Sleep(time.Second)
+}
+
+// TestMapConcurrentPutGet tests concurrent Put/Get access
+func TestMapConcurrentPutGet(t *testing.T) {
+	m := MakeSyncMap[string, string]()
+	go func() {
+		for {
+			m.Load("x")
+		}
+	}()
+	go func() {
+		for {
+			m.Store("y", "foo")
+		}
+	}()
+	time.Sleep(time.Second)
+	// note -- if no panic, test has suceeded
+}
+
+// TestMapConcurrentPutEnumerate_DEMO demonstrates panic when regular map is used
+func TestMapConcurrentPutEnumerate_DEMO(t *testing.T) {
+	t.Skip("DISABLED -- this demo-test causes PANIC / fatal error: concurrent map writes")
+	var m = make(map[string]string)
+	go func() {
+		for {
+			for range m {
+				_ = m["x"]
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	}()
+	go func() {
+		for {
+			m["y"] = "foo"
+		}
+	}()
+	time.Sleep(time.Second)
+}
+
+func TestMapConcurrentPutEnumerate(t *testing.T) {
+	m := MakeSyncMap[string, string]()
+	go func() {
+		for {
+			m.Range(func(key, value string) bool {
+				m.Load("x")
+				return true
+			})
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+	go func() {
+		for {
+			m.Store("y", "foo")
+		}
+	}()
+	time.Sleep(time.Second)
+	// note -- if no panic, test has suceeded
+}


### PR DESCRIPTION
* add simple SyncMap implementation
* fixed UTs

Signed-off-by: Zoran Rajic <zox@portworx.com>

Manually fixed Conflicts:
	pkg/controller/storagecluster/controller_test.go

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1303 into the `master`-branch

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-34391 (master)

**Special notes for your reviewer**:

see https://github.com/libopenstorage/operator/pull/1303