### PR TITLE
PWX-34650: allow autopilot to watch pvc

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -274,7 +274,7 @@ func (c *autopilot) createClusterRole() error {
 		{
 			APIGroups: []string{""},
 			Resources: []string{"persistentvolumeclaims", "persistentvolumes"},
-			Verbs:     []string{"get", "list", "update"},
+			Verbs:     []string{"get", "list", "update", "watch"},
 		},
 		{
 			APIGroups: []string{""},

--- a/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
@@ -14,7 +14,7 @@ rules:
     verbs: ["list"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims", "persistentvolumes"]
-    verbs: ["get", "list", "update"]
+    verbs: ["get", "list", "update", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "patch", "update"]

--- a/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
@@ -14,7 +14,7 @@ rules:
     verbs: ["list"]
   - apiGroups: [""]
     resources: ["persistentvolumeclaims", "persistentvolumes"]
-    verbs: ["get", "list", "update"]
+    verbs: ["get", "list", "update", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "patch", "update"]


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
currently autopilot complains about "Failed to watch *v1.PersistentVolumeClaim: unknown (get persistentvolumeclaims)" due to missing of watch permission on pvc and this error is gone on the testing cluster once watch is allowed for autopilot's clusterrole on pvc/pv 

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

