### PR TITLE
PWX-34798: allow autopilot to watch configmap

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -279,7 +279,7 @@ func (c *autopilot) createClusterRole() error {
 		{
 			APIGroups: []string{""},
 			Resources: []string{"configmaps"},
-			Verbs:     []string{"get", "list", "patch", "update"},
+			Verbs:     []string{"get", "list", "patch", "update", "watch"},
 		},
 		{
 			APIGroups: []string{"autopilot.libopenstorage.org"},

--- a/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
@@ -17,7 +17,7 @@ rules:
     verbs: ["get", "list", "update", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list", "patch", "update"]
+    verbs: ["get", "list", "patch", "update", "watch"]
   - apiGroups: ["autopilot.libopenstorage.org"]
     resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects"]
     verbs: ["*"]

--- a/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
@@ -17,7 +17,7 @@ rules:
     verbs: ["get", "list", "update", "watch"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    verbs: ["get", "list", "patch", "update"]
+    verbs: ["get", "list", "patch", "update", "watch"]
   - apiGroups: ["autopilot.libopenstorage.org"]
     resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects"]
     verbs: ["*"]


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We also need to allow autopilot to watch on configmaps otherwise error logs like 
`level=error msg="Failed to watch on config map: autopilot-config due to: unknown (get configmaps)" file="main.go:439"`
will show up, although it doesn't affect functionality of reloading autopilot when config changes

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

