### PR TITLE
PWX-34796: added scc and vol mnt

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -70,6 +70,15 @@ var (
 				},
 			},
 		},
+		{
+			Name:      "varcores",
+			MountPath: "/var/cores",
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: "/var/cores",
+				},
+			},
+		},
 	}
 )
 
@@ -290,6 +299,12 @@ func (c *autopilot) createClusterRole() error {
 			APIGroups: []string{"apiextensions.k8s.io"},
 			Resources: []string{"customresourcedefinitions"},
 			Verbs:     []string{"create", "get", "update"},
+		},
+		{
+			APIGroups:     []string{"security.openshift.io"},
+			Resources:     []string{"securitycontextconstraints"},
+			ResourceNames: []string{"portworx-restricted"},
+			Verbs:         []string{"use"},
 		},
 	}
 	if c.k8sVersion.LessThan(k8sutil.K8sVer1_25) {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -4368,10 +4368,10 @@ func TestAutopilotVolumesChange(t *testing.T) {
 	autopilotDeployment := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-	// Checking after first volume as autopilot deployment already has 1 volume
-	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:])
+	// Checking the 2nd volume as autopilot deployment already has the other two defined
+	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:2])
 	require.ElementsMatch(t, volumeMounts,
-		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:])
+		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:2])
 
 	// Case: Updated volumes should be applied to the deployment
 	propagation := v1.MountPropagationBidirectional
@@ -4389,9 +4389,9 @@ func TestAutopilotVolumesChange(t *testing.T) {
 	autopilotDeployment = &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:])
+	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:2])
 	require.ElementsMatch(t, volumeMounts,
-		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:])
+		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:2])
 
 	// Case: New volumes should be applied to the deployment
 	volumeSpecs = append(volumeSpecs, corev1.VolumeSpec{
@@ -4414,9 +4414,10 @@ func TestAutopilotVolumesChange(t *testing.T) {
 	autopilotDeployment = &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:])
+	// Newly added volume should follow the 2nd volume due to their naming
+	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:3])
 	require.ElementsMatch(t, volumeMounts,
-		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:])
+		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:3])
 
 	// Case: Removed volumes should be removed from the deployment
 	volumeSpecs = []corev1.VolumeSpec{volumeSpecs[0]}
@@ -4431,9 +4432,9 @@ func TestAutopilotVolumesChange(t *testing.T) {
 	autopilotDeployment = &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:])
+	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:2])
 	require.ElementsMatch(t, volumeMounts,
-		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:])
+		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:2])
 
 	// Case: If volumes are empty, should be removed from the deployment
 	cluster.Spec.Autopilot.Volumes = []corev1.VolumeSpec{}
@@ -4446,8 +4447,9 @@ func TestAutopilotVolumesChange(t *testing.T) {
 	autopilotDeployment = &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-	require.Empty(t, autopilotDeployment.Spec.Template.Spec.Volumes[1:])
-	require.Empty(t, autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:])
+	// Should contain at least two volumes from the defination
+	require.Empty(t, autopilotDeployment.Spec.Template.Spec.Volumes[2:])
+	require.Empty(t, autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[2:])
 
 	// Case: Volumes should be added back if not present in deployment
 	cluster.Spec.Autopilot.Volumes = volumeSpecs
@@ -4461,9 +4463,9 @@ func TestAutopilotVolumesChange(t *testing.T) {
 	autopilotDeployment = &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:])
+	require.ElementsMatch(t, volumes, autopilotDeployment.Spec.Template.Spec.Volumes[1:2])
 	require.ElementsMatch(t, volumeMounts,
-		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:])
+		autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:2])
 
 	// Case: If volumes is nil, deployment should not have volumes
 	cluster.Spec.Autopilot.Volumes = nil
@@ -4476,8 +4478,8 @@ func TestAutopilotVolumesChange(t *testing.T) {
 	autopilotDeployment = &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-	require.Empty(t, autopilotDeployment.Spec.Template.Spec.Volumes[1:])
-	require.Empty(t, autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[1:])
+	require.Empty(t, autopilotDeployment.Spec.Template.Spec.Volumes[2:])
+	require.Empty(t, autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts[2:])
 }
 
 func TestSecurityInstall(t *testing.T) {

--- a/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
@@ -24,3 +24,7 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "get", "update"]
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["portworx-restricted"]
+    verbs: ["use"]

--- a/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
@@ -28,3 +28,7 @@ rules:
     resources: ["podsecuritypolicies"]
     resourceNames: ["px-restricted"]
     verbs: ["use"]
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["portworx-restricted"]
+    verbs: ["use"]

--- a/drivers/storage/portworx/testspec/autopilotDeployment.yaml
+++ b/drivers/storage/portworx/testspec/autopilotDeployment.yaml
@@ -50,6 +50,8 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /etc/config
+        - name: varcores
+          mountPath: /var/cores
         env:
         - name: PX_NAMESPACE
           value: kube-test
@@ -120,3 +122,7 @@ spec:
             items:
             - key: config.yaml
               path: config.yaml
+        - hostPath:
+            path: /var/cores
+            type: ""
+          name: varcores


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
In op-23.5.0, usage of podsecuritypolicy for autopilot was removed if deployed on k8s 1.25 beyond, but in OCP in order for autopilot to access directories like /var/cores, we also need to allow its clusterrole to use portworx-restricted scc and also mount this folder from host.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-34796

**Special notes for your reviewer**:
Error messages like 
`time="30-10-2023 17:15:34" level=error msg="failed to create debug logs: mkdir /var/cores: permission denied" file="main.go:315"
time="30-10-2023 17:15:34" level=error msg="failed to start custom signal handlers: mkdir /var/cores: permission denied" file="main.go:277"`
are gone from autopilot log on OCP with this change

