### PR TITLE
PWX-22131, PWX-34256 -pt3: oci-mon node-wiper

### DIFF
--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -64,8 +64,10 @@ const (
 )
 
 var (
-	instance Manifest
-	once     sync.Once
+	instance      Manifest
+	once          sync.Once
+	pxVer2_5_7, _ = version.NewVersion("2.5.7")
+	pxVer3_1_0, _ = version.NewVersion("3.1.0")
 )
 
 // Release is a single release object with images for different components
@@ -190,7 +192,6 @@ func (m *manifest) GetVersions(
 	ver := pxutil.GetImageTag(cluster.Spec.Image)
 	currPxVer, err := version.NewSemver(ver)
 	if err == nil {
-		pxVer2_5_7, _ := version.NewVersion("2.5.7")
 		if currPxVer.LessThan(pxVer2_5_7) {
 			provider = newDeprecatedManifest(ver)
 		}
@@ -218,6 +219,9 @@ func (m *manifest) GetVersions(
 		return defaultRelease(m.k8sVersion)
 	}
 
+	if currPxVer != nil && currPxVer.GreaterThanOrEqual(pxVer3_1_0) && rel.Components.NodeWiper == "" {
+		rel.Components.NodeWiper = cluster.Spec.Image
+	}
 	fillDefaults(rel, m.k8sVersion)
 	m.lastUpdated = time.Now()
 	m.cachedVersions = rel

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -1033,6 +1033,8 @@ func (p *portworx) DeleteStorage(
 		completeMsg = storageClusterUninstallAndWipeMsg
 	}
 
+	logrus.WithField("removeData", removeData).Warnf("Deleting portworx cluster %s", cluster.Name)
+
 	u := NewUninstaller(cluster, p.k8sClient)
 	completed, inProgress, total, err := u.GetNodeWiperStatus()
 	if err != nil && errors.IsNotFound(err) {

--- a/drivers/storage/portworx/testspec/nodeWiper.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiper.yaml
@@ -23,7 +23,7 @@ spec:
         securityContext:
           privileged: true
         readinessProbe:
-          initialDelaySeconds: 30
+          initialDelaySeconds: 15
           exec:
             command:
             - cat

--- a/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
@@ -23,7 +23,7 @@ spec:
         securityContext:
           privileged: true
         readinessProbe:
-          initialDelaySeconds: 30
+          initialDelaySeconds: 15
           exec:
             command:
             - cat

--- a/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
@@ -24,7 +24,7 @@ spec:
         securityContext:
           privileged: true
         readinessProbe:
-          initialDelaySeconds: 30
+          initialDelaySeconds: 15
           exec:
             command:
             - cat

--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -236,7 +236,7 @@ func (u *uninstallPortworx) RunNodeWiper(
 								Privileged: &trueVar,
 							},
 							ReadinessProbe: &v1.Probe{
-								InitialDelaySeconds: 30,
+								InitialDelaySeconds: 15,
 								ProbeHandler: v1.ProbeHandler{
 									Exec: &v1.ExecAction{
 										Command: []string{"cat", "/tmp/px-node-wipe-done"},
@@ -401,6 +401,11 @@ func (u *uninstallPortworx) RunNodeWiper(
 				},
 			},
 		},
+	}
+
+	if strings.Contains(wiperImage, "monitor") {
+		logrus.Warnf("Using oci-monitor %s as node-wiper image", wiperImage)
+		ds.Spec.Template.Spec.Containers[0].Command = []string{"/px-node-wiper"}
 	}
 
 	if u.cluster.Spec.ImagePullSecret != nil && *u.cluster.Spec.ImagePullSecret != "" {


### PR DESCRIPTION
* will use `oci-monitor` image for node-wipes on PX-3.1.0 or higher
* also reduced the time till we start checking RedynessProbe

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This changes the _DEFAULT_ NodeWiper image, to `oci-monitor`
* if `install.portworx.com/version` provided a distinct image for node-wiper, we'll use the one provided by `/version` -manifest
* change will apply only on px-3.1.0  (or higher)

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-22131, PWX-34256   (part 3)

**Special notes for your reviewer**:

