### PR TITLE
PWX-34916: changed the default log level for autopilot from debug to info

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -405,7 +405,7 @@ func (c *autopilot) createDeployment(
 
 	args := map[string]string{
 		"config":    "/etc/config/config.yaml",
-		"log-level": "debug",
+		"log-level": "info",
 	}
 	for k, v := range cluster.Spec.Autopilot.Args {
 		if _, exists := autopilotConfigParams[k]; exists {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3227,7 +3227,7 @@ func TestAutopilotInstall(t *testing.T) {
 				},
 				Args: map[string]string{
 					"min_poll_interval": "4",
-					"log-level":         "debug",
+					"log-level":         "info",
 				},
 			},
 			Security: &corev1.SecuritySpec{
@@ -3992,7 +3992,7 @@ func TestAutopilotArgumentsChange(t *testing.T) {
 	)
 	require.Contains(t,
 		autopilotDeployment.Spec.Template.Spec.Containers[0].Command,
-		"--log-level=debug",
+		"--log-level=info",
 	)
 
 	// Overwrite existing argument with new value

--- a/drivers/storage/portworx/testspec/autopilotDeployment.yaml
+++ b/drivers/storage/portworx/testspec/autopilotDeployment.yaml
@@ -37,7 +37,7 @@ spec:
       - command:
         - /autopilot
         - --config=/etc/config/config.yaml
-        - --log-level=debug
+        - --log-level=info
         imagePullPolicy: Always
         image: docker.io/portworx/autopilot:1.1.1
         resources:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
QA is reporting to observe lots of frequent DEBUG repetitive logs from Autopilot pod. And since customer has the ability to set the log level at storagecluster spec, we'd like to change default to info from autopilot deployment so that only info/warn/error will show up

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Verified on testing cluster that with this change, by default only info/warn/error logs keep print out and once stc spec is edited with 
```
    args:
      log-level: debug
```
debug logs also show up
