### PR TITLE
PWX-22131, PWX-34256 -pt3 (23.12.0): oci-mon node-wiper (#1323)

### DIFF
--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -63,8 +63,10 @@ const (
 )
 
 var (
-	instance Manifest
-	once     sync.Once
+	instance      Manifest
+	once          sync.Once
+	pxVer2_5_7, _ = version.NewVersion("2.5.7")
+	pxVer3_1_0, _ = version.NewVersion("3.1.0")
 )
 
 // Release is a single release object with images for different components
@@ -185,7 +187,6 @@ func (m *manifest) GetVersions(
 	ver := pxutil.GetImageTag(cluster.Spec.Image)
 	currPxVer, err := version.NewSemver(ver)
 	if err == nil {
-		pxVer2_5_7, _ := version.NewVersion("2.5.7")
 		if currPxVer.LessThan(pxVer2_5_7) {
 			provider = newDeprecatedManifest(ver)
 		}
@@ -213,6 +214,9 @@ func (m *manifest) GetVersions(
 		return defaultRelease(m.k8sVersion)
 	}
 
+	if currPxVer != nil && currPxVer.GreaterThanOrEqual(pxVer3_1_0) && rel.Components.NodeWiper == "" {
+		rel.Components.NodeWiper = cluster.Spec.Image
+	}
 	fillDefaults(rel, m.k8sVersion)
 	m.lastUpdated = time.Now()
 	m.cachedVersions = rel

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/util"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
@@ -454,6 +455,34 @@ func TestManifestWithPartialComponents(t *testing.T) {
 	require.Equal(t, expected.PortworxVersion, rel.PortworxVersion)
 	require.Equal(t, defaultRelease(nil).Components, rel.Components)
 	require.Empty(t, rel.Components.CSIProvisioner)
+
+	// TestCase: No Nodewiper images
+	expected.PortworxVersion = "3.0.0"
+	expected.Components = Release{
+		Stork:          "image/stork:3.0.0",
+		Prometheus:     "image/prometheus:3.0.0",
+		CSIProvisioner: "image/csiprovisioner:3.0.0",
+	}
+	body, _ = yaml.Marshal(expected)
+	versionsConfigMap.Data[VersionConfigMapKey] = string(body)
+	err = k8sClient.Update(context.TODO(), versionsConfigMap)
+	require.NoError(t, err)
+
+	m.Init(k8sClient, nil, k8sVersion)
+	rel = m.GetVersions(cluster, true)
+	assert.Equal(t, defaultNodeWiperImage, rel.Components.NodeWiper)
+
+	cluster.Spec.Image = "foo/bar:3.1.0"
+	rel = m.GetVersions(cluster, true)
+	assert.Equal(t, cluster.Spec.Image, rel.Components.NodeWiper)
+
+	expected.Components.NodeWiper = "image/specific-nodewiper:123"
+	body, _ = yaml.Marshal(expected)
+	versionsConfigMap.Data[VersionConfigMapKey] = string(body)
+	err = k8sClient.Update(context.TODO(), versionsConfigMap)
+	require.NoError(t, err)
+	rel = m.GetVersions(cluster, true)
+	assert.Equal(t, expected.Components.NodeWiper, rel.Components.NodeWiper)
 }
 
 func TestManifestFillPrometheusDefaults(t *testing.T) {

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -822,6 +822,8 @@ func (p *portworx) DeleteStorage(
 		completeMsg = storageClusterUninstallAndWipeMsg
 	}
 
+	logrus.WithField("removeData", removeData).Warnf("Deleting portworx cluster %s", cluster.Name)
+
 	u := NewUninstaller(cluster, p.k8sClient)
 	completed, inProgress, total, err := u.GetNodeWiperStatus()
 	if err != nil && errors.IsNotFound(err) {

--- a/drivers/storage/portworx/testspec/nodeWiper.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiper.yaml
@@ -23,7 +23,7 @@ spec:
         securityContext:
           privileged: true
         readinessProbe:
-          initialDelaySeconds: 30
+          initialDelaySeconds: 15
           exec:
             command:
             - cat

--- a/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperPKS.yaml
@@ -23,7 +23,7 @@ spec:
         securityContext:
           privileged: true
         readinessProbe:
-          initialDelaySeconds: 30
+          initialDelaySeconds: 15
           exec:
             command:
             - cat

--- a/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
+++ b/drivers/storage/portworx/testspec/nodeWiperWithWipe.yaml
@@ -24,7 +24,7 @@ spec:
         securityContext:
           privileged: true
         readinessProbe:
-          initialDelaySeconds: 30
+          initialDelaySeconds: 15
           exec:
             command:
             - cat

--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -237,7 +237,7 @@ func (u *uninstallPortworx) RunNodeWiper(
 								Privileged: &trueVar,
 							},
 							ReadinessProbe: &v1.Probe{
-								InitialDelaySeconds: 30,
+								InitialDelaySeconds: 15,
 								ProbeHandler: v1.ProbeHandler{
 									Exec: &v1.ExecAction{
 										Command: []string{"cat", "/tmp/px-node-wipe-done"},
@@ -402,6 +402,11 @@ func (u *uninstallPortworx) RunNodeWiper(
 				},
 			},
 		},
+	}
+
+	if strings.Contains(wiperImage, "monitor") {
+		logrus.Warnf("Using oci-monitor %s as node-wiper image", wiperImage)
+		ds.Spec.Template.Spec.Containers[0].Command = []string{"/px-node-wiper"}
 	}
 
 	if u.cluster.Spec.ImagePullSecret != nil && *u.cluster.Spec.ImagePullSecret != "" {


### PR DESCRIPTION
* will use `oci-monitor` image for node-wipes on PX-3.1.0 or higher
* also reduced the time till we start checking RedynessProbe

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1323 into `px-rel-23.12.0` branch

**Which issue(s) this PR fixes** (optional)
Closes # PWX-22131, PWX-34256 -pt3 (23.12.0)

**Special notes for your reviewer**:

