### PR TITLE
PWX-33232: Save logging from pre-flight pod for diagnostics.

### DIFF
--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -44,6 +44,8 @@ const (
 	DefCmetaAzure = "type=Premium_LRS,size=64"
 	// DefCmetaGKE default metadata cloud device for DMthin GKE
 	DefCmetaGKE = "type=pd-ssd,size=64"
+	// preFlightOutputLog log location for pre-flight output
+	preFlightOutputLog = "/var/cores/px-pre-flight-output.log"
 )
 
 // PreFlightPortworx provides a set of APIs to uninstall portworx
@@ -177,7 +179,10 @@ func (u *preFlightPortworx) CreatePreFlightDaemonsetSpec(ownerRef *metav1.OwnerR
 		preflightDS.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Port = intstr.FromInt(preFltEndPtPort)
 		// Add pre-flight param w/--pre-flight-port
 		preflightDS.Spec.Template.Spec.Containers[0].Args = append(
-			[]string{"--pre-flight-port", fmt.Sprintf("%d", preFltEndPtPort)},
+			[]string{
+				"--pre-flight-port", fmt.Sprintf("%d", preFltEndPtPort),
+				"--log", preFlightOutputLog,
+			},
 			preflightDS.Spec.Template.Spec.Containers[0].Args...)
 	}
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Preflight pod logging disappears after pre-flight pods terminate and we need to preserve logging for diagnostics.   So pass parameter specifying where to save pre-flight logging.  

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-33232

**Special notes for your reviewer**:
Tested manually and inspected the output log on the node 
```
root@jose-1:/var/cores# cat px-pre-flight-output.log 
------------------------------------------------------------------------------
time="2023-11-11T01:18:23Z" level=info msg="Started logging into /var/cores/px-pre-flight-output.log"
time="2023-11-11T01:18:23Z" level=info msg="running in pre-flight mode..."
time="2023-11-11T01:18:23Z" level=info msg="Updated arguments: /px-oci-mon -T px-storev2 -c px-cluster-c175997e-3ac1-4b4f-ad71-dbd34f839409 -x kubernetes -b -s /dev/sdd -s /dev/sde -secret_type k8s" install-opts=--upgrade
time="2023-11-11T01:18:23Z" level=info msg="OCI-Monitor computed version v“3.1.0”-g6b46646e-dirty"
time="2023-11-11T01:18:23Z" level=info msg="using pre-flight endpoint: 127.0.0.1:9030"
time="2023-11-11T01:18:23Z" level=info msg="using pre-flight health endpoint: http://127.0.0.1:9030/v1/cluster/nodehealth"
time="2023-11-11T01:18:23Z" level=info msg="REAPER: Starting ..."
time="2023-11-11T01:18:23Z" level=info msg="Service handler initialized as DBus{type:dbus,svc:portworx.service,id:0xc0005c15a8}"
time="2023-11-11T01:18:23Z" level=info msg="Setting up container handler"
time="2023-11-11T01:18:23Z" level=info msg="Locating my container handler"
time="2023-11-11T01:18:23Z" level=info msg="Negotiated Docker API version: 1.42"
```

This PR: https://github.com/portworx/porx/pull/12586 will collect logs in the diags.