### PR TITLE
PWX-34634: Upgrade build to golang-1.21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 dist: focal
 language: go
 go:
-  - 1.20.7
+  - 1.21.4
 before_install:
   - sudo wget -O opm https://github.com/operator-framework/operator-registry/releases/latest/download/linux-amd64-opm
   - sudo chmod +x opm

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ container:
 	@echo "Building operator image $(OPERATOR_IMG)"
 	docker build --pull --tag $(OPERATOR_IMG) -f build/Dockerfile .
 
-DOCK_BUILD_CNT	:= golang:1.20
+DOCK_BUILD_CNT	:= golang:1.21
 
 docker-build:
 	@echo "Building using docker"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libopenstorage/operator
 
-go 1.19
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go v1.44.45

--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.21
 
 # Install dependancies
 RUN apt-get update && \ 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Security scanners are complaining the `operator` was build via golang-1.20.x
* as a fix, we're upgrading the operator-build to golang-1.21.4  (latest stable)

**Which issue(s) this PR fixes** (optional)
Closes # PWX-34634

**Special notes for your reviewer**:

Quick test:

```
$ docker run --rm -it -v /tmp:/tmp --entrypoint bash zoxpx/px-operator:latest
bash-4.4$ cp /operator /tmp/
bash-4.4$ exit

$ go version /tmp/operator
/tmp/operator: go1.21.4
```

+ manual test: the new operator was able to deploy a functional PX cluster successfully.