### PR TITLE
PWX-35044: Upgrade base-container to UBI-9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -313,4 +313,4 @@ clean: clean-release-manifest clean-bundle
 	@rm -rf $(BIN)
 	@go clean -i $(PKGS)
 	@echo "Deleting image "$(OPERATOR_IMG)
-	@docker rmi -f $(OPERATOR_IMG) registry.access.redhat.com/ubi8-minimal:latest
+	@docker rmi -f $(OPERATOR_IMG) registry.access.redhat.com/ubi9-minimal:latest

--- a/README.md
+++ b/README.md
@@ -18,19 +18,18 @@ cd operator
 make downloads all
 ```
 
-Troubleshooting: 
+Troubleshooting:
 
-If you get errors like 
+Do not modify `$GOBIN` -- this build process depends on installing and using linter-tools (i.e. `staticcheck`) from the default `$GOPATH/bin`.
 
-```sh
-/usr/local/go/src/math/erf.go:189:6: Erf defined in both Go and assembly
-/usr/local/go/src/math/erf.go:274:6: Erfc defined in both Go and assembly
+
+Q: I'm getting the following warning during the build:
+
+```
+WARNING: Tool /go/bin/my-linter-tool compiled with go1.20.10	 (you are using go1.21.4)
 ```
 
-
-try to switch to go 1.19. 
-
-Make sure not only $GOPATH but also $GOPATH/bin are in your system $PATH, otherwise `staticcheck` would fail.
+A: To fix this, just remove the binary, and the build-process should automatically rebuild the tool using your current golang compiler.
 
 ## Build operator container
 

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ export DOCKER_HUB_REPO=<eg. mybuildx>
 ```sh
 make container deploy
 ```
+

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 RUN microdnf clean all && \
     microdnf install -y tar && \


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The security-scans keep raising issues in the base-container (UBI-8)
* as a fix, we're upgrading the base-container to the latest UBI-9jj

**Which issue(s) this PR fixes** (optional)
Closes # PWX-35044

**Special notes for your reviewer**:

Tested PX wipe + deployment manually -- PX deployed OK

Also checking the `kubectl cp` -- since this uses `tar` command inside the container:
```
$ kubectl cp portworx-operator-9d45c5c47-vvc9z:/operator /tmp/operagtor-copy
$ ls -al /tmp/operagtor-copy
-rw-r--r-- 1 zox users 65564672 Nov 17 11:56 /tmp/operagtor-copy
```
* this also worked OK