### PR TITLE
PWX-35067 (23.10.1): Don't set the cloud provider from preflight provider name (PR #1339)

### DIFF
--- a/deploy/olm-catalog/portworx/23.10.1/portworx-certified.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/23.10.1/portworx-certified.clusterserviceversion.yaml
@@ -4,6 +4,7 @@ metadata:
   name: portworx-operator.v23.10.1
   namespace: placeholder
   annotations:
+    olm.skipRange: '=23.10.0'
     capabilities: Auto Pilot
     categories: "Storage"
     description: Cloud native storage solution for production workloads
@@ -53,7 +54,7 @@ spec:
   version: 23.10.1
   minKubeVersion: "1.21.0"
   maturity: stable
-  replaces: portworx-operator.v23.10.0
+  replaces: portworx-operator.v23.7.0
   maintainers:
   - name: Portworx
     email: support@portworx.com

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/libopenstorage/cloudops"
+	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,11 +23,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 
+	"github.com/libopenstorage/cloudops"
 	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/preflight"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
-	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 )
 
 func TestBasicRuncPodSpec(t *testing.T) {
@@ -1824,59 +1824,6 @@ func TestPodSpecWithCloudStorageSpecOnGCE(t *testing.T) {
 		"-x", "kubernetes",
 		"-b",
 		"-cloud_provider", "gce",
-		"-secret_type", "k8s",
-	}
-	actual, _ := driver.GetStoragePodSpec(cluster, fakeK8sNodes.Items[0].Name)
-	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
-
-	// Reset preflight for other tests
-	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
-	err = preflight.InitPreflightChecker(k8sClient)
-	require.NoError(t, err)
-}
-
-func TestPodSpecWithCloudStorageSpecOnAzure(t *testing.T) {
-	fakeK8sNodes := &v1.NodeList{Items: []v1.Node{
-		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Spec: v1.NodeSpec{ProviderID: "azure://node-id-1"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "node2"}, Spec: v1.NodeSpec{ProviderID: "azure://node-id-2"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "node3"}, Spec: v1.NodeSpec{ProviderID: "azure://node-id-3"}},
-	}}
-
-	versionClient := fakek8sclient.NewSimpleClientset(fakeK8sNodes)
-	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
-		GitVersion: "v1.26.5",
-	}
-	coreops.SetInstance(coreops.New(versionClient))
-	k8sClient := testutil.FakeK8sClient(fakeK8sNodes)
-	err := preflight.InitPreflightChecker(k8sClient)
-	require.NoError(t, err)
-
-	c := preflight.Instance()
-	require.Equal(t, cloudops.Azure, c.ProviderName())
-
-	driver := portworx{}
-	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
-	require.NoError(t, err)
-
-	cluster := &corev1.StorageCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "px-cluster",
-			Namespace: "kube-test",
-		},
-		Spec: corev1.StorageClusterSpec{
-			Image:        "portworx/oci-monitor:3.0.0",
-			CloudStorage: &corev1.CloudStorageSpec{},
-		},
-	}
-
-	err = driver.SetDefaultsOnStorageCluster(cluster)
-	require.NoError(t, err)
-
-	expectedArgs := []string{
-		"-c", "px-cluster",
-		"-x", "kubernetes",
-		"-b",
-		"-cloud_provider", "azure",
 		"-secret_type", "k8s",
 	}
 	actual, _ := driver.GetStoragePodSpec(cluster, fakeK8sNodes.Items[0].Name)

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -739,7 +739,6 @@ func TestPreflightAnnotations(t *testing.T) {
 
 	err := preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
-	require.Equal(t, string(cloudops.AWS), pxutil.GetCloudProvider(cluster)) // Make sure aws
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 	check, ok := cluster.Annotations[pxutil.AnnotationPreflightCheck]

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -15,30 +15,28 @@ import (
 	"strings"
 	"time"
 
-	"github.com/libopenstorage/cloudops"
-
 	"github.com/google/shlex"
 	"github.com/hashicorp/go-version"
+	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/metadata"
-
-	"github.com/libopenstorage/openstorage/api"
-	"github.com/libopenstorage/openstorage/pkg/auth"
-	"github.com/libopenstorage/openstorage/pkg/grpcserver"
-	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/constants"
-	"github.com/libopenstorage/operator/pkg/preflight"
-	"github.com/libopenstorage/operator/pkg/util"
-	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
-	coreops "github.com/portworx/sched-ops/k8s/core"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/libopenstorage/cloudops"
+	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/pkg/auth"
+	"github.com/libopenstorage/openstorage/pkg/grpcserver"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	"github.com/libopenstorage/operator/pkg/util"
+	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 )
 
 const (
@@ -369,11 +367,6 @@ func GetCloudProvider(cluster *corev1.StorageCluster) string {
 	if IsVsphere(cluster) {
 		return cloudops.Vsphere
 	}
-
-	if len(preflight.Instance().ProviderName()) > 0 {
-		return preflight.Instance().ProviderName()
-	}
-
 	// TODO: implement conditions for other providers
 	return ""
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

### Don't set the cloud provider from preflight provider name
The preflight provider name is derived from the k8s node.spec.provider
field. These values don't necessarily match with the portworx cloudops
providers. If we blindly set the preflight values to the cloud provider, it
leads to portworx crashing as it does not recognize that cloudops provider.

Reverting back to the old behavior where we only explicitly check for
vsphere. In future, we can either have common cloud providers between preflight
and cloudops or we can do the conversion somewhere before setting the cloud
provider in storagecluster spec.

### Skipping upgrading to 23.10.0 if users are on older version.

Openshift operator upgrades happen one version at a time. If users go to
23.10.0, they will hit the bug where operator is incorrectly adding the cloud
provider in the storage cluster spec.
That's why we want to skip 23.10.0 upgrade and customers can directly go from
23.7.0 to 23.10.1


**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-35067

**Special notes for your reviewer**:

Testing Notes:
- Tested this manually  on an Anthos Baremetal cluster
- Tested this manually on an Anthos VMWare cluster with Pure FA CloudDrives