### PR TITLE
PWX-35067 Don't set the cloud provider from preflight provider name

### DIFF
--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
+	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,8 +32,6 @@ import (
 	"github.com/libopenstorage/operator/pkg/cloudprovider"
 	"github.com/libopenstorage/operator/pkg/preflight"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
-	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
-	coreops "github.com/portworx/sched-ops/k8s/core"
 )
 
 func TestBasicRuncPodSpec(t *testing.T) {
@@ -2042,60 +2042,6 @@ func TestPodSpecWithCloudStorageSpecOnGCE(t *testing.T) {
 		"-x", "kubernetes",
 		"-b",
 		"-cloud_provider", "gce",
-		"-max_storage_nodes_per_zone", "3",
-		"-secret_type", "k8s",
-	}
-	actual, _ := driver.GetStoragePodSpec(cluster, fakeK8sNodes.Items[0].Name)
-	assert.ElementsMatch(t, expectedArgs, actual.Containers[0].Args)
-
-	// Reset preflight for other tests
-	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
-	err = preflight.InitPreflightChecker(k8sClient)
-	require.NoError(t, err)
-}
-
-func TestPodSpecWithCloudStorageSpecOnAzure(t *testing.T) {
-	fakeK8sNodes := &v1.NodeList{Items: []v1.Node{
-		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Spec: v1.NodeSpec{ProviderID: "azure://node-id-1"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "node2"}, Spec: v1.NodeSpec{ProviderID: "azure://node-id-2"}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "node3"}, Spec: v1.NodeSpec{ProviderID: "azure://node-id-3"}},
-	}}
-
-	versionClient := fakek8sclient.NewSimpleClientset(fakeK8sNodes)
-	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
-		GitVersion: "v1.26.5",
-	}
-	coreops.SetInstance(coreops.New(versionClient))
-	k8sClient := testutil.FakeK8sClient(fakeK8sNodes)
-	err := preflight.InitPreflightChecker(k8sClient)
-	require.NoError(t, err)
-
-	c := preflight.Instance()
-	require.Equal(t, cloudops.Azure, c.ProviderName())
-
-	driver := portworx{}
-	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
-	require.NoError(t, err)
-
-	cluster := &corev1.StorageCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "px-cluster",
-			Namespace: "kube-test",
-		},
-		Spec: corev1.StorageClusterSpec{
-			Image:        "portworx/oci-monitor:3.0.0",
-			CloudStorage: &corev1.CloudStorageSpec{},
-		},
-	}
-
-	err = driver.SetDefaultsOnStorageCluster(cluster)
-	require.NoError(t, err)
-
-	expectedArgs := []string{
-		"-c", "px-cluster",
-		"-x", "kubernetes",
-		"-b",
-		"-cloud_provider", "azure",
 		"-max_storage_nodes_per_zone", "3",
 		"-secret_type", "k8s",
 	}

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -798,7 +798,6 @@ func TestValidateAzure(t *testing.T) {
 
 	actual, err := driver.GetStoragePodSpec(cluster, "testNode")
 	assert.NoError(t, err, "Unexpected error on GetStoragePodSpec")
-	require.Contains(t, strings.Join(actual.Containers[0].Args, " "), "-cloud_provider "+cloudops.Azure)
 	require.Contains(t, strings.Join(actual.Containers[0].Args, " "), "-metadata "+DefCmetaAzure)
 
 	require.NotEmpty(t, recorder.Events)
@@ -1187,7 +1186,6 @@ func TestPreflightAnnotations(t *testing.T) {
 
 	err := preflight.InitPreflightChecker(k8sClient)
 	require.NoError(t, err)
-	require.Equal(t, string(cloudops.AWS), pxutil.GetCloudProvider(cluster)) // Make sure aws
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 	check, ok := cluster.Annotations[pxutil.AnnotationPreflightCheck]

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -38,7 +38,6 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/grpcserver"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"
-	"github.com/libopenstorage/operator/pkg/preflight"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
 )
@@ -424,10 +423,6 @@ func GetCloudProvider(cluster *corev1.StorageCluster) string {
 
 	if IsPure(cluster) {
 		return cloudops.Pure
-	}
-
-	if len(preflight.Instance().ProviderName()) > 0 {
-		return preflight.Instance().ProviderName()
 	}
 
 	// TODO: implement conditions for other providers


### PR DESCRIPTION
The preflight provider name is derived from the k8s node.spec.provider field. These values don't necessarily match with the portworx cloudops providers. If we blindly set the preflight values to the cloud provider, it leads to portworx crashing as it does not recognize that cloudops provider.

Reverting back to the old behavior where we only explicitly check for vsphere. In future, we can either have common cloud providers between preflight and cloudops or we can do the conversion somewhere before setting the cloud provider in storagecluster spec.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-35067

**Special notes for your reviewer**:

