### PR TITLE
PWX-35044 (23.12.0): Upgrade base-container to UBI-9 (#1337)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,4 +298,4 @@ clean: clean-release-manifest clean-bundle
 	@rm -rf $(BIN)
 	@go clean -i $(PKGS)
 	@echo "Deleting image "$(OPERATOR_IMG)
-	@docker rmi -f $(OPERATOR_IMG) registry.access.redhat.com/ubi8-minimal:latest
+	@docker rmi -f $(OPERATOR_IMG) registry.access.redhat.com/ubi9-minimal:latest

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 RUN microdnf clean all && \
     microdnf install -y tar && \


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1337 into `px-rel-23.12.0` branch

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-35044 (23.12.0)

**Special notes for your reviewer**:

