### PR TITLE
Integration-test image build fix

### DIFF
--- a/test/integration_test/Dockerfile
+++ b/test/integration_test/Dockerfile
@@ -2,19 +2,21 @@ FROM golang:1.21
 
 # Install dependancies
 RUN apt-get update && \ 
-    /usr/local/go/bin/go install gotest.tools/gotestsum@latest
-RUN apt-get install -y jq
+    apt-get install -y jq file
+RUN /usr/local/go/bin/go install gotest.tools/gotestsum@latest
 
 # Install aws-iam-authenticator
 # This is needed by test running inside EKS cluster and making API calls to aws.
-RUN curl -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator && \
+RUN curl -fsSL -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator && \
+    (file aws-iam-authenticator | grep -q "ELF 64-bit LSB executable") && \
     chmod a+x aws-iam-authenticator && \
-    mv aws-iam-authenticator /bin
+    mv aws-iam-authenticator /bin/
 
 # Install kubectl
-RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
-RUN chmod +x ./kubectl
-RUN mv ./kubectl /usr/local/bin
+RUN curl -fsSL -o kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    (file kubectl | grep -q "ELF 64-bit LSB executable") && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/
 
 WORKDIR /
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Adding more checks into the `make integration-test-container`

ISSUE:
* the docker-build just downloads 2 executables from the Internet, without checking if they actually downloaded OK

FIX:
* changed `curl` -command flags, so it'll fail with `$? != 0` if download fails, also
* added basic `file`-test on the downloaded binaries

**Which issue(s) this PR fixes** (optional)
Closes # -

**Special notes for your reviewer**:

Manual test:

```
# make integration-test integration-test-container
...
Sending build context to Docker daemon  78.23MB
Step 1/10 : FROM golang:1.21
 ---> 4c88d2e04e7d
Step 2/10 : RUN apt-get update &&     apt-get install -y jq file
 ---> Using cache
 ---> baf19866c7e8
Step 3/10 : RUN /usr/local/go/bin/go install gotest.tools/gotestsum@latest
 ---> Using cache
 ---> 2c432093b512
Step 4/10 : RUN curl -fsSL -o aws-iam-authenticator https://amazon-eks.s3.us-west-2.amazonaws.com/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator &&     (file aws-iam-authenticator | grep -q "ELF 64-bit LSB executable") &&     chmod a+x aws-iam-authenticator &&     mv aws-iam-authenticator /bin/
 ---> Using cache
 ---> f5f19250b784
Step 5/10 : RUN curl -fsSL -o kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" &&     (file kubectl | grep -q "ELF 64-bit LSB executable") &&     chmod +x ./kubectl &&     mv ./kubectl /usr/local/bin/
 ---> Using cache
 ---> 329fe41dec09
Step 6/10 : WORKDIR /
 ---> Using cache
 ---> f0555d3047d8
Step 7/10 : COPY operator.test /
 ---> Using cache
 ---> f3aec19bd373
Step 8/10 : COPY testspec /testspec
 ---> Using cache
 ---> d296f1b204db
Step 9/10 : COPY test-deploy.sh /
 ---> Using cache
 ---> 781b731399a0
Step 10/10 : COPY operator-test-pod-template.yaml /
 ---> Using cache
 ---> 220fdf0a5d94
Successfully built 220fdf0a5d94
Successfully tagged 127.0.0.1/zoxpx/px-operator-test:latest
```