### PR TITLE
PWX-34411 Allow overriding the min available value of px-storage PDB

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -11504,7 +11504,21 @@ func TestPodDisruptionBudgetEnabled(t *testing.T) {
 	err = testutil.Get(k8sClient, storagePDB, component.StoragePodDisruptionBudgetName, cluster.Namespace)
 	require.True(t, errors.IsNotFound(err))
 
-	// TestCase: Create storage PDB if total nodes with storage is at least 3
+	// TestCase: Do not create storage PDB if storage pod annotation value is less than 2
+	cluster.Annotations = map[string]string{
+		pxutil.AnnotationStoragePodDisruptionBudget: "1",
+	}
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	storagePDB = &policyv1.PodDisruptionBudget{}
+	err = testutil.Get(k8sClient, storagePDB, component.StoragePodDisruptionBudgetName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+
+	// TestCase: Create storage PDB if total nodes with storage is at least 3.
+	// Also, ignore the annotation if the value is an invalid integer
+	cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] = "invalid"
 	expectedNodeEnumerateResp.Nodes = []*osdapi.StorageNode{
 		{Pools: []*osdapi.StoragePool{{ID: 1}}, SchedulerNodeName: "node1"},
 		{Pools: []*osdapi.StoragePool{{ID: 2}}, SchedulerNodeName: "node2"},
@@ -11525,7 +11539,9 @@ func TestPodDisruptionBudgetEnabled(t *testing.T) {
 	require.Equal(t, cluster.Name, storagePDB.Spec.Selector.MatchLabels[constants.LabelKeyClusterName])
 	require.Equal(t, constants.LabelValueTrue, storagePDB.Spec.Selector.MatchLabels[constants.LabelKeyStoragePod])
 
-	// TestCase: Update storage PDB if count of nodes with storage changes
+	// TestCase: Update storage PDB if count of nodes with storage changes.
+	// Also, ignore the annotation if the value is an invalid integer
+	cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] = "still_invalid"
 	expectedNodeEnumerateResp.Nodes = []*osdapi.StorageNode{
 		{Pools: []*osdapi.StoragePool{{ID: 1}}, SchedulerNodeName: "node1"},
 		{Pools: []*osdapi.StoragePool{{ID: 2}}, SchedulerNodeName: "node2"},
@@ -11545,7 +11561,20 @@ func TestPodDisruptionBudgetEnabled(t *testing.T) {
 
 	require.Equal(t, 4, storagePDB.Spec.MinAvailable.IntValue())
 
+	// TestCase: Update storage PDB if overwritten using annotation
+	cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] = "10"
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	storagePDB = &policyv1.PodDisruptionBudget{}
+	err = testutil.Get(k8sClient, storagePDB, component.StoragePodDisruptionBudgetName, cluster.Namespace)
+	require.NoError(t, err)
+
+	require.Equal(t, 10, storagePDB.Spec.MinAvailable.IntValue())
+
 	// TestCase: Use NonQuorumMember flag to determine storage node count
+	cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] = ""
 	expectedNodeEnumerateResp.Nodes = []*osdapi.StorageNode{
 		{NonQuorumMember: false, SchedulerNodeName: "node1", NodeLabels: map[string]string{pxutil.NodeLabelPortworxVersion: "3.1.0"}},
 		{NonQuorumMember: false, SchedulerNodeName: "node2", NodeLabels: map[string]string{pxutil.NodeLabelPortworxVersion: "3.2.0"}},

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -130,6 +130,9 @@ const (
 	AnnotationRunOnMaster = pxAnnotationPrefix + "/run-on-master"
 	// AnnotationPodDisruptionBudget annotation indicating whether to create pod disruption budgets
 	AnnotationPodDisruptionBudget = pxAnnotationPrefix + "/pod-disruption-budget"
+	// AnnotationStoragePodDisruptionBudget annotation to specify the min available value of the px-storage
+	// pod disruption budget
+	AnnotationStoragePodDisruptionBudget = pxAnnotationPrefix + "/storage-pdb-min-available"
 	// AnnotationPodSecurityPolicy annotation indicating whether to enable creation
 	// of pod security policies
 	AnnotationPodSecurityPolicy = pxAnnotationPrefix + "/pod-security-policy"
@@ -1296,6 +1299,13 @@ func GetClusterID(cluster *corev1.StorageCluster) string {
 		return cluster.Annotations[AnnotationClusterID]
 	}
 	return cluster.Name
+}
+
+func MinAvailableForStoragePDB(cluster *corev1.StorageCluster) (int, error) {
+	if cluster.Annotations[AnnotationStoragePodDisruptionBudget] != "" {
+		return strconv.Atoi(cluster.Annotations[AnnotationStoragePodDisruptionBudget])
+	}
+	return -1, nil
 }
 
 // CountStorageNodes counts how many px storage node are there on given k8s cluster,


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Currently the storage PDB allows deletion of only one PX pod at any given time. This is to ensure we don't lose volume replica quorum. This allows user to knowingly change the PDB value and run the k8s upgrade faster by upgrading multiple nodes in parallel. The users who will use it understand the risk and we will document accordingly.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-34411

**Special notes for your reviewer**:

