### PR TITLE
Modifying UTs for docs change in PWX-35016

### DIFF
--- a/drivers/storage/portworx/testspec/prometheusRule.yaml
+++ b/drivers/storage/portworx/testspec/prometheusRule.yaml
@@ -173,12 +173,12 @@ spec:
         scrape_target_name: "{{$labels.node}}"
     - alert: PXKvdbNodeViewUnhealthy
       annotations:
-        description: Portworx node {{$labels.node_id}} from cluster {{$labels.cluster}} is unable to talk to kvdb. Please check the KVDB health and node's connection to KVDB.
-        summary: Portworx node {{$labels.node_id}} is unable to talk to kvdb.
+        description: Portworx node {{$labels.node}} from cluster {{$labels.cluster}} is unable to talk to kvdb. Please check the KVDB health and node's connection to KVDB.
+        summary: Portworx node {{$labels.node}} is unable to talk to kvdb.
       expr: px_kvdb_health_state_node_view == 2
       for: 5m
       labels:
-        issue: Portworx node {{$labels.node_id}} is unable to talk to kvdb.
+        issue: Portworx node {{$labels.node}} is unable to talk to kvdb.
         severity: critical
         resource_type: portworx-node
         resource_name: "{{$labels.node}}"
@@ -186,7 +186,7 @@ spec:
         scrape_target_name: "{{$labels.node}}"
     - alert: PXKvdbClusterViewUnhealthy
       annotations:
-        description: Portworx node {{$labels.node_id}} from cluster {{$labels.cluster}} is reporting that the cluster is unable to talk to kvdb. Please check KVDB health and the node's connection to KVDB and the other nodes in the cluster.
+        description: Portworx node {{$labels.node}} from cluster {{$labels.cluster}} is reporting that the cluster is unable to talk to kvdb. Please check KVDB health and the node's connection to KVDB and the other nodes in the cluster.
         summary: Portworx cluster {{$labels.cluster}} is unable to talk to kvdb.
       expr: px_kvdb_health_state_cluster_view == 2
       labels:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This PR corrects the UTs that fail due to changing the portworx docs in ticket PWX-35016

**Which issue(s) this PR fixes** :Closes # PWX-35138

**Special notes to the reviewer**: Initially, prometheus alerts - PXKvdbNodeViewUnhealthy and PXKvdbClusterViewUnhealthy used the metric label "{$labels.node_id}" to identify nodes which was not valid. The docs website was modified to change the prometheus-rules yaml to use "{$labels.node}" instead. This change has been verified in the prometheus UI as well.


