### PR TITLE
PTX-21234: Fix incorrect validation for csi-node-driver-registrar inside portworx-api pods instead of oci-mon pods for older operators

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -178,6 +178,7 @@ var (
 	opVer23_5_1, _                    = version.NewVersion("23.5.1-")
 	opVer23_7, _                      = version.NewVersion("23.7.0-")
 	minOpVersionForKubeSchedConfig, _ = version.NewVersion("1.10.2-")
+	pxOperatorMasterVersion, _        = version.NewVersion("99.9.9")
 
 	// OCP Dynamic Plugin is only supported in starting with OCP 4.12+ which is k8s v1.25.0+
 	minK8sVersionForDynamicPlugin, _ = version.NewVersion("1.25.0")
@@ -2437,7 +2438,9 @@ func ValidateCsiEnabled(pxImageList map[string]string, cluster *corev1.StorageCl
 
 		var pods *v1.PodList
 		var err error
-		if pxVersion.GreaterThanOrEqual(pxVer2_13) {
+
+		// TODO: Need to change "pxOperatorMasterVersion" to the release version when released
+		if opVersion, _ := GetPxOperatorVersion(); pxVersion.LessThan(pxVer2_13) && opVersion.Equal(pxOperatorMasterVersion) {
 			pods, err = coreops.Instance().GetPods(cluster.Namespace, map[string]string{"name": "portworx-api"})
 			if err != nil {
 				return nil, true, err
@@ -2547,7 +2550,8 @@ func validateCsiContainerInPxPods(namespace string, csi bool, timeout, interval 
 				podsReady++
 			}
 
-			if pxVersion.LessThan(pxVer2_13) {
+			// TODO: Need to change "pxOperatorMasterVersion" to the release version when released
+			if opVersion, _ := GetPxOperatorVersion(); pxVersion.LessThan(pxVer2_13) && opVersion.Equal(pxOperatorMasterVersion) {
 				for _, container := range pod.Spec.Containers {
 					if container.Name == "csi-node-driver-registrar" {
 						pxPodsWithCsiContainer = append(pxPodsWithCsiContainer, pod.Name)
@@ -2558,7 +2562,8 @@ func validateCsiContainerInPxPods(namespace string, csi bool, timeout, interval 
 
 		}
 
-		if pxVersion.GreaterThanOrEqual(pxVer2_13) {
+		// TODO: Need to change "pxOperatorMasterVersion" to the release version when released
+		if opVersion, _ := GetPxOperatorVersion(); pxVersion.LessThan(pxVer2_13) && opVersion.Equal(pxOperatorMasterVersion) {
 			apiPods, err := coreops.Instance().GetPods(namespace, listOptionsNew)
 			if err != nil {
 				return nil, false, err

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -178,7 +178,7 @@ var (
 	opVer23_5_1, _                    = version.NewVersion("23.5.1-")
 	opVer23_7, _                      = version.NewVersion("23.7.0-")
 	minOpVersionForKubeSchedConfig, _ = version.NewVersion("1.10.2-")
-	pxOperatorMasterVersion, _        = version.NewVersion("99.9.9")
+	pxOperatorMasterVersion, _        = version.NewVersion(PxOperatorMasterVersion)
 
 	// OCP Dynamic Plugin is only supported in starting with OCP 4.12+ which is k8s v1.25.0+
 	minK8sVersionForDynamicPlugin, _ = version.NewVersion("1.25.0")
@@ -2440,7 +2440,7 @@ func ValidateCsiEnabled(pxImageList map[string]string, cluster *corev1.StorageCl
 		var err error
 
 		// TODO: Need to change "pxOperatorMasterVersion" to the release version when released
-		if opVersion, _ := GetPxOperatorVersion(); pxVersion.LessThan(pxVer2_13) && opVersion.Equal(pxOperatorMasterVersion) {
+		if opVersion, _ := GetPxOperatorVersion(); pxVersion.GreaterThanOrEqual(pxVer2_13) && opVersion.GreaterThanOrEqual(pxOperatorMasterVersion) {
 			pods, err = coreops.Instance().GetPods(cluster.Namespace, map[string]string{"name": "portworx-api"})
 			if err != nil {
 				return nil, true, err
@@ -2551,7 +2551,7 @@ func validateCsiContainerInPxPods(namespace string, csi bool, timeout, interval 
 			}
 
 			// TODO: Need to change "pxOperatorMasterVersion" to the release version when released
-			if opVersion, _ := GetPxOperatorVersion(); pxVersion.LessThan(pxVer2_13) && opVersion.Equal(pxOperatorMasterVersion) {
+			if opVersion, _ := GetPxOperatorVersion(); pxVersion.LessThan(pxVer2_13) || opVersion.LessThan(pxOperatorMasterVersion) {
 				for _, container := range pod.Spec.Containers {
 					if container.Name == "csi-node-driver-registrar" {
 						pxPodsWithCsiContainer = append(pxPodsWithCsiContainer, pod.Name)
@@ -2563,7 +2563,7 @@ func validateCsiContainerInPxPods(namespace string, csi bool, timeout, interval 
 		}
 
 		// TODO: Need to change "pxOperatorMasterVersion" to the release version when released
-		if opVersion, _ := GetPxOperatorVersion(); pxVersion.LessThan(pxVer2_13) && opVersion.Equal(pxOperatorMasterVersion) {
+		if opVersion, _ := GetPxOperatorVersion(); pxVersion.GreaterThanOrEqual(pxVer2_13) && opVersion.GreaterThanOrEqual(pxOperatorMasterVersion) {
 			apiPods, err := coreops.Instance().GetPods(namespace, listOptionsNew)
 			if err != nil {
 				return nil, false, err

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -2568,11 +2568,11 @@ func validateCsiContainerInPxApiPods(namespace string, csi bool, timeout, interv
 
 		if csi {
 			if len(pxPodsWithCsiContainer) != len(pods.Items) {
-				return nil, true, fmt.Errorf("failed to validate CSI containers in PX Api pods: expected %d, got %d, %d/%d Ready pods", len(pods.Items), len(pxPodsWithCsiContainer), podsReady, len(pods.Items))
+				return nil, true, fmt.Errorf("failed to validate CSI containers in PX Api pods [portworx-api]: expected %d, got %d, %d/%d Ready pods", len(pods.Items), len(pxPodsWithCsiContainer), podsReady, len(pods.Items))
 			}
 		} else {
 			if len(pxPodsWithCsiContainer) > 0 || len(pods.Items) != podsReady {
-				return nil, true, fmt.Errorf("failed to validate CSI container in PX pods Api: expected: 0, got %d, %d/%d Ready pods", len(pxPodsWithCsiContainer), podsReady, len(pods.Items))
+				return nil, true, fmt.Errorf("failed to validate CSI container in PX Api pods [portworx-api]: expected: 0, got %d, %d/%d Ready pods", len(pxPodsWithCsiContainer), podsReady, len(pods.Items))
 			}
 		}
 		return nil, false, nil
@@ -2629,11 +2629,11 @@ func validateCsiContainerInPxPods(namespace string, csi bool, timeout, interval 
 
 		if csi {
 			if len(pxPodsWithCsiContainer) != len(pods.Items) {
-				return nil, true, fmt.Errorf("failed to validate CSI containers in PX pods: expected %d, got %d, %d/%d Ready pods", len(pods.Items), len(pxPodsWithCsiContainer), podsReady, len(pods.Items))
+				return nil, true, fmt.Errorf("failed to validate CSI containers in PX pods [portworx]: expected %d, got %d, %d/%d Ready pods", len(pods.Items), len(pxPodsWithCsiContainer), podsReady, len(pods.Items))
 			}
 		} else {
 			if len(pxPodsWithCsiContainer) > 0 || len(pods.Items) != podsReady {
-				return nil, true, fmt.Errorf("failed to validate CSI container in PX pods: expected: 0, got %d, %d/%d Ready pods", len(pxPodsWithCsiContainer), podsReady, len(pods.Items))
+				return nil, true, fmt.Errorf("failed to validate CSI container in PX pods: expected [portworx]: 0, got %d, %d/%d Ready pods", len(pxPodsWithCsiContainer), podsReady, len(pods.Items))
 			}
 		}
 		return nil, false, nil


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Fixes incorrect validation for csi-node-driver-registrar inside portworx-api pods instead of oci-mon pods for older operators. PR-1334 is breaking automation as the changes made in the integration tests do not apply to older versions of operator. Hence temporarily the test has been changed to validate  csi-node-driver-registrar inside portworx-api pods only for master version - 99.9.9. This operator version needs to be modified when the fix in PR-1334 is to be released.

**Which issue(s) this PR fixes** (optional)
Closes # PTX-21234

