### PR TITLE
PWX-31340: Add capability to handle fatal pre-flight error which will…

### DIFF
--- a/deploy/crds/core_v1_storagenode_crd.yaml
+++ b/deploy/crds/core_v1_storagenode_crd.yaml
@@ -148,6 +148,9 @@ spec:
                     success:
                       type: boolean
                       description: If true, the check was successful
+                    result:
+                      type: string
+                      description: Result of the success or failure of the check
               geography:
                 type: object
                 description: Contains topology information for the storage node.

--- a/deploy/crds/core_v1_storagenode_crd.yaml
+++ b/deploy/crds/core_v1_storagenode_crd.yaml
@@ -150,7 +150,7 @@ spec:
                       description: If true, the check was successful
                     result:
                       type: string
-                      description: Result of the check: fatal, warning, success
+                      description: Result of the check fatal, warning, success
               geography:
                 type: object
                 description: Contains topology information for the storage node.

--- a/deploy/crds/core_v1_storagenode_crd.yaml
+++ b/deploy/crds/core_v1_storagenode_crd.yaml
@@ -150,7 +150,7 @@ spec:
                       description: If true, the check was successful
                     result:
                       type: string
-                      description: Result of the success or failure of the check
+                      description: Result of the check: fatal, warning, success
               geography:
                 type: object
                 description: Contains topology information for the storage node.

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -496,7 +496,7 @@ func TestValidateCheckFatal(t *testing.T) {
 	require.Len(t, recorder.Events, 4)
 	<-recorder.Events // Pop first event which is Default telemetry enabled event
 	require.Contains(t, <-recorder.Events,
-		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedPreFlight, "usage pre-flight check failed"))
+		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedPreFlight, "usage pre-flight check"))
 	require.Contains(t, <-recorder.Events,
 		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedPreFlight, "fatal: PX-StoreV2 unsupported storage disk spec"))
 	require.Contains(t, <-recorder.Events,

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -385,7 +385,7 @@ func TestValidateCheckFailure(t *testing.T) {
 	require.Len(t, recorder.Events, 3)
 	<-recorder.Events // Pop first event which is Default telemetry enabled event
 	require.Contains(t, <-recorder.Events,
-		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedPreFlight, "usage pre-flight check failed"))
+		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedPreFlight, "usage pre-flight check"))
 	require.Contains(t, <-recorder.Events,
 		fmt.Sprintf("%v %v %s", v1.EventTypeNormal, util.PassPreFlight, "Not enabling PX-StoreV2"))
 }

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -370,6 +370,119 @@ func TestValidateCheckFailure(t *testing.T) {
 		fmt.Sprintf("%v %v %s", v1.EventTypeNormal, util.PassPreFlight, "Not enabling PX-StoreV2"))
 }
 
+func TestValidateCheckFatal(t *testing.T) {
+	driver := portworx{}
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPreflightCheck: "true",
+			},
+		},
+	}
+
+	labels := map[string]string{
+		"name": pxPreFlightDaemonSetName,
+	}
+
+	clusterRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	preflightDS := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            pxPreFlightDaemonSetName,
+			Namespace:       cluster.Namespace,
+			Labels:          labels,
+			UID:             types.UID("preflight-ds-uid"),
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
+
+	checks := []corev1.CheckResult{
+		{
+			Type:    "usage",
+			Reason:  "fatal: PX-StoreV2 unsupported storage disk spec: unsupported cloud spec drive type found type=io2,size=100,iops=4000, only support [\"gp3\" \"io1\"]",
+			Success: false,
+			Result:  "fatal",
+		},
+		{
+			Type:    "usage",
+			Reason:  "px-runc: PX-StoreV2 unsupported storage disk spec: 'consume unused' (-A/-a) options not valid with PX-StoreV2",
+			Success: false,
+		},
+		{
+			Type:    "status",
+			Reason:  "oci-mon: pre-flight completed",
+			Success: true,
+		},
+	}
+
+	status := corev1.NodeStatus{
+		Checks: checks,
+	}
+
+	storageNode := &corev1.StorageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "node-1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Status: status,
+	}
+
+	preFlightPod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "preflight-1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{UID: preflightDS.UID}},
+		},
+		Status: v1.PodStatus{
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:  "portworx",
+					Ready: true,
+				},
+			},
+		},
+	}
+
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	k8sClient := testutil.FakeK8sClient(preflightDS)
+
+	err := k8sClient.Create(context.TODO(), preFlightPod1)
+	require.NoError(t, err)
+
+	preflightDS.Status.DesiredNumberScheduled = int32(1)
+	err = k8sClient.Status().Update(context.TODO(), preflightDS)
+	require.NoError(t, err)
+
+	recorder := record.NewFakeRecorder(100)
+	err = driver.Init(k8sClient, runtime.NewScheme(), recorder)
+	require.NoError(t, err)
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	err = k8sClient.Create(context.TODO(), storageNode)
+	require.NoError(t, err)
+
+	err = driver.Validate(cluster)
+	require.Error(t, err)
+	require.NotEmpty(t, recorder.Events)
+	require.Len(t, recorder.Events, 4)
+	<-recorder.Events // Pop first event which is Default telemetry enabled event
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedPreFlight, "usage pre-flight check failed"))
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedPreFlight, "fatal: PX-StoreV2 unsupported storage disk spec"))
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedPreFlight, "PX-StoreV2 pre-check failed"))
+}
+
 func TestValidateMissingRequiredCheck(t *testing.T) {
 	driver := portworx{}
 	cluster := &corev1.StorageCluster{

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -364,7 +364,10 @@ func (u *preFlightPortworx) processNodesChecks(recorder record.EventRecorder, st
 			passed = false // pre-flight status check failed, keep going for logging
 
 			if check.Result == "fatal" {
-				// collect fatal msgs for output at end.
+				// This loop processes check results looking for any failures. However there
+				// is a difference between a failure and "fatal" failure.  So collect all
+				// fatal msgs so they can be outputted all at once instead of being intermixed
+				// with other failed events.
 				fmsgs = append(fmsgs, check.Reason)
 				isFatal = true
 				continue
@@ -380,7 +383,8 @@ func (u *preFlightPortworx) processNodesChecks(recorder record.EventRecorder, st
 		}
 	}
 
-	if isFatal { // Add events for fatal checks
+	if isFatal {
+		// Output all the "fatal" events collected above.  So they are not intermixed with other failed events.
 		for _, fmsg := range fmsgs {
 			k8sutil.WarningEvent(recorder, u.cluster, util.FailedPreFlight, fmsg)
 		}

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -46,6 +46,8 @@ const (
 	DefCmetaGKE = "type=pd-ssd,size=64"
 	// preFlightOutputLog log location for pre-flight output
 	preFlightOutputLog = "/var/cores/px-pre-flight-output.log"
+	// Fatal result string from pre-flight check
+	Fatal = "fatal"
 )
 
 // PreFlightPortworx provides a set of APIs to uninstall portworx
@@ -354,7 +356,7 @@ func (u *preFlightPortworx) processNodesChecks(recorder record.EventRecorder, st
 				continue
 			}
 
-			msg := fmt.Sprintf("%s pre-flight check ", check.Type)
+			msg := fmt.Sprintf("%s pre-flight check: ", check.Type)
 			if check.Success {
 				msg = msg + "passed: " + check.Reason
 				k8sutil.InfoEvent(recorder, u.cluster, util.PassPreFlight, msg)
@@ -363,7 +365,7 @@ func (u *preFlightPortworx) processNodesChecks(recorder record.EventRecorder, st
 
 			passed = false // pre-flight status check failed, keep going for logging
 
-			if check.Result == "fatal" {
+			if check.Result == Fatal {
 				// This loop processes check results looking for any failures. However there
 				// is a difference between a failure and "fatal" failure.  So collect all
 				// fatal msgs so they can be outputted all at once instead of being intermixed
@@ -373,7 +375,7 @@ func (u *preFlightPortworx) processNodesChecks(recorder record.EventRecorder, st
 				continue
 			}
 
-			msg = msg + "failed: " + check.Reason
+			msg = msg + check.Reason
 			k8sutil.WarningEvent(recorder, u.cluster, util.FailedPreFlight, msg)
 		}
 

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -361,6 +361,8 @@ func (u *preFlightPortworx) processNodesChecks(recorder record.EventRecorder, st
 				continue
 			}
 
+			passed = false // pre-flight status check failed, keep going for logging
+
 			if check.Result == "fatal" {
 				// collect fatal msgs for output at end.
 				fmsgs = append(fmsgs, check.Reason)
@@ -370,7 +372,6 @@ func (u *preFlightPortworx) processNodesChecks(recorder record.EventRecorder, st
 
 			msg = msg + "failed: " + check.Reason
 			k8sutil.WarningEvent(recorder, u.cluster, util.FailedPreFlight, msg)
-			passed = false // pre-flight status check failed, keep going for logging
 		}
 
 		if !statusExists {

--- a/pkg/apis/core/v1/storagenode.go
+++ b/pkg/apis/core/v1/storagenode.go
@@ -100,6 +100,8 @@ type CheckResult struct {
 	Reason string `json:"reason,omitempty"`
 	// Success indicates if the check was successful or failed
 	Success bool `json:"success,omitempty"`
+	// Result of the success or failure
+	Result string `json:"result,omitempty"`
 }
 
 // NetworkStatus network status of the storage node


### PR DESCRIPTION
… prevent PX startup.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
For AWS io2 disk are not supported for dmthin or btrfs.    Usually operator will start PX with btrfs if any pre-flight check fails.  However if a "fatal" result is returned operator will not start PX.  

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-31340
**Special notes for your reviewer**:
This PX PR handles the 'io2' fatal error returned:  https://github.com/portworx/porx/pull/12663 and we need to vendor in APIs into px-installer after this merge is made.
