### PR TITLE
PWX-32111: Disable security when running pre-flight.

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -127,7 +127,9 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 		util.UpdateStorageClusterCondition(cluster, condition)
 	}
 
-	podSpec, err := p.GetStoragePodSpec(cluster, "")
+	preFltCluster := GetPreFlightStorageCluster(cluster)
+
+	podSpec, err := p.GetStoragePodSpec(preFltCluster, "")
 	if err != nil {
 		err = fmt.Errorf("pre-flight: get storage pod spec: %v", err)
 		setClusterCondition(corev1.ClusterConditionStatusFailed, err.Error())

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -89,6 +89,26 @@ func TestInit(t *testing.T) {
 	require.Equal(t, k8sClient, driver.k8sClient)
 }
 
+func TestValidatePreFlightDisableSecurity(t *testing.T) {
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPreflightCheck: "true",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+			},
+		},
+	}
+
+	preflightStorageCluster := GetPreFlightStorageCluster(cluster)
+	require.Nil(t, preflightStorageCluster.Spec.Security)
+}
+
 func TestValidate(t *testing.T) {
 	driver := portworx{}
 	cluster := &corev1.StorageCluster{

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -76,6 +76,18 @@ type preFlightPortworx struct {
 // Existing dmThin strings
 var dmthinRegex = regexp.MustCompile("(?i)(PX-StoreV2|px-store-v2)")
 
+func GetPreFlightStorageCluster(cluster *corev1.StorageCluster) *corev1.StorageCluster {
+	// Creates a copy of the existing storage cluster which can be  modified to enable/disable
+	// capability for pre-flght pod without affecting original storage cluster
+	preFlightCluster := cluster.DeepCopy()
+
+	if pxutil.AuthEnabled(&preFlightCluster.Spec) { // Disable  security if its enabled
+		preFlightCluster.Spec.Security = nil
+	}
+
+	return preFlightCluster
+}
+
 // NewPreFlighter returns an implementation of PreFlightPortworx interface
 func NewPreFlighter(
 	cluster *corev1.StorageCluster,


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Secrets are not setup when pre-flight is run so if security is enabled disable it for pre-flight pod so pre-flight checks can be run.   
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-32111
**Special notes for your reviewer**:
Tested by enabling security on my k8s cluster and pre-flight ran fine.   Will retest on Rohits setup before merging in.  