### PR TITLE
PWX-35203 : Disable dmthin preflight check for all environments excep…

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -140,6 +140,11 @@ func (p *portworx) Validate(cluster *corev1.StorageCluster) error {
 		}
 	}
 
+	if !pxutil.IsEKS(cluster) {
+		logrus.Warnf("pre-flight is not enabled on this environment")
+		return nil
+	}
+
 	check, ok := cluster.Annotations[pxutil.AnnotationPreflightCheck]
 	check = strings.TrimSpace(strings.ToLower(check))
 	if !ok || check == "skip" {

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -92,6 +92,7 @@ func TestValidate(t *testing.T) {
 			Namespace: "kube-test",
 			Annotations: map[string]string{
 				pxutil.AnnotationPreflightCheck: "true",
+				pxutil.AnnotationIsEKS:          "true",
 			},
 		},
 	}
@@ -256,7 +257,8 @@ func TestValidate(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestValidateVsphere(t *testing.T) {
+// disabled preflight for all environments except EKS in 23.10.2
+/*func TestValidateVsphere(t *testing.T) {
 	driver := portworx{}
 	cluster := &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -358,7 +360,7 @@ func TestValidateVsphere(t *testing.T) {
 	require.Contains(t, <-recorder.Events,
 		fmt.Sprintf("%v %v %s", v1.EventTypeNormal, util.PassPreFlight, "Enabling PX-StoreV2"))
 	require.Contains(t, *cluster.Spec.CloudStorage.SystemMdDeviceSpec, DefCmetaVsphere)
-}
+}*/
 
 func TestValidateCheckFailure(t *testing.T) {
 	driver := portworx{}
@@ -368,6 +370,7 @@ func TestValidateCheckFailure(t *testing.T) {
 			Namespace: "kube-test",
 			Annotations: map[string]string{
 				pxutil.AnnotationPreflightCheck: "true",
+				pxutil.AnnotationIsEKS:          "true",
 			},
 		},
 	}
@@ -473,6 +476,7 @@ func TestValidateMissingRequiredCheck(t *testing.T) {
 			Namespace: "kube-test",
 			Annotations: map[string]string{
 				pxutil.AnnotationPreflightCheck: "true",
+				pxutil.AnnotationIsEKS:          "true",
 			},
 		},
 	}


### PR DESCRIPTION


**What this PR does / why we need it**:  Due to limitations with the dmthin backend in PX on vsphere and Azure environments, we want to refrain from running dmthin in these environments. Previously we enabled the dmthin preflight checks on these environments. These preflight checks on success enable dmthin backend in portworx. We need to stop running the preflight checks on these environments. That way dmthin won’t get auto-enabled.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-35203

**Special notes for your reviewer**:
Tested based on UTs