### PR TITLE
PWX-35203 : Disable dmthin preflight check for all environments excep…

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -308,29 +308,34 @@ func (p *portworx) preflightShouldRun(toUpdate *corev1.StorageCluster) bool {
 		return check == "true"
 	}
 
-	if !preflight.RequiresCheck() { // Preflight is only supported on AWS, VSPHERE & Pure
+	/*if !preflight.RequiresCheck() { // Preflight is only supported on AWS, VSPHERE & Pure
 		return false
 	}
+	*/
 
+	// PWX-35203 : Preflight should run only on AWS
 	if preflight.IsAWS() { // Preflight runs on AWS & PX 3.0.0 or above
 		return true
 	}
 
-	pxVer31, _ := version.NewVersion("3.1")
-	if clusterPXver.GreaterThanOrEqual(pxVer31) { // PX version is 3.1.0 or above
-		if pxutil.IsVsphere(toUpdate) {
-			if preflight.IsPKS() { // Don't run preflight on Vsphere w/PKS
-				return false
-			}
+	// disable Preflight for all environments other than AWS
+	/*
+		pxVer31, _ := version.NewVersion("3.1")
+		if clusterPXver.GreaterThanOrEqual(pxVer31) { // PX version is 3.1.0 or above
+			if pxutil.IsVsphere(toUpdate) {
+				if preflight.IsPKS() { // Don't run preflight on Vsphere w/PKS
+					return false
+				}
 
-			envValue, exists := pxutil.GetClusterEnvValue(toUpdate, "VSPHERE_INSTALL_MODE")
-			if exists && envValue == pxutil.VsphereInstallModeLocal { // Don't run preflight on Vsphere w/local install mode
-				return false
-			}
+				envValue, exists := pxutil.GetClusterEnvValue(toUpdate, "VSPHERE_INSTALL_MODE")
+				if exists && envValue == pxutil.VsphereInstallModeLocal { // Don't run preflight on Vsphere w/local install mode
+					return false
+				}
 
-			return true // Preflight runs on Vsphere & PX 3.1.0 or above
+				return true // Preflight runs on Vsphere & PX 3.1.0 or above
+			}
 		}
-	}
+	*/
 
 	return false // All else disable
 }

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -646,8 +646,8 @@ func TestShouldPreflightRun(t *testing.T) {
 	require.NoError(t, err)
 
 	setPortworxStorageSpecDefaults(cluster)
-	require.True(t, driver.preflightShouldRun(cluster))
-	logrus.Infof("vshpere cloud w/PX >= 3.1, preflight will run")
+	require.False(t, driver.preflightShouldRun(cluster))
+	logrus.Infof("vshpere cloud w/PX >= 3.1, preflight will not run")
 
 	// TestCase: Vsphere cloud provider with Install mode 'local'
 	logrus.Infof("check vsphere cloud w/local install mode...")


### PR DESCRIPTION
What this PR does / why we need it: Due to limitations with the dmthin backend in PX on vsphere and Azure environments, we want to refrain from running dmthin in these environments. Previously we enabled the dmthin preflight checks on these environments. These preflight checks on success enable dmthin backend in portworx. We need to stop running the preflight checks on these environments. That way dmthin won’t get auto-enabled.

Which issue(s) this PR fixes (optional)
Closes # https://portworx.atlassian.net/browse/PWX-35203

Special notes for your reviewer:
Tested based on UTs