### PR TITLE
PWX-35173: Move the deleting of portworx-api pod for re registering csi driver from update stc logic to create px-pod logic

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	// DefaultCordonedRestartDelay initial duration for which the operator should not try
 	// to restart pods after the node is cordoned
-	DefaultCordonedRestartDelay = 5 * time.Second
+	DefaultCordonedRestartDelay = 5 * time.Minute
 	// MaxCordonedRestartDelay maximum duration for which the operator should not try
 	// to restart pods after the node is cordoned
 	MaxCordonedRestartDelay = 15 * time.Minute

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -4103,11 +4103,10 @@ func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 	// validate revision 1 and revision 2 exist
 	require.ElementsMatch(t, []int64{1, 2}, []int64{revisions.Items[0].Revision, revisions.Items[1].Revision})
 	// The old pod should be marked for deletion
-	// Since version of portworx is greater than 2.13, portworx-api pods are also deleted to register csi nodes.
 	require.Empty(t, podControl.Templates)
 	require.Empty(t, podControl.ControllerRefs)
-	require.Len(t, podControl.DeletePodName, 2)
-	require.ElementsMatch(t, []string{oldPod.Name, pxApiPodName}, podControl.DeletePodName)
+	require.Len(t, podControl.DeletePodName, 1)
+	require.Equal(t, []string{oldPod.Name}, podControl.DeletePodName)
 
 	// Test case: Running reconcile again should start a new pod with new
 	// revision hash.
@@ -4121,13 +4120,16 @@ func TestUpdateStorageClusterWithRollingUpdateStrategy(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, result)
 
+	// Newer px pods are created
+	// Since version of portworx is greater than 2.13, portworx-api pods are deleted to re-register csi nodes driver
+	require.Len(t, podControl.DeletePodName, 1)
+	require.Equal(t, []string{pxApiPodName}, podControl.DeletePodName)
+
 	// New revision should not be created as the cluster spec is unchanged
 	revisions = &appsv1.ControllerRevisionList{}
 	err = testutil.List(k8sClient, revisions)
 	require.NoError(t, err)
 	require.Len(t, revisions.Items, 2)
-
-	require.Empty(t, podControl.DeletePodName)
 
 	require.Len(t, podControl.ControllerRefs, 1)
 	require.Equal(t, *clusterRef, podControl.ControllerRefs[0])


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Before in ticket - PWX-34360, the csi-node-driver-registrar container was moved from px pods deployment to px-api daemonset. Change was also made such that every time stc was updated, the px-api pod of the corresponding px pod node will also be deleted. This was done so that csi driver will be reregistered. The deletion of px-api pods in update stc logic had a flaw as mentioned in ticket PWX-35173. This PR moves the deletion of px-api pods to happen during the creation of the px-pods. This will take care of edge cases.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-35173

**Testing notes**:
a) During update of storage cluster
     1) Storage cluster and older version of operator are running
     2) Update the operator version to one with this change
     3) portworx-api daemonset gets updated and px-api pods have 2 containers
     4) Update storage cluster
     5) As each px pod gets deleted and created, only 1 container comes up in it. Its corresponding px-api pod also gets deleted and comes up. This is done to re-register csi driver

b) When individual px pods are deleted 
     1) Storage cluster and older version of operator are running
     2) Update operator version to one with change
     3) Cluster is not updated, but individual pods are deleted - manually or due to any reason
     4) When the pod comes up again, its corresponding px-api pod gets deleted and comes up again.
          The storage pod that was deleted only has 1 container and px-api pod has 2 containers

