### PR TITLE
[master] PWX-35203 : Disable dmthin preflight check for all environments except eks

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -487,40 +487,9 @@ func (p *portworx) preflightShouldRun(toUpdate *corev1.StorageCluster) bool {
 		return check == "true"
 	}
 
-	if !preflight.RequiresCheck() { // Preflight is only supported on GKE, AWS, VSPHERE & Pure
-		return false
-	}
-
-	if preflight.IsAWS() { // Preflight runs on AWS & PX 3.0.0 or above
+	// PWX-35203 : disable Preflight for all environments other than AWS
+	if preflight.IsEKS() { // Preflight runs on EKS & PX 3.0.0 or above
 		return true
-	}
-
-	pxVer31, _ := version.NewVersion("3.1")
-	if clusterPXver.GreaterThanOrEqual(pxVer31) { // PX version is 3.1.0 or above
-		if pxutil.IsPure(toUpdate) { // Preflight runs on Pure & PX 3.1.0 or above
-			return true
-		}
-
-		if preflight.IsAzure() { // Preflight runs on Azure & PX 3.1.0 or above
-			return true
-		}
-
-		if preflight.IsGKE() {
-			return true
-		}
-
-		if pxutil.IsVsphere(toUpdate) {
-			if preflight.IsPKS() { // Don't run preflight on Vsphere w/PKS
-				return false
-			}
-
-			envValue, exists := pxutil.GetClusterEnvValue(toUpdate, "VSPHERE_INSTALL_MODE")
-			if exists && envValue == pxutil.VsphereInstallModeLocal { // Don't run preflight on Vsphere w/local install mode
-				return false
-			}
-
-			return true // Preflight runs on Vsphere & PX 3.1.0 or above
-		}
 	}
 
 	return false // All else disable


### PR DESCRIPTION
Changes to master for PR https://github.com/libopenstorage/operator/pull/1361

What this PR does / why we need it: Due to limitations with the dmthin backend in PX on vsphere and Azure environments, we want to refrain from running dmthin in these environments. Previously we enabled the dmthin preflight checks on these environments. These preflight checks on success enable dmthin backend in portworx. We need to stop running the preflight checks on these environments. That way dmthin won’t get auto-enabled.

Which issue(s) this PR fixes (optional)
Closes # https://portworx.atlassian.net/browse/PWX-35203

Special notes for your reviewer:
Tested based on UTs

