### PR TITLE
PWX-35255: add AR finalizers to clusterrole for autopilot on OCP

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -122,7 +122,7 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 	if err := c.createServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createClusterRole(cluster); err != nil {
+	if err := c.createClusterRole(); err != nil {
 		return err
 	}
 	if err := c.createClusterRoleBinding(cluster.Namespace); err != nil {
@@ -263,7 +263,7 @@ func (c *autopilot) createServiceAccount(
 	)
 }
 
-func (c *autopilot) createClusterRole(cluster *corev1.StorageCluster) error {
+func (c *autopilot) createClusterRole() error {
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"", "events.k8s.io"},
@@ -292,7 +292,7 @@ func (c *autopilot) createClusterRole(cluster *corev1.StorageCluster) error {
 		},
 		{
 			APIGroups: []string{"autopilot.libopenstorage.org"},
-			Resources: []string{"actionapprovals", "autopilotrules", "autopilotruleobjects"},
+			Resources: []string{"actionapprovals", "autopilotrules", "autopilotruleobjects", "autopilotrules/finalizers"},
 			Verbs:     []string{"*"},
 		},
 		{
@@ -313,14 +313,6 @@ func (c *autopilot) createClusterRole(cluster *corev1.StorageCluster) error {
 			Resources:     []string{"podsecuritypolicies"},
 			ResourceNames: []string{constants.RestrictedPSPName},
 			Verbs:         []string{"use"},
-		},
-		)
-	}
-	if pxutil.IsOpenshift(cluster) {
-		rules = append(rules, rbacv1.PolicyRule{
-			APIGroups: []string{"autopilot.libopenstorage.org"},
-			Resources: []string{"autopilotrules/finalizers"},
-			Verbs:     []string{"update"},
 		},
 		)
 	}

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -122,7 +122,7 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 	if err := c.createServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
-	if err := c.createClusterRole(); err != nil {
+	if err := c.createClusterRole(cluster); err != nil {
 		return err
 	}
 	if err := c.createClusterRoleBinding(cluster.Namespace); err != nil {
@@ -263,7 +263,7 @@ func (c *autopilot) createServiceAccount(
 	)
 }
 
-func (c *autopilot) createClusterRole() error {
+func (c *autopilot) createClusterRole(cluster *corev1.StorageCluster) error {
 	rules := []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{"", "events.k8s.io"},
@@ -313,6 +313,14 @@ func (c *autopilot) createClusterRole() error {
 			Resources:     []string{"podsecuritypolicies"},
 			ResourceNames: []string{constants.RestrictedPSPName},
 			Verbs:         []string{"use"},
+		},
+		)
+	}
+	if pxutil.IsOpenshift(cluster) {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{"autopilot.libopenstorage.org"},
+			Resources: []string{"autopilotrules/finalizers"},
+			Verbs:     []string{"update"},
 		},
 		)
 	}

--- a/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
@@ -19,7 +19,7 @@ rules:
     resources: ["configmaps"]
     verbs: ["get", "list", "patch", "update", "watch"]
   - apiGroups: ["autopilot.libopenstorage.org"]
-    resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects"]
+    resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects", "autopilotrules/finalizers"]
     verbs: ["*"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]

--- a/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
@@ -19,7 +19,7 @@ rules:
     resources: ["configmaps"]
     verbs: ["get", "list", "patch", "update", "watch"]
   - apiGroups: ["autopilot.libopenstorage.org"]
-    resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects"]
+    resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects", "autopilotrules/finalizers"]
     verbs: ["*"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Currently autopilot fails to generate AROs on OCP due to the lack of update permission of AR finalizer in its own clusterrole definition. Solution is to add such when the cluster is found to be on OCP. 

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
After manually editing autopilot clusterrole to add "update" on "autopilotrules/finalizers", the error message of "_failed to insert watcher event due to: autopilotruleobjects.autopilot.libopenstorage.org \"pvc-e836c495-0eab-4a63-b9e8-1aa4481bee37-volume-resize\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>" file="statehandlers.go:696_" is gone and ARO shows up correctly

`[root@users-ezhang-ezhang-k8s-1-4-3 PWX-35255]# kubectl get aro -A`
`NAMESPACE   NAME                                                     AGE`
`test        pvc-435108c1-effa-4213-8d75-be4735fb8aaa-volume-resize   28s`
`test        pvc-a5cd77a2-545f-44dc-84dc-e9a229398c12-volume-resize   28s`
