### PR TITLE
PWX-35004 : Operator reconciles and removes image param specified in the STC

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1688,7 +1688,7 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		// NOTE: race condition can happen when updating status right after spec,
 		// revision got from live cluster can become stale, so ignoring the error in syncStorageCluster
 		cluster.Status = *toUpdate.Status.DeepCopy()
-		if err := k8s.UpdateStorageClusterStatus(c.client, cluster); err != nil {
+		if err := k8s.UpdateStorageClusterStatusWithRetries(c.client, cluster); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1688,7 +1688,7 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		// NOTE: race condition can happen when updating status right after spec,
 		// revision got from live cluster can become stale, so ignoring the error in syncStorageCluster
 		cluster.Status = *toUpdate.Status.DeepCopy()
-		if err := k8s.UpdateStorageClusterStatusWithRetries(c.client, cluster); err != nil {
+		if err := k8s.UpdateStorageClusterStatusWithRetries(c.client, cluster, 5, 2*time.Second); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1685,8 +1685,7 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 			return err
 		}
 
-		fmt.Println(" cluster resource version before :: ", cluster.ResourceVersion)
-
+		// NOTE: race condition can happen when updating status right after spec,
 		cluster.Status = *toUpdate.Status.DeepCopy()
 		if err := k8s.UpdateStorageClusterStatus(c.client, cluster); err != nil {
 			logrus.Errorf("error updating status for %s/%s trying again...", cluster.Namespace, cluster.Name)

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1269,6 +1269,8 @@ func UpdateStorageClusterStatus(
 		return err
 	}
 
+	fmt.Println(" cluster resource version after :: ", cluster.ResourceVersion)
+
 	cluster.ResourceVersion = existingCluster.ResourceVersion
 	if !reflect.DeepEqual(cluster.Status, existingCluster.Status) {
 		err := k8sClient.Status().Update(context.TODO(), cluster)

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -3,6 +3,12 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"os"
+	"path"
+	"reflect"
+	"regexp"
+	"strconv"
+
 	"github.com/hashicorp/go-version"
 	consolev1 "github.com/openshift/api/console/v1"
 	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
@@ -25,12 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"path"
-	"reflect"
-	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/constants"

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1284,6 +1284,8 @@ func UpdateStorageClusterStatus(
 func UpdateStorageClusterStatusWithRetries(
 	k8sClient client.Client,
 	cluster *corev1.StorageCluster,
+	maxRetries int,
+	retryInterval time.Duration,
 ) error {
 	existingCluster := &corev1.StorageCluster{}
 	if err := k8sClient.Get(
@@ -1297,9 +1299,6 @@ func UpdateStorageClusterStatusWithRetries(
 		logrus.WithError(err).Errorf("error getting %s/%s", cluster.Namespace, cluster.Name)
 		return err
 	}
-
-	maxRetries := 2
-	retryInterval := 5 * time.Second
 
 	cluster.ResourceVersion = existingCluster.ResourceVersion
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: The attempt to update which is throwing error initially while updating the status, because of this error, we see difference in cluster.Spec.version  and cluster.status.version as cluster’s status is not updated. The changes include retrying again in case of status update failure.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-35004

**Special notes for your reviewer**: Verified while installing portworx, operator tries to update status again and autopilot image is not reset to empty.

