### PR TITLE
PWX-35255: add AR finalizers to clusterrole for autopilot on OCP (#1368)

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -253,7 +253,7 @@ func (c *autopilot) createClusterRole() error {
 		},
 		{
 			APIGroups: []string{"autopilot.libopenstorage.org"},
-			Resources: []string{"actionapprovals", "autopilotrules", "autopilotruleobjects"},
+			Resources: []string{"actionapprovals", "autopilotrules", "autopilotruleobjects", "autopilotrules/finalizers"},
 			Verbs:     []string{"*"},
 		},
 		{

--- a/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole.yaml
@@ -19,7 +19,7 @@ rules:
     resources: ["configmaps"]
     verbs: ["get", "list", "patch", "update", "watch"]
   - apiGroups: ["autopilot.libopenstorage.org"]
-    resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects"]
+    resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects", "autopilotrules/finalizers"]
     verbs: ["*"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]

--- a/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
+++ b/drivers/storage/portworx/testspec/autopilotClusterRole_k8s_1.24.yaml
@@ -19,7 +19,7 @@ rules:
     resources: ["configmaps"]
     verbs: ["get", "list", "patch", "update", "watch"]
   - apiGroups: ["autopilot.libopenstorage.org"]
-    resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects"]
+    resources: ["actionapprovals", "autopilotrules", "autopilotruleobjects", "autopilotrules/finalizers"]
     verbs: ["*"]
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]


### PR DESCRIPTION
* add autopilotrule finalizers permission to cluster role for all platform deployment

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
cherry-pick from [merged PR](https://github.com/libopenstorage/operator/pull/1368) in master

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

