### PR TITLE
PWX-34916: changed the default log level for autopilot from debug to …

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -371,7 +371,7 @@ func (c *autopilot) createDeployment(
 
 	args := map[string]string{
 		"config":    "/etc/config/config.yaml",
-		"log-level": "debug",
+		"log-level": "info",
 	}
 	for k, v := range cluster.Spec.Autopilot.Args {
 		if _, exists := autopilotConfigParams[k]; exists {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3043,7 +3043,7 @@ func TestAutopilotInstall(t *testing.T) {
 				},
 				Args: map[string]string{
 					"min_poll_interval": "4",
-					"log-level":         "debug",
+					"log-level":         "info",
 				},
 			},
 			Security: &corev1.SecuritySpec{
@@ -3365,7 +3365,7 @@ func TestAutopilotArgumentsChange(t *testing.T) {
 	)
 	require.Contains(t,
 		autopilotDeployment.Spec.Template.Spec.Containers[0].Command,
-		"--log-level=debug",
+		"--log-level=info",
 	)
 
 	// Overwrite existing argument with new value

--- a/drivers/storage/portworx/testspec/autopilotDeployment.yaml
+++ b/drivers/storage/portworx/testspec/autopilotDeployment.yaml
@@ -37,7 +37,7 @@ spec:
       - command:
         - /autopilot
         - --config=/etc/config/config.yaml
-        - --log-level=debug
+        - --log-level=info
         imagePullPolicy: Always
         image: docker.io/portworx/autopilot:1.1.1
         resources:


### PR DESCRIPTION
…info (#1324)

* changed the default log level for autopilot from debug to info

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
cherry-pick change from approved master [PR](https://github.com/libopenstorage/operator/pull/1324)

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

