### PR TITLE
PWX-35282: Do not restart portworx pod for 5m when the node is cordoned

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,7 +5,7 @@ import "time"
 const (
 	// DefaultCordonedRestartDelay initial duration for which the operator should not try
 	// to restart pods after the node is cordoned
-	DefaultCordonedRestartDelay = 5 * time.Second
+	DefaultCordonedRestartDelay = 5 * time.Minute
 	// MaxCordonedRestartDelay maximum duration for which the operator should not try
 	// to restart pods after the node is cordoned
 	MaxCordonedRestartDelay = 15 * time.Minute


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: During a Kubernetes node upgrade, the node is cordoned and drained of all pods. The operator uses an exponential backoff strategy, delaying the restart of the PX pod by 5s initially, and then increasing the delay with each deletion during the drain process. This approach ensures proper draining of applications using PX volumes, particularly CSI applications relying on the node's registration as a CSI node. After change in ticket PWX-34360, CSI node registrar container becomes a part of the portworx-api pod instead of Portworx pod. So portworx pod can be down.

This change increases the default restart delay of the portworx pod in a cordoned node to 5 minutes against the previous value of 5 seconds. Exponential backoff logic is continued with the maximum value staying the same 15 minutes.

**Which issue(s) this PR fixes** 
Closes # PWX-35282

**Testing notes**: Tested the change in an Anthos 3 node cluster. 1 node was cordoned and drained. portworx on that pod did not come up for 5 minutes as the node was still cordoned.  When the pod came up after 5 minutes, it was again deleted and now the pod only came up after 10 minutes. Its next restart value was set to 15 minutes.

