### PR TITLE
PWX-35007, PWX-35008: kube-scheduler image updates

### DIFF
--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -303,11 +303,7 @@ func (c *pvcController) createDeployment(
 		return err
 	}
 
-	imageName := "gcr.io/google_containers/kube-controller-manager-amd64"
-	if k8sutil.IsNewKubernetesRegistry(&c.k8sVersion) {
-		imageName = k8sutil.DefaultK8SRegistryPath + "/kube-controller-manager-amd64"
-	}
-	imageName = imageName + ":v" + c.k8sVersion.String()
+	imageName := k8sutil.GetDefaultKubeControllerManagerImage(&c.k8sVersion)
 	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.KubeControllerManager != "" {
 		imageName = cluster.Status.DesiredImages.KubeControllerManager
 	}

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -235,9 +235,6 @@ func fillDefaults(
 	rel *Version,
 	k8sVersion *version.Version,
 ) {
-	if rel.Components.Stork == "" {
-		rel.Components.Stork = defaultStorkImage
-	}
 	if rel.Components.Autopilot == "" {
 		rel.Components.Autopilot = defaultAutopilotImage
 	}
@@ -258,10 +255,38 @@ func fillDefaults(
 	if rel.Components.DynamicPluginProxy == "" {
 		rel.Components.DynamicPluginProxy = DefaultDynamicPluginProxyImage
 	}
+	fillStorkDefaults(rel, k8sVersion)
 	fillCSIDefaults(rel, k8sVersion)
 	fillPrometheusDefaults(rel, k8sVersion)
 	fillGrafanaDefaults(rel, k8sVersion)
 	fillTelemetryDefaults(rel)
+	fillK8sDefaults(rel, k8sVersion)
+}
+
+func fillStorkDefaults(
+	rel *Version,
+	k8sVersion *version.Version,
+) {
+	if rel.Components.Stork == "" {
+		rel.Components.Stork = defaultStorkImage
+	}
+
+	if rel.Components.KubeScheduler == "" {
+		rel.Components.KubeScheduler = k8sutil.GetDefaultKubeSchedulerImage(k8sVersion)
+	}
+}
+
+func fillK8sDefaults(
+	rel *Version,
+	k8sVersion *version.Version,
+) {
+	if rel.Components.KubeControllerManager == "" {
+		rel.Components.KubeControllerManager = k8sutil.GetDefaultKubeControllerManagerImage(k8sVersion)
+	}
+
+	if rel.Components.Pause == "" {
+		rel.Components.Pause = pxutil.ImageNamePause
+	}
 }
 
 func fillCSIDefaults(

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -44,6 +44,9 @@ func TestManifestWithNewerPortworxVersion(t *testing.T) {
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
+			KubeScheduler:             "gcr.io/google_containers/kube-scheduler-amd64:v1.15.0",
+			KubeControllerManager:     "gcr.io/google_containers/kube-controller-manager-amd64:v1.15.0",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -86,6 +89,7 @@ func TestManifestWithNewerPortworxVersionAndConfigMapPresent(t *testing.T) {
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -184,6 +184,7 @@ func TestManifestWithOlderPortworxVersion(t *testing.T) {
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -279,6 +280,9 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
+			KubeScheduler:             "gcr.io/google_containers/kube-scheduler-amd64:v1.15.0",
+			KubeControllerManager:     "gcr.io/google_containers/kube-controller-manager-amd64:v1.15.0",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -406,6 +410,7 @@ func TestManifestWithoutPortworxVersion(t *testing.T) {
 			PxRepo:                    "portworx/px-repo:1.1.0",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.25",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	cluster := &corev1.StorageCluster{

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -598,6 +598,9 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
 			toUpdate.Status.DesiredImages.Stork = release.Components.Stork
+			if toUpdate.Status.DesiredImages.KubeScheduler == "" {
+				toUpdate.Status.DesiredImages.KubeScheduler = release.Components.KubeScheduler
+			}
 		}
 
 		if autoUpdateAutopilot(toUpdate) &&
@@ -717,7 +720,6 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			releaseImage string
 		}{
 			{&toUpdate.Status.DesiredImages.KubeControllerManager, release.Components.KubeControllerManager},
-			{&toUpdate.Status.DesiredImages.KubeScheduler, release.Components.KubeScheduler},
 			{&toUpdate.Status.DesiredImages.Pause, release.Components.Pause},
 		}
 		for _, v := range imagesData {
@@ -736,6 +738,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 
 	if !autoUpdateStork(toUpdate) {
 		toUpdate.Status.DesiredImages.Stork = ""
+		toUpdate.Status.DesiredImages.KubeScheduler = ""
 	}
 
 	if !autoUpdateAutopilot(toUpdate) {

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -104,10 +104,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 
 	require.NoError(t, err)
 
-	k8sMinVersionForKubeSchedulerConfiguration, err := version.NewVersion(minK8sVersionForKubeSchedulerConfiguration)
-	require.NoError(t, err)
-
-	if k8sVersion.GreaterThanOrEqual(k8sMinVersionForKubeSchedulerConfiguration) {
+	if k8sVersion.GreaterThanOrEqual(k8s.MinVersionForKubeSchedulerConfiguration) {
 		// Stork ConfigMap
 		leaderElect := true
 		schedulerName := storkDeploymentName
@@ -313,7 +310,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 	require.Equal(t, expectedStorkDeployment.Spec, storkDeployment.Spec)
 
 	// Sched Scheduler Deployment
-	if k8sVersion.GreaterThanOrEqual(k8sMinVersionForKubeSchedulerConfiguration) {
+	if k8sVersion.GreaterThanOrEqual(k8s.MinVersionForKubeSchedulerConfiguration) {
 		expectedSchedDeployment := testutil.GetExpectedDeployment(t, "storkSchedKubeSchedConfigDeployment.yaml")
 		schedDeployment := &appsv1.Deployment{}
 		err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
@@ -327,7 +324,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 		schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 		require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
 		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
-			expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minK8sVersionForKubeSchedulerConfiguration, k8sVersionStr, -1)
+			expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, k8s.MinVersionForKubeSchedulerConfiguration.String(), k8sVersionStr, -1)
 		require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
 	} else {
 		expectedSchedDeployment := testutil.GetExpectedDeployment(t, "storkSchedDeployment.yaml")
@@ -496,7 +493,7 @@ func TestStorkSchedulerK8SVersions(t *testing.T) {
 	schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 	require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
 	expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
-		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minK8sVersionForKubeSchedulerConfiguration, k8sVersionStr, -1)
+		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, k8s.MinVersionForKubeSchedulerConfiguration.String(), k8sVersionStr, -1)
 	require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
 
 	k8sVersionStr = "1.25.0"
@@ -515,7 +512,7 @@ func TestStorkSchedulerK8SVersions(t *testing.T) {
 	schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 	require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
 	expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
-		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minK8sVersionForKubeSchedulerConfiguration, k8sVersionStr, -1)
+		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, k8s.MinVersionForKubeSchedulerConfiguration.String(), k8sVersionStr, -1)
 	require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
 }
 

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -68,6 +68,8 @@ var (
 	K8sVer1_25, _ = version.NewVersion("1.25")
 	// K8sVer1_26 k8s 1.26
 	K8sVer1_26, _ = version.NewVersion("1.26")
+	// MinVersionForKubeSchedulerConfiguration k8s 1.23.0
+	MinVersionForKubeSchedulerConfiguration, _ = version.NewVersion("1.23.0")
 )
 
 // NewK8sClient returns a new controller runtime Kubernetes client
@@ -2274,4 +2276,34 @@ func AddManagedByOperatorLabel(om metav1.ObjectMeta) metav1.ObjectMeta {
 	}
 	om.Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 	return om
+}
+
+func GetDefaultKubeControllerManagerImage(k8sVersion *version.Version) string {
+	if k8sVersion == nil {
+		return ""
+	}
+	prefix := "gcr.io/google_containers"
+	if IsNewKubernetesRegistry(k8sVersion) {
+		prefix = DefaultK8SRegistryPath
+	}
+	return prefix + "/kube-controller-manager-amd64:v" + k8sVersion.String()
+}
+
+func GetDefaultKubeSchedulerImage(k8sVersion *version.Version) string {
+	if k8sVersion == nil {
+		return ""
+	}
+	minVersionForPinnedStorkScheduler, _ := version.NewVersion("1.22.0")
+	prefix := "gcr.io/google_containers"
+	if IsNewKubernetesRegistry(k8sVersion) {
+		prefix = DefaultK8SRegistryPath
+	}
+	prefix += "/kube-scheduler-amd64:v"
+
+	if k8sVersion.GreaterThanOrEqual(minVersionForPinnedStorkScheduler) &&
+		k8sVersion.LessThan(MinVersionForKubeSchedulerConfiguration) {
+		// Stork scheduler cannot run with kube-scheduler image > v1.22
+		return prefix + "1.21.4"
+	}
+	return prefix + k8sVersion.String()
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This PR fixes the following issues:
* the `kubeControllerManager`, `kubeScheduler`, and `pause` images were not included in `StorageCluster.spec.desiredImages` list, also
* the `kubeScheduler` needs to be _bound_ to the `stork` image - if `stork` is disabled, both `kubeScheduler` and `stork` images should be removed from the `desiredImages` list
* finally, it should be possible to update the `kubeScheduler` image via `px-versions` ConfigMap

**Which issue(s) this PR fixes** (optional)
Closes # PWX-35007, PWX-35008

**Special notes for your reviewer**:

Manual testing:

Test1:
* deployed cluster using custom `px-version` ConfigMap, overriding all images to `10.13.1.19/portworx/*`
* also, STORK was NOT enabled

```
status:
  clusterName: px-cluster-foo-a007226b8a30
  clusterUid: 36ab07d7-3d64-49ae-b34c-14a1138ebd4c
  conditions:
  - lastTransitionTime: "2023-12-08T06:40:28Z"
    message: Portworx installation completed on 3 nodes
    source: Portworx
    status: Completed
    type: Install
  - lastTransitionTime: "2023-12-08T06:39:24Z"
    source: Portworx
    status: Online
    type: RuntimeState
  desiredImages:
    autopilot: 10.13.1.19/portworx/autopilot:1.3.12
    csiAttacher: 10.13.1.19/portworx/csi-attacher:v1.2.1-1
    csiNodeDriverRegistrar: 10.13.1.19/portworx/csi-node-driver-registrar:v2.9.0
    csiProvisioner: 10.13.1.19/portworx/csi-provisioner:v3.6.1
    csiResizer: 10.13.1.19/portworx/csi-resizer:v1.9.1
    csiSnapshotController: 10.13.1.19/portworx/snapshot-controller:v6.3.1
    csiSnapshotter: 10.13.1.19/portworx/csi-snapshotter:v6.3.1
    dynamicPlugin: 10.13.1.19/portworx/portworx-dynamic-plugin:1.1.0
    dynamicPluginProxy: 10.13.1.19/portworx/nginx-unprivileged:1.25
    kubeControllerManager: 10.13.1.20/portworx/kube-controller-manager-amd64:v1.28.4
    logUploader: 10.13.1.19/portworx/log-upload:px-1.0.16
    metricsCollector: 10.13.1.19/portworx/realtime-metrics:1.0.20
    pause: 10.13.1.20/portworx/pause:3.1
    telemetry: 10.13.1.19/portworx/ccm-go:1.0.25
    telemetryProxy: 10.13.1.19/portworx/telemetry-envoy:1.1.6
```
  - note, `kubeControllerManager` and `pause` are now explicitly listed in the `desiredImages`, but
  - the `stork` and `kubeScheduler` are missing

Test 2:
* updated STC and enabled stork (`stork.enabled: true`)

```
  desiredImages:
    autopilot: 10.13.1.19/portworx/autopilot:1.3.12
    csiAttacher: 10.13.1.19/portworx/csi-attacher:v1.2.1-1
    csiNodeDriverRegistrar: 10.13.1.19/portworx/csi-node-driver-registrar:v2.9.0
    csiProvisioner: 10.13.1.19/portworx/csi-provisioner:v3.6.1
    csiResizer: 10.13.1.19/portworx/csi-resizer:v1.9.1
    csiSnapshotController: 10.13.1.19/portworx/snapshot-controller:v6.3.1
    csiSnapshotter: 10.13.1.19/portworx/csi-snapshotter:v6.3.1
    dynamicPlugin: 10.13.1.19/portworx/portworx-dynamic-plugin:1.1.0
    dynamicPluginProxy: 10.13.1.19/portworx/nginx-unprivileged:1.25
    kubeControllerManager: 10.13.1.20/portworx/kube-controller-manager-amd64:v1.28.4
    kubeScheduler: 10.13.1.19/portworx/kube-scheduler-amd64:v1.28.4
    logUploader: 10.13.1.19/portworx/log-upload:px-1.0.16
    metricsCollector: 10.13.1.19/portworx/realtime-metrics:1.0.20
    pause: 10.13.1.20/portworx/pause:3.1
    stork: 10.13.1.19/portworx/stork:23.8.0
    telemetry: 10.13.1.19/portworx/ccm-go:1.0.25
    telemetryProxy: 10.13.1.19/portworx/telemetry-envoy:1.1.6
```
   - stork got deployed
   - the `stork` and `kubeScheduler` entries added to the `desiredImages`

Test 3:
* updated px-versions CM (~kubeScheduler: 10.13.1.19/portworx/kube-scheduler-amd64:v1.28.4~ -> `10.13.1.20/portworx-test2`), also "bounced" stork  (enabled false/true in STC)

```
  desiredImages:
    autopilot: 10.13.1.19/portworx/autopilot:1.3.12
    csiAttacher: 10.13.1.19/portworx/csi-attacher:v1.2.1-1
    csiNodeDriverRegistrar: 10.13.1.19/portworx/csi-node-driver-registrar:v2.9.0
    csiProvisioner: 10.13.1.19/portworx/csi-provisioner:v3.6.1
    csiResizer: 10.13.1.19/portworx/csi-resizer:v1.9.1
    csiSnapshotController: 10.13.1.19/portworx/snapshot-controller:v6.3.1
    csiSnapshotter: 10.13.1.19/portworx/csi-snapshotter:v6.3.1
    dynamicPlugin: 10.13.1.19/portworx/portworx-dynamic-plugin:1.1.0
    dynamicPluginProxy: 10.13.1.19/portworx/nginx-unprivileged:1.25
    kubeControllerManager: 10.13.1.20/portworx/kube-controller-manager-amd64:v1.28.4
    kubeScheduler: 10.13.1.20/portworx-test2/kube-scheduler-amd64:v1.28.4
    logUploader: 10.13.1.19/portworx/log-upload:px-1.0.16
    metricsCollector: 10.13.1.19/portworx/realtime-metrics:1.0.20
    pause: 10.13.1.20/portworx/pause:3.1
    stork: 10.13.1.19/portworx/stork:23.8.0
    telemetry: 10.13.1.19/portworx/ccm-go:1.0.25
    telemetryProxy: 10.13.1.19/portworx/telemetry-envoy:1.1.6
```
   - note, the `kubeScheduler` got updated to the new value, as requested in `px-veresion` ConfigMap