### PR TITLE
PWX-35330: fixed gitops spec definition

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -205,11 +205,11 @@ func (c *autopilot) createConfigMap(
 			if key == AutopilotDefaultReviewersKey {
 				params += fmt.Sprintf(`
     %s:`, AutopilotDefaultReviewersKey)
-				values := strings.Split(val, ",")
-				for _, v := range values {
-					v = strings.TrimSpace(v)
+				var reviewers []interface{} = val.([]interface{})
+				for _, r := range reviewers {
+					r = strings.TrimSpace(r.(string))
 					params += fmt.Sprintf(`
-      - "%s"`, v)
+      - "%s"`, r)
 				}
 				continue
 			}

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -206,10 +206,12 @@ func (c *autopilot) createConfigMap(
 				params += fmt.Sprintf(`
     %s:`, AutopilotDefaultReviewersKey)
 				var reviewers []interface{} = val.([]interface{})
-				for _, r := range reviewers {
-					r = strings.TrimSpace(r.(string))
-					params += fmt.Sprintf(`
+				for _, reviewer := range reviewers {
+					if r, ok := reviewer.(string); ok {
+						r = strings.TrimSpace(r)
+						params += fmt.Sprintf(`
       - "%s"`, r)
+					}
 				}
 				continue
 			}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3235,8 +3235,8 @@ func TestAutopilotInstall(t *testing.T) {
 				GitOps: &corev1.GitOpsSpec{
 					Name: "test",
 					Type: "bitbucket-scm",
-					Params: map[string]string{
-						"defaultReviewers": "user1, user2",
+					Params: map[string]interface{}{
+						"defaultReviewers": []interface{}{"user1", "user2"},
 						"user":             "oksana",
 						"repo":             "autopilot-bb",
 						"folder":           "workloads",

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -544,9 +544,9 @@ type DataProviderSpec struct {
 
 // GitOpsSpec contains the details for GitOps provider like github or bitbucket
 type GitOpsSpec struct {
-	Name   string            `json:"name,omitempty"`
-	Type   string            `json:"type,omitempty"`
-	Params map[string]string `json:"params,omitempty"`
+	Name   string                 `json:"name,omitempty"`
+	Type   string                 `json:"type,omitempty"`
+	Params map[string]interface{} `json:"params,omitempty"`
 }
 
 // MonitoringSpec contains monitoring configuration for the storage cluster.

--- a/pkg/apis/core/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1/zz_generated.deepcopy.go
@@ -455,7 +455,7 @@ func (in *GitOpsSpec) DeepCopyInto(out *GitOpsSpec) {
 	*out = *in
 	if in.Params != nil {
 		in, out := &in.Params, &out.Params
-		*out = make(map[string]string, len(*in))
+		*out = make(map[string]interface{}, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
[PR830](https://github.com/libopenstorage/operator/pull/830) was supposed to add gitops support to autopilot through stc configuration. But it fails to do so due to the fact that wrong type of defaultReviewers parameter is processed (expected array but got string). This bug will cause operator to go down and couldn't generate anticipated autopilot configmap with gitops config definition

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Before the change, operator breaks down if in stc spec we have definition of gitops like:
`    autopilot:
      args:
        log-level: debug
        min_poll_interval: "10"
      enabled: true
      gitops:
        params:
          baseUrl: https://bitbucket-staging.dev.purestorage.com
          branch: master
          defaultReviewers:
          - svc-cnbu-devops
          - user1
          folder: test
          projectKey: PXAUT
          repo: autopilot-eugene-test
          user: svc-cnbu-devops
        type: bitbucket-scm
      providers:
      - name: default
        params:
          url: http://px-prometheus:9090
        type: prometheus`

with error 

> W1211 20:41:26.727165       1 reflector.go:424] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:262: failed to list *v1.StorageCluster: json: cannot unmarshal array into Go struct field GitOpsSpec.items.spec.autopilot.gitops.params of type string
E1211 20:41:26.727232       1 reflector.go:140] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:262: Failed to watch *v1.StorageCluster: failed to list *v1.StorageCluster: json: cannot unmarshal array into Go struct field GitOpsSpec.items.spec.autopilot.gitops.params of type string

Therefore no gitops definition was found in autopilot-config cm.

With this change, operator now runs without error/restart and autopilot-config cm now contains the correct content for gitops
`[root@users-ezhang-ezhang-k8s-1-4-3 autopilot]# kp get cm  autopilot-config -oyaml
apiVersion: v1
data:
  config.yaml: "providers:\n- name: default\n  type: prometheus\n  params: url=http://px-prometheus:9090\ngitops:\n
    \ name: \n  type: bitbucket-scm\n  params:\n    baseUrl: https://bitbucket-staging.dev.purestorage.com\n
    \   branch: master\n    defaultReviewers:\n      - \"svc-cnbu-devops\"\n      -
    \"user1\"\n    folder: test\n    projectKey: PXAUT\n    repo: autopilot-eugene-test\n
    \   user: svc-cnbu-devops\nmin_poll_interval: 10"
kind: ConfigMap`
