### PR TITLE
PWX-22131,PWX-34256_pt4 (px-rel-23.10.2): Version parsing fix (#1383)

### DIFF
--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -186,10 +186,12 @@ func (m *manifest) GetVersions(
 	var provider versionProvider
 	ver := pxutil.GetImageTag(cluster.Spec.Image)
 	currPxVer, err := version.NewSemver(ver)
-	if err == nil {
-		if currPxVer.LessThan(pxVer2_5_7) {
-			provider = newDeprecatedManifest(ver)
-		}
+	if currPxVer == nil || err != nil {
+		// note, dev-bulids like `c2bb2a0_14e4543` won't parse correctly, so adding this as a failback
+		currPxVer = pxutil.GetPortworxVersion(cluster)
+	}
+	if currPxVer != nil && currPxVer.LessThan(pxVer2_5_7) {
+		provider = newDeprecatedManifest(ver)
 	}
 
 	if provider == nil {

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -296,6 +296,47 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 	require.Equal(t, expected, rel)
 }
 
+func TestManifestWithDevelopmentPortworxVersion(t *testing.T) {
+	k8sVersion, _ := version.NewSemver("1.28.4")
+	expected := &Version{
+		PortworxVersion: "c2bb2a0_14e4543",
+		Components: Release{
+			Stork:     "image/stork:22.33.44",
+			Autopilot: "image/autopi:55.666.777",
+		},
+	}
+	httpGet = func(url string) (*http.Response, error) {
+		body, _ := yaml.Marshal(expected)
+		return &http.Response{
+			Body: io.NopCloser(bytes.NewReader(body)),
+		}, nil
+	}
+
+	expected_ociMon := "px/image:" + expected.PortworxVersion
+	cluster := &corev1.StorageCluster{
+		Spec: corev1.StorageClusterSpec{
+			Image: expected_ociMon,
+			CommonConfig: corev1.CommonConfig{
+				Env: []v1.EnvVar{
+					{
+						Name:  envKeyReleaseManifestURL,
+						Value: "https://edge-install.portworx.com/3.1.0/version",
+					},
+				},
+			},
+		},
+	}
+
+	m := Instance()
+	m.Init(testutil.FakeK8sClient(), nil, k8sVersion)
+	rel, err := m.GetVersions(cluster, true)
+	require.NoError(t, err)
+	assert.Equal(t, rel.PortworxVersion, expected.PortworxVersion)
+	assert.Equal(t, rel.Components.Stork, expected.Components.Stork)
+	assert.Equal(t, rel.Components.Autopilot, expected.Components.Autopilot)
+	assert.Equal(t, rel.Components.NodeWiper, expected_ociMon)
+}
+
 func TestManifestWithUnknownNonSemvarPortworxVersion(t *testing.T) {
 	httpGet = func(url string) (*http.Response, error) {
 		// Return empty response without any versions

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -329,8 +329,7 @@ func TestManifestWithDevelopmentPortworxVersion(t *testing.T) {
 
 	m := Instance()
 	m.Init(testutil.FakeK8sClient(), nil, k8sVersion)
-	rel, err := m.GetVersions(cluster, true)
-	require.NoError(t, err)
+	rel := m.GetVersions(cluster, true)
 	assert.Equal(t, rel.PortworxVersion, expected.PortworxVersion)
 	assert.Equal(t, rel.Components.Stork, expected.Components.Stork)
 	assert.Equal(t, rel.Components.Autopilot, expected.Components.Autopilot)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1383 into `px-rel-23.10.2` branch

**Which issue(s) this PR fixes** (optional)
PWX-22131,PWX-34256_pt4 (px-rel-23.10.2)

**Special notes for your reviewer**:

