### PR TITLE
PWX-34256_op-23.10.2: node-wiper fix for custom-dir installs (#1388)

### DIFF
--- a/drivers/storage/portworx/uninstall.go
+++ b/drivers/storage/portworx/uninstall.go
@@ -407,6 +407,7 @@ func (u *uninstallPortworx) RunNodeWiper(
 	if strings.Contains(wiperImage, "monitor") {
 		logrus.Warnf("Using oci-monitor %s as node-wiper image", wiperImage)
 		ds.Spec.Template.Spec.Containers[0].Command = []string{"/px-node-wiper"}
+		pxutil.AppendUserVolumeMounts(&ds.Spec.Template.Spec, u.cluster.Spec.Volumes)
 	}
 
 	if u.cluster.Spec.ImagePullSecret != nil && *u.cluster.Spec.ImagePullSecret != "" {

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1262,3 +1262,45 @@ func GetTLSCipherSuites(cluster *corev1.StorageCluster) (string, error) {
 	}
 	return strings.Join(outList, ","), nil
 }
+
+// AppendUserVolumeMounts appends "user" vol specs to the pod spec
+//   - note, the user volume specs will override container mounts, if the mount
+//     destination directory is the same
+//   - caveat: caller needs to ensure that the volume specs NAMES are unique
+func AppendUserVolumeMounts(
+	podSpec *v1.PodSpec,
+	userVolSpecList []corev1.VolumeSpec,
+) {
+	if podSpec == nil {
+		return
+	} else if len(userVolSpecList) == 0 {
+		return
+	}
+
+	// make map of user-volumes, also append vols to pod spec
+	usrSpecMap := make(map[string]corev1.VolumeSpec)
+	for _, v := range userVolSpecList {
+		usrSpecMap[v.MountPath] = v
+		podSpec.Volumes = append(podSpec.Volumes, v1.Volume{
+			Name:         UserVolumeName(v.Name),
+			VolumeSource: v.VolumeSource,
+		})
+	}
+
+	// update container volumes, when destination-dir matches
+	for idx1, cntr := range podSpec.Containers {
+		for idx2, cv := range cntr.VolumeMounts {
+			if uv, has := usrSpecMap[cv.MountPath]; has {
+				logrus.Debugf("Replacing container %s:%s mount '%s' with user-mount '%s'",
+					cntr.Name, cv.MountPath, cv.Name, uv.Name)
+
+				podSpec.Containers[idx1].VolumeMounts[idx2] = v1.VolumeMount{
+					Name:             UserVolumeName(uv.Name),
+					MountPath:        uv.MountPath,
+					ReadOnly:         uv.ReadOnly,
+					MountPropagation: uv.MountPropagation,
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Zoran Rajic <zox@portworx.com>

Manually fixed Conflicts:
	drivers/storage/portworx/util/util.go

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1388 into `px-rel-23.10.2` branch

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-34256 (op-23.10.2)

**Special notes for your reviewer**:

