### PR TITLE
PWX-35704: The pks distribution string was incorrect.  Change it from  'gke' to 'pks'

### DIFF
--- a/pkg/preflight/pks.go
+++ b/pkg/preflight/pks.go
@@ -1,7 +1,7 @@
 package preflight
 
 const (
-	pksDistribution = "gke"
+	pksDistribution = "pks"
 	// PksSystemNamespace PKS system namespace
 	PksSystemNamespace = "pks-system"
 )


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The pks distribution string was incorrect and triggered incorrect mounts to be added to the telemetry spec when running on gke install.  Change the the string be 'pks'.

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-35704
**Special notes for your reviewer**:

