### PR TITLE
PWX-35704: Cherry pick correct distribution string for PKS

### DIFF
--- a/pkg/preflight/pks.go
+++ b/pkg/preflight/pks.go
@@ -1,7 +1,7 @@
 package preflight
 
 const (
-	pksDistribution = "gke"
+	pksDistribution = "pks"
 	// PksSystemNamespace PKS system namespace
 	PksSystemNamespace = "pks-system"
 )


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The distribution string was incorrect for PKS.  Resulting in wrong mounts for 'gke'.   Use the correct string.
**Which issue(s) this PR fixes** (optional)
Closes #
PWX-35704
**Special notes for your reviewer**:

