### PR TITLE
Add additional properties to the crd schema definitions

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -39,6 +39,18 @@ spec:
       openAPIV3Schema:
         type: object
         properties:
+          apiVersion:
+            type: string
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          kind:
+            type: string
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          metadata:
+            type: object
           spec:
             type: object
             description: The desired behavior of the storage cluster.

--- a/deploy/crds/core_v1_storagenode_crd.yaml
+++ b/deploy/crds/core_v1_storagenode_crd.yaml
@@ -39,6 +39,18 @@ spec:
       openAPIV3Schema:
         type: object
         properties:
+          apiVersion:
+            type: string
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          kind:
+            type: string
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          metadata:
+            type: object
           spec:
             type: object
             description: The desired behavior of the storage node. Currently changing the spec does


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: When using [kubeconform](https://github.com/yannh/kubeconform) to validate CRDs, the StorageCluster CRD was being reported as invalid due to the CRD schema definition not possessing the keywords 'kind', 'metadata' and 'apiVersion'. This PR would make the CRD schema definition more complete and allow a more strict validation of the StorageCluster resource.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

