### PR TITLE
PWX-35865 : Fixing moving csi registrar to pc-api pod gaps due to PR #1334

### DIFF
--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -202,19 +202,24 @@ func (c *portworxAPI) createDaemonSet(
 
 	//  If px version is greater than 2.13 then update daemonset when csi-node-driver-registrar image changes if CSI is enabled
 	pxVersion := pxutil.GetPortworxVersion(cluster)
+	removeCSIRegistrar := false
 	checkCSIDriverRegistrarChange := false
 	if pxutil.IsCSIEnabled(cluster) && pxVersion.GreaterThanOrEqual(csiRegistrarAdditionPxVersion) && len(existingDaemonSet.Spec.Template.Spec.Containers) > 1 {
 		existingCsiDriverRegistrarImageName = existingDaemonSet.Spec.Template.Spec.Containers[1].Image
 		csiNodeRegistrarImageName = cluster.Status.DesiredImages.CSINodeDriverRegistrar
 		csiNodeRegistrarImageName = util.GetImageURN(cluster, csiNodeRegistrarImageName)
 		checkCSIDriverRegistrarChange = true
+	} else if !pxutil.IsCSIEnabled(cluster) && pxVersion.GreaterThanOrEqual(csiRegistrarAdditionPxVersion) && len(existingDaemonSet.Spec.Template.Spec.Containers) > 1 {
+		// When CSI is disabled, remove the csi-node-driver-registrar container from the daemonset
+		removeCSIRegistrar = true
+
 	}
 
 	pauseImageName = util.GetImageURN(cluster, pauseImageName)
 	serviceAccount := pxutil.PortworxServiceAccountName(cluster)
 	existingServiceAccount := existingDaemonSet.Spec.Template.Spec.ServiceAccountName
 
-	modified := existingPauseImageName != pauseImageName ||
+	modified := existingPauseImageName != pauseImageName || removeCSIRegistrar ||
 		(checkCSIDriverRegistrarChange && (existingCsiDriverRegistrarImageName != csiNodeRegistrarImageName)) ||
 		existingServiceAccount != serviceAccount ||
 		util.HasPullSecretChanged(cluster, existingDaemonSet.Spec.Template.Spec.ImagePullSecrets) ||

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -202,31 +202,34 @@ func (c *portworxAPI) createDaemonSet(
 
 	//  If px version is greater than 2.13 then update daemonset when csi-node-driver-registrar image changes if CSI is enabled
 	pxVersion := pxutil.GetPortworxVersion(cluster)
-	removeCSIRegistrar := false
-	addCSIRegistrar := false
+	addOrRemoveCSIRegistrar := false
 	checkCSIDriverRegistrarChange := false
-	if pxutil.IsCSIEnabled(cluster) && pxVersion.GreaterThanOrEqual(csiRegistrarAdditionPxVersion) && len(existingDaemonSet.Spec.Template.Spec.Containers) > 1 {
+	isCsiEnabled := pxutil.IsCSIEnabled(cluster)
+	pxVersionGTE2_13 := pxVersion.GreaterThanOrEqual(csiRegistrarAdditionPxVersion)
+	hasMultipleCsiContainers := len(existingDaemonSet.Spec.Template.Spec.Containers) > 1
+	isSingleCsiContainer := len(existingDaemonSet.Spec.Template.Spec.Containers) == 1
+
+	if isCsiEnabled && pxVersionGTE2_13 && hasMultipleCsiContainers {
 		existingCsiDriverRegistrarImageName = existingDaemonSet.Spec.Template.Spec.Containers[1].Image
 		csiNodeRegistrarImageName = cluster.Status.DesiredImages.CSINodeDriverRegistrar
 		csiNodeRegistrarImageName = util.GetImageURN(cluster, csiNodeRegistrarImageName)
 		checkCSIDriverRegistrarChange = true
-	} else if !pxutil.IsCSIEnabled(cluster) && pxVersion.GreaterThanOrEqual(csiRegistrarAdditionPxVersion) && len(existingDaemonSet.Spec.Template.Spec.Containers) > 1 {
+	} else if !isCsiEnabled && pxVersionGTE2_13 && hasMultipleCsiContainers {
 		// When CSI is disabled, remove the csi-node-driver-registrar container from the daemonset
-		removeCSIRegistrar = true
-
-	} else if pxVersion.LessThan(csiRegistrarAdditionPxVersion) && len(existingDaemonSet.Spec.Template.Spec.Containers) > 1 {
+		addOrRemoveCSIRegistrar = true
+	} else if !pxVersionGTE2_13 && hasMultipleCsiContainers {
 		// When px version is less than 2.13, remove the csi-node-driver-registrar container from the daemonset
-		removeCSIRegistrar = true
-	} else if pxutil.IsCSIEnabled(cluster) && pxVersion.GreaterThanOrEqual(csiRegistrarAdditionPxVersion) && len(existingDaemonSet.Spec.Template.Spec.Containers) == 1 {
+		addOrRemoveCSIRegistrar = true
+	} else if isCsiEnabled && pxVersionGTE2_13 && isSingleCsiContainer {
 		// When px version is greater than 2.13 and CSI is enabled, add the csi-node-driver-registrar container to the daemonset
-		addCSIRegistrar = true
+		addOrRemoveCSIRegistrar = true
 	}
 
 	pauseImageName = util.GetImageURN(cluster, pauseImageName)
 	serviceAccount := pxutil.PortworxServiceAccountName(cluster)
 	existingServiceAccount := existingDaemonSet.Spec.Template.Spec.ServiceAccountName
 
-	modified := existingPauseImageName != pauseImageName || removeCSIRegistrar || addCSIRegistrar ||
+	modified := existingPauseImageName != pauseImageName || addOrRemoveCSIRegistrar ||
 		(checkCSIDriverRegistrarChange && (existingCsiDriverRegistrarImageName != csiNodeRegistrarImageName)) ||
 		existingServiceAccount != serviceAccount ||
 		util.HasPullSecretChanged(cluster, existingDaemonSet.Spec.Template.Spec.ImagePullSecrets) ||

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -203,6 +203,7 @@ func (c *portworxAPI) createDaemonSet(
 	//  If px version is greater than 2.13 then update daemonset when csi-node-driver-registrar image changes if CSI is enabled
 	pxVersion := pxutil.GetPortworxVersion(cluster)
 	removeCSIRegistrar := false
+	addCSIRegistrar := false
 	checkCSIDriverRegistrarChange := false
 	if pxutil.IsCSIEnabled(cluster) && pxVersion.GreaterThanOrEqual(csiRegistrarAdditionPxVersion) && len(existingDaemonSet.Spec.Template.Spec.Containers) > 1 {
 		existingCsiDriverRegistrarImageName = existingDaemonSet.Spec.Template.Spec.Containers[1].Image
@@ -213,13 +214,19 @@ func (c *portworxAPI) createDaemonSet(
 		// When CSI is disabled, remove the csi-node-driver-registrar container from the daemonset
 		removeCSIRegistrar = true
 
+	} else if pxVersion.LessThan(csiRegistrarAdditionPxVersion) && len(existingDaemonSet.Spec.Template.Spec.Containers) > 1 {
+		// When px version is less than 2.13, remove the csi-node-driver-registrar container from the daemonset
+		removeCSIRegistrar = true
+	} else if pxutil.IsCSIEnabled(cluster) && pxVersion.GreaterThanOrEqual(csiRegistrarAdditionPxVersion) && len(existingDaemonSet.Spec.Template.Spec.Containers) == 1 {
+		// When px version is greater than 2.13 and CSI is enabled, add the csi-node-driver-registrar container to the daemonset
+		addCSIRegistrar = true
 	}
 
 	pauseImageName = util.GetImageURN(cluster, pauseImageName)
 	serviceAccount := pxutil.PortworxServiceAccountName(cluster)
 	existingServiceAccount := existingDaemonSet.Spec.Template.Spec.ServiceAccountName
 
-	modified := existingPauseImageName != pauseImageName || removeCSIRegistrar ||
+	modified := existingPauseImageName != pauseImageName || removeCSIRegistrar || addCSIRegistrar ||
 		(checkCSIDriverRegistrarChange && (existingCsiDriverRegistrarImageName != csiNodeRegistrarImageName)) ||
 		existingServiceAccount != serviceAccount ||
 		util.HasPullSecretChanged(cluster, existingDaemonSet.Spec.Template.Spec.ImagePullSecrets) ||

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -11076,6 +11076,136 @@ func TestDisableCSI_1_0(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 }
 
+// Test to check the movement of csi registrar container when px version is upgraded/downgraded from 2.13
+func TestCSIRegistrarContainerShift(t *testing.T) {
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.14.0",
+	}
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(10))
+	require.NoError(t, err)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/image:2.12.0",
+			CSI: &corev1.CSISpec{
+				Enabled: true,
+			},
+		},
+	}
+	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Initially since px version is lesser than 2.13, oci monitor pods will have csi-registrar container
+	newDs := &appsv1.DaemonSet{}
+	err = testutil.Get(k8sClient, newDs, component.PxAPIDaemonSetName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(newDs.Spec.Template.Spec.Containers))
+
+	podSpec, err := driver.GetStoragePodSpec(cluster, "")
+	require.NoError(t, err)
+	require.Equal(t, 2, len(podSpec.Containers))
+
+	// On upgrading px version to 2.13, csi registrar containers will be moved to px-api pods
+	cluster.Spec.Image = "portworx/image:2.13.0"
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	newDs = &appsv1.DaemonSet{}
+	err = testutil.Get(k8sClient, newDs, component.PxAPIDaemonSetName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(newDs.Spec.Template.Spec.Containers))
+
+	podSpec, err = driver.GetStoragePodSpec(cluster, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(podSpec.Containers))
+
+	// Now downgrade version back to 2.12.0, csi-registrar container should be moved back to oci monitor pods
+	cluster.Spec.Image = "portworx/image:2.12.0"
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	newDs = &appsv1.DaemonSet{}
+	err = testutil.Get(k8sClient, newDs, component.PxAPIDaemonSetName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(newDs.Spec.Template.Spec.Containers))
+
+	podSpec, err = driver.GetStoragePodSpec(cluster, "")
+	require.NoError(t, err)
+	require.Equal(t, 2, len(podSpec.Containers))
+
+}
+
+// Test to verify if disabling CSI for PX version >= 2.13 will remove csi-registrar container from px-api pods
+func TestDisableCSI_GTPxVersion2_13(t *testing.T) {
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.14.0",
+	}
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(10))
+	require.NoError(t, err)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/image:2.13.0",
+			CSI: &corev1.CSISpec{
+				Enabled: true,
+			},
+		},
+	}
+	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// When CSI is enabled, px-api pods will have csi-node-registration container
+	newDs := &appsv1.DaemonSet{}
+	err = testutil.Get(k8sClient, newDs, component.PxAPIDaemonSetName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(newDs.Spec.Template.Spec.Containers))
+
+	podSpec, err := driver.GetStoragePodSpec(cluster, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(podSpec.Containers))
+
+	// disable CSI
+	cluster.Spec.CSI.Enabled = false
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Now px-api daemonset should have only one container
+	newDs = &appsv1.DaemonSet{}
+	err = testutil.Get(k8sClient, newDs, component.PxAPIDaemonSetName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(newDs.Spec.Template.Spec.Containers))
+
+	podSpec, err = driver.GetStoragePodSpec(cluster, "")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(podSpec.Containers))
+
+}
+
 func TestMonitoringMetricsEnabled(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This ticket fixes all issues that were found while running integration tests on px-rel-23.10.3 branch.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-35865 and PWX-35867

**Testing notes: The following cases were tested manually:**

1) fresh installation of operator with current changes:

    i) install px verison <2.13 - no change in current behavior
    ii) install px version>=2.13 - px-api pods have csi-registrar containers, oci-monitor pod have only 1 container
    iii) px version>=2.13 , csi disabled - both px-api and oci-monitor pods have 1 container each
    
2) Existing PX installation with older operator image, update operator image first then upgrade px
     i) start with px version<2.13, upgrade operator - no change in px api pods
        upgrade px version but ensure it is also version <2.13 - no change in px or api pods 
    ii) px version<2.13, update operator - no change in px api pods
        upgrade px version >=2.13 - px-api pods get 2 containers, oci pods have 1
   iii) px version<2.13, upgrade operator - no change
        upgrade px version>=2.13, disable CSI - no change in px api pods, oci monitor pods have 1 container as csi is 
        removed
   iv) start with px version>=2.13, update operator - px api pods get 2 containers, oci monitor pods continue to have 2 
        containers
        upgarde px to newer version than previous - px api pods restart with 2 containers, oci monitor pods have 1 container
   v)  px version>=2.13, update operator - px api pods get 2 containers, oci monitor pods have 1 container
        upgrade px version, disable CSI - px api pods restart with 1 container as csi is disabled
   vi) px version>=2.13, update operator - px api pods get 2 containers, oci monitor pods have 1 container
        downgrade px version to <2.13 - px api has 1 container, oci monitor has 2 containers

3) portworx is running with operator that has the changes
   i) upgrade px version from <2.13 to >=2.13 - px api pods get 2 containers, oci pods get 1 container
   ii) downgrade px version from >=2.13 to <2.13 - px api pods go back to 1 container and oci gets 2 containers
   iii) px version is >=2.13, csi which was enabled is disabled - csi-registrar container from px-api pods is removed
   iv) px version is >=2.13, csi which was disabled is enabled - px-api pods gets csi-registrar container

