### PR TITLE
OCP 4.14 : Fix Mount volume to autopilot pod only if secret is created

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -757,7 +757,7 @@ func (c *autopilot) isAutopilotSecretCreated(namespace string) bool {
 		secret,
 	)
 
-	if err == nil && secret.Name == AutopilotSecretName {
+	if err == nil {
 		return true
 	}
 

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -724,7 +724,7 @@ func (c *autopilot) getDesiredVolumesAndMounts(
 ) ([]v1.Volume, []v1.VolumeMount) {
 	volumeSpecs := make([]corev1.VolumeSpec, 0)
 
-	if c.isOCPUserWorkloadSupported() && !c.isVolumeMounted {
+	if c.isOCPUserWorkloadSupported() && !c.isVolumeMounted && c.isAutopilotSecretCreated(cluster.Namespace) {
 		c.isVolumeMounted = true
 		autopilotDeploymentVolumes = append(autopilotDeploymentVolumes, openshiftDeploymentVolume...)
 	}
@@ -743,6 +743,30 @@ func (c *autopilot) getDesiredVolumesAndMounts(
 	sort.Sort(k8sutil.VolumeByName(volumes))
 	sort.Sort(k8sutil.VolumeMountByName(volumeMounts))
 	return volumes, volumeMounts
+}
+
+func (c *autopilot) isAutopilotSecretCreated(namespace string) bool {
+	secret := &v1.Secret{}
+
+	err := c.k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      AutopilotSecretName,
+			Namespace: namespace,
+		},
+		secret,
+	)
+
+	if err == nil && secret.Name == AutopilotSecretName {
+		return true
+	}
+
+	if err != nil && errors.IsNotFound(err) {
+		return false
+	}
+
+	logrus.Errorf("error while fetching secret %s ", err)
+	return false
 }
 
 func (c *autopilot) getPrometheusTokenAndCert() (encodedToken, caCert string, err error) {


### PR DESCRIPTION
**What this PR does / why we need it**: We should mount token and sertificates to autopilot pod only if autopilot-prometheus-auth secret is created, otherwise autopilot pod will start failing to come up and mounting error.


Extension of PR https://github.com/libopenstorage/operator/pull/1410

