### PR TITLE
Update plugin deployment PullPolicy to Always regardless of STC's PullPolicy

### DIFF
--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -230,12 +230,6 @@ func (p *plugin) createDeployment(filename, deploymentName string, ownerRef *met
 	}
 	deployment.Namespace = cluster.Namespace
 	deployment.OwnerReferences = []metav1.OwnerReference{*ownerRef}
-	if deployment.Name == PluginDeploymentName {
-		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPluginImage(cluster)
-	}
-	if deployment.Name == NginxDeploymentName {
-		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPluginProxyImage(cluster)
-	}
 	deployment.Spec.Template.ObjectMeta = k8s.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 
 	existingDeployment := &appsv1.Deployment{}
@@ -252,6 +246,14 @@ func (p *plugin) createDeployment(filename, deploymentName string, ownerRef *met
 	}
 
 	pxutil.ApplyStorageClusterSettingsToPodSpec(cluster, &deployment.Spec.Template.Spec)
+
+	if deployment.Name == PluginDeploymentName {
+		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPluginImage(cluster)
+		deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullAlways
+	}
+	if deployment.Name == NginxDeploymentName {
+		deployment.Spec.Template.Spec.Containers[0].Image = getDesiredPluginProxyImage(cluster)
+	}
 
 	equal, _ := util.DeepEqualPodTemplate(&deployment.Spec.Template, &existingDeployment.Spec.Template)
 

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -15887,6 +15887,10 @@ func TestPluginInstallAndUninstall(t *testing.T) {
 			Name:      "px-cluster",
 			Namespace: "kube-test",
 		},
+		Spec: corev1.StorageClusterSpec{
+			Image:           "portworx/image:2.2",
+			ImagePullPolicy: v1.PullIfNotPresent,
+		},
 	}
 
 	err = driver.PreInstall(cluster)
@@ -15935,11 +15939,14 @@ func TestPluginInstallAndUninstall(t *testing.T) {
 	// test creation of plugin-deployment
 	expectedPluginDeployment := testutil.GetExpectedDeployment(t, "plugin-deployment.yaml")
 	pxutil.ApplyStorageClusterSettingsToPodSpec(cluster, &expectedPluginDeployment.Spec.Template.Spec)
+	expectedPluginDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = v1.PullAlways
+
 	actualPluginDeployment := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, actualPluginDeployment, component.PluginDeploymentName, "kube-test")
 	require.NoError(t, err)
 	require.Equal(t, expectedPluginDeployment.Name, actualPluginDeployment.Name)
 	require.Equal(t, expectedPluginDeployment.Spec, actualPluginDeployment.Spec)
+	require.Equal(t, expectedPluginDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy, actualPluginDeployment.Spec.Template.Spec.Containers[0].ImagePullPolicy)
 
 	pluginComponent, _ := component.Get(component.PluginComponentName)
 	err = pluginComponent.Delete(cluster)


### PR DESCRIPTION
**What this PR does / why we need it**: Update imagePullPolicy for px-plugin pods to always, regardless of STC's ImagePullPolicy, to fetch latest security/other fixes on existing tag.
The imagePullPolicy for the pod is now being set to Always, after StorageClusterSetting is applied, so that STC's PullPolicy doesn't override.

**Special notes for your reviewer**:
Verified that ImagePullPolicy of plugin pod is set to 'Always' if
- ImagePullPolicy in Storagecluster pod is set to 'IfNotPresent'
- ImagePullPolicy in Storagecluster pod is set to 'Always'


