### PR TITLE
PTX-22180 Disable Alertmanager and Grafana tests for OCP 4.14+ and 23.10.3+

### DIFF
--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -194,7 +194,7 @@ var testStorageClusterBasicCases = []types.TestCase{
 				}
 
 				ocpVersion, _ := version.NewVersion(ocpVer)
-				if ocpVersion.GreaterThanOrEqual(ocpVer4_14) {
+				if ocpVersion.GreaterThanOrEqual(ocpVer4_14) && ci_utils.PxOperatorVersion.GreaterThanOrEqual(ci_utils.PxOperatorVer23_10_3) {
 					logrus.Warnf("Skipping BasicGrafanaRegression, because Openshift version is [%s] which is higher than 4.14, PX Prometheus is not supported here and will skip this test", ocpVer)
 					skip = true
 				}
@@ -217,6 +217,23 @@ var testStorageClusterBasicCases = []types.TestCase{
 			ObjectMeta: metav1.ObjectMeta{Name: "test-stc"},
 		}),
 		TestFunc: BasicAlertManagerRegression,
+		ShouldSkip: func(tc *types.TestCase) bool {
+			skip := false
+			if testutil.IsOpenshiftCluster() {
+				ocpVer, err := testutil.GetOpenshiftVersion()
+				if err != nil {
+					logrus.Warnf("Skipping BasicAlertManagerRegression, because not able to determine Openshift version, Err: %v", err)
+					skip = true
+				}
+
+				ocpVersion, _ := version.NewVersion(ocpVer)
+				if ocpVersion.GreaterThanOrEqual(ocpVer4_14) && ci_utils.PxOperatorVersion.GreaterThanOrEqual(ci_utils.PxOperatorVer23_10_3) {
+					logrus.Warnf("Skipping BasicAlertManagerRegression, because Openshift version is [%s] which is higher than 4.14, PX Prometheus is not supported here and will skip this test", ocpVer)
+					skip = true
+				}
+			}
+			return skip
+		},
 	},
 	{
 		TestName:        "BasicKvdbRegression",

--- a/test/integration_test/utils/px_operator.go
+++ b/test/integration_test/utils/px_operator.go
@@ -34,6 +34,8 @@ var (
 	PxOperatorVer23_5_1, _ = version.NewVersion("23.5.1")
 	// PxOperatorVer23_8 portworx-operator 23.8 minimum version
 	PxOperatorVer23_8, _ = version.NewVersion("23.8-")
+	// PxOperatorVer23_10_3 portworx-operator 23.10.3 version is when we not allowing to deploy our own PX Prometheus
+	PxOperatorVer23_10_3, _ = version.NewVersion("23.10.3-")
 )
 
 // TODO: Install portworx-operator in test automation


### PR DESCRIPTION
Disable Alertmanager and Grafana tests for OCP 4.14+ and 23.10.3+

