### PR TITLE
PWX-36015 Disable PX-prometheus for OCP 4.14+ on new installs

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -552,6 +552,8 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 		}
 	}
 
+	p.disablePrometheusOnNewInstall(toUpdate)
+
 	shouldRun := p.preflightShouldRun(toUpdate)
 	if _, ok := toUpdate.Annotations[pxutil.AnnotationPreflightCheck]; !ok {
 		toUpdate.Annotations[pxutil.AnnotationPreflightCheck] = strings.ToLower(strconv.FormatBool(shouldRun))
@@ -1525,24 +1527,24 @@ func setAutopilotDefaults(
 		return
 	}
 
-	var hostUrl string
-	var err error
-	isSupported, err := pxutil.IsSupportedOCPVersion(k8sClient, pxutil.OpenshiftPrometheusSupportedVersion)
-	if err != nil {
-		logrus.Errorf("Error checking for OpenShift version %s", err.Error())
-		return
-	}
-	if isSupported {
-		hostUrl, err = pxutil.GetOCPPrometheusHost(k8sClient)
+	if len(toUpdate.Spec.Autopilot.Providers) == 0 {
+		var hostUrl string
+		var err error
+		isSupported, err := pxutil.IsSupportedOCPVersion(k8sClient, pxutil.OpenshiftPrometheusSupportedVersion)
 		if err != nil {
-			logrus.Errorf("Error during fetching autopilot host url %s", err.Error())
+			logrus.Errorf("Error checking for OpenShift version %s", err.Error())
 			return
 		}
-	} else {
-		hostUrl = component.AutopilotDefaultProviderEndpoint
-	}
+		if isSupported {
+			hostUrl, err = pxutil.GetOCPPrometheusHost(k8sClient)
+			if err != nil {
+				logrus.Errorf("Error during fetching autopilot host url %s", err.Error())
+				return
+			}
+		} else {
+			hostUrl = component.AutopilotDefaultProviderEndpoint
+		}
 
-	if len(toUpdate.Spec.Autopilot.Providers) == 0 {
 		toUpdate.Spec.Autopilot.Providers = []corev1.DataProviderSpec{
 			{
 				Name: "default",
@@ -1711,6 +1713,27 @@ func (p *portworx) setTelemetryDefaults(
 		toUpdate.Spec.Monitoring.Telemetry.Enabled = true
 	}
 	return nil
+}
+
+func (p *portworx) disablePrometheusOnNewInstall(toUpdate *corev1.StorageCluster) {
+	if toUpdate.Spec.Version == "" &&
+		toUpdate.Spec.Monitoring != nil &&
+		toUpdate.Spec.Monitoring.Prometheus != nil &&
+		toUpdate.Spec.Monitoring.Prometheus.Enabled {
+		isOCPPrometheusSupported, err := pxutil.IsSupportedOCPVersion(p.k8sClient, pxutil.OpenshiftPrometheusSupportedVersion)
+		if err != nil {
+			logrus.Errorf("Error checking for OpenShift version %s", err.Error())
+			return
+		}
+		if isOCPPrometheusSupported {
+			toUpdate.Spec.Monitoring.Prometheus.Enabled = false
+			p.warningEvent(toUpdate, util.FailedComponentReason,
+				fmt.Sprintf("Disabling Portworx managed Prometheus in lieu of OpenShift managed Prometheus starting OpenShift %s",
+					pxutil.OpenshiftPrometheusSupportedVersion,
+				),
+			)
+		}
+	}
 }
 
 func removeDeprecatedFields(


### PR DESCRIPTION

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Starting OCP 4.14 we recommend using OCP user workload prometheus to be used for Portworx and Autopilot. That is why we will disable prometheus from STC spec if the user enables it on this environment. This will be done only on first/fresh installs. We will not change it again if the user overwrites that back to "enabled".
- We also raise a warning when disabling it so the user knows why we did that.
- Unrelated change: Checking openshift version only if the autopilot providers are not set. That way we don't end up querying the K8s API server repeatedly.


**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-36015

**Special notes for your reviewer**:
UTs added.
