### PR TITLE
[PWX-36029] Update certificate's mountpath in autopilot pod

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -106,7 +106,7 @@ var (
 		},
 		{
 			Name:      "ca-cert-volume",
-			MountPath: "/etc/ssl/certs",
+			MountPath: "/etc/ssl/px-custom/1",
 			ReadOnly:  true,
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{

--- a/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_14.yaml
+++ b/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_14.yaml
@@ -49,7 +49,7 @@ spec:
           name: autopilot
           volumeMounts:
             - name: ca-cert-volume
-              mountPath: /etc/ssl/certs
+              mountPath: /etc/ssl/px-custom/1
               readOnly: true
             - name: config-volume
               mountPath: /etc/config


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: 
Our container-mount for Destination:/etc/ssl/certs/ca-certificates.crt was overriding (removing) the system-CA bundle /etc/ssl/certs/ca-bundle.crt (/etc/pki/tls/certs/ca-bundle.crt) inside the container.

since the https://thanos-querier-openshift-monitoring… SSL cert was signed by the issuer: C=US; O=Let's Encrypt; CN=R3 – we needed the original system-CA bundle to verify this SSL certificate chain

We need to change the path where  operator is mounting the certificate currently, as that ovverides existing certificate bundle.

With this change, operator mounts custom-certs at /etc/ssl/px-custom/1  (can also do /etc/ssl/custom/2 , 3, 4 -- if needed)

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-36029

**Special notes for your reviewer**:

