### PR TITLE
PWX-32899_pt1: K8s DNS domain fix

### DIFF
--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -865,7 +865,7 @@ func GetPortworxConn(sdkConn *grpc.ClientConn, k8sClient client.Client, namespac
 	}
 
 	// note, using symbolic name for the `endpoint`, as SSL certificates won't have K8s service IP
-	endpoint := PortworxServiceName + "." + namespace + ".svc.cluster.local"
+	endpoint := PortworxServiceName + "." + namespace
 	sdkPort := defaultSDKPort
 
 	// Get the ports from service


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The px-operator should not assume the K8s cluster is running a default domain `.svc.cluster.local`

FIX:
* as a fix, we will use `portworx-api.<namespace>` hostname
* this relies on `/etc/resolv.conf` to supply `search <domain>` statements

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-32899  (part 1)

**Special notes for your reviewer**:

Tested manually on a K8s cluster with modified DNS domain -- Px still deploys correctly, and no significant errors observed in operator's log.

Note also that the `plugin` [@.../component/plugin.go](https://github.com/libopenstorage/operator/blob/master/drivers/storage/portworx/component/plugin.go#L325) still uses the `.svc.cluster.local` default DNS domain
* this DNS-domain was not changed, since plugin works on OCP, and OCP does not offer modification of DNS-domain as a part of the install process