### PR TITLE
PWX-31769: Add validation test to operator for checking to make sure …

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -4238,6 +4238,7 @@ func ValidateTelemetryContainerOrchestrator(pxImageList map[string]string, clust
 
 	coStartTime, startErr := getCoStateTimeStamp(coStateDir + "/kvStart.ts")
 	if startErr != nil {
+		logrus.Errorf("error obtaining start time from costate file: %v\n", startErr)
 		return fmt.Errorf("container orchestrator validated failed, error obtaining start time from costate file")
 	}
 	logrus.Infof("container orchestrater server start time: %v", time.Unix(coStartTime, 0))
@@ -4258,8 +4259,8 @@ func ValidateTelemetryContainerOrchestrator(pxImageList map[string]string, clust
 
 	if setErr != nil && getErr != nil {
 		// No secret handler timestamp exists
-		logrus.Infof("error obtaining set time from costate file: %v\n", setErr)
-		logrus.Infof("error obtaining get time from costate file: %v\n", getErr)
+		logrus.Errorf("error obtaining set time from costate file: %v\n", setErr)
+		logrus.Errorf("error obtaining get time from costate file: %v\n", getErr)
 		return fmt.Errorf("container orchestrator validated failed, error obtaining costate file")
 	}
 

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -4376,9 +4376,12 @@ func ValidateTelemetryV2Enabled(pxImageList map[string]string, cluster *corev1.S
 		return fmt.Errorf("failed to find telemetry image version")
 	}
 
+	masterOpVersion, _ := version.NewVersion(PxOperatorMasterVersion)
 	opVersion, _ := GetPxOperatorVersion()
 	pxVersion := GetPortworxVersion(cluster)
-	if opVersion.GreaterThanOrEqual(OpVer23_10_3) && pxVersion.GreaterThanOrEqual(minimumPxVersionCO) && ccmGoVersion.GreaterThanOrEqual(minimumCcmGoVersionCO) { // Validate the versions
+
+	// NOTE: These versions will need to be updated when we move the CO code to a release. Currently its bound to master branches
+	if opVersion.GreaterThanOrEqual(masterOpVersion) && pxVersion.GreaterThanOrEqual(minimumPxVersionCO) && ccmGoVersion.GreaterThanOrEqual(minimumCcmGoVersionCO) { // Validate the versions
 		if err := ValidateTelemetryContainerOrchestrator(pxImageList, cluster, timeout, interval); err != nil {
 			return err
 		}


### PR DESCRIPTION
What this PR does / why we need it:

The container orchestrator is a PX component which saves/retrieves/deletes the telemetry registration certificate from the k8s secrets. The original ccm-go handled the registration certificate management and stored it directly into the k8s secrets on behalf of PX. However the new ccm-go removes that special PX secret handling and uses a GRPC api to access a server in PX which will handle the certificate secret management.

This PR provides the validation test for PX container orchestrator. Telemetry must be enabled and container orchestrator usage must be denoted in the spec. The test will check container orchestrator timestamp to determine if it was executed properly.

Which issue(s) this PR fixes (optional)
Closes #
PWX-31767

Special notes for your reviewer:
Test spreadsheet provided: https://portworx.atlassian.net/browse/PWX-31767
This change is dependent on Operator PR: https://github.com/libopenstorage/operator/pull/1394
This change is dependent on PX PR: https://github.com/portworx/porx/pull/12890
