### PR TITLE
PWX-35633 : Don't allow overriding storage PDB value to more than number of storagenodes

### DIFF
--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -107,17 +107,21 @@ func (c *disruptionBudget) createPortworxPodDisruptionBudget(
 	}
 
 	var minAvailable int
-	if err != nil || userProvidedMinValue < 0 {
-		c.sdkConn, err = pxutil.GetPortworxConn(c.sdkConn, c.k8sClient, cluster.Namespace)
-		if err != nil {
-			return err
-		}
+	c.sdkConn, err = pxutil.GetPortworxConn(c.sdkConn, c.k8sClient, cluster.Namespace)
+	if err != nil {
+		return err
+	}
 
-		storageNodesCount, err := pxutil.CountStorageNodes(cluster, c.sdkConn, c.k8sClient)
-		if err != nil {
-			c.closeSdkConn()
-			return err
-		}
+	storageNodesCount, err := pxutil.CountStorageNodes(cluster, c.sdkConn, c.k8sClient)
+	if err != nil {
+		c.closeSdkConn()
+		return err
+	}
+
+	// Set minAvailable value to storagenodes-1 if no value is provided,
+	// or if the user provided value is lesser than 0
+	// or greater than or equal to the number of storage nodes.
+	if userProvidedMinValue < 0 || userProvidedMinValue >= storageNodesCount {
 		minAvailable = storageNodesCount - 1
 	} else {
 		minAvailable = userProvidedMinValue

--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -122,6 +122,7 @@ func (c *disruptionBudget) createPortworxPodDisruptionBudget(
 	// or if the user provided value is lesser than 0
 	// or greater than or equal to the number of storage nodes.
 	if userProvidedMinValue < 0 || userProvidedMinValue >= storageNodesCount {
+		logrus.Warnf("Value for px-storage pod disruption budget not provided or is invalid, using default calculated value %d: ", storageNodesCount-1)
 		minAvailable = storageNodesCount - 1
 	} else {
 		minAvailable = userProvidedMinValue

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -12061,6 +12061,19 @@ func TestPodDisruptionBudgetEnabled(t *testing.T) {
 	require.Equal(t, 4, storagePDB.Spec.MinAvailable.IntValue())
 
 	// TestCase: Update storage PDB if overwritten using annotation
+	cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] = "3"
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	storagePDB = &policyv1.PodDisruptionBudget{}
+	err = testutil.Get(k8sClient, storagePDB, component.StoragePodDisruptionBudgetName, cluster.Namespace)
+	require.NoError(t, err)
+
+	require.Equal(t, 3, storagePDB.Spec.MinAvailable.IntValue())
+
+	// TestCase: Ignore annotation and go back to default PDB calculation
+	// if annotation value is greater than or equal to storagenodes
 	cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] = "10"
 
 	err = driver.PreInstall(cluster)
@@ -12070,7 +12083,7 @@ func TestPodDisruptionBudgetEnabled(t *testing.T) {
 	err = testutil.Get(k8sClient, storagePDB, component.StoragePodDisruptionBudgetName, cluster.Namespace)
 	require.NoError(t, err)
 
-	require.Equal(t, 10, storagePDB.Spec.MinAvailable.IntValue())
+	require.Equal(t, 4, storagePDB.Spec.MinAvailable.IntValue())
 
 	// TestCase: Use NonQuorumMember flag to determine storage node count
 	cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] = ""


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: As a part of PWX-34411, PDB value for px-storage can be overridden using an annotation, but when the value is greater than or equal to total storage nodes, it prevents upgrades from happening as allowed disruptions becomes 0. This PR ensures than if the annotation value is greater than or equal to total storage nodes, then the default calculation for pdb is used.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-35633

