### PR TITLE
PWX-35377 Update metrics collector version

### DIFF
--- a/deploy/ccm/metrics-collector-deployment.yaml
+++ b/deploy/ccm/metrics-collector-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       - env:
         - name: CONFIG
           value: config/portworx.yaml
-        image: purestorage/realtime-metrics:1.0.4
+        image: purestorage/realtime-metrics:1.0.23
         imagePullPolicy: Always
         name: collector
         resources:

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -433,7 +433,6 @@ func (t *telemetry) deleteCCMGoPhonehomeCluster(
 	return nil
 }
 
-// PWX-27401 only reconcile metrics collector if it's already running
 func (t *telemetry) shouldReconcileMetricsCollector(
 	cluster *corev1.StorageCluster,
 ) error {

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -142,10 +142,6 @@ func (t *telemetry) deployMetricsCollectorV1(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
-	if t.reconcileMetricsCollector == nil || !*t.reconcileMetricsCollector {
-		return nil
-	}
-
 	if err := t.createCollectorServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -48,7 +48,7 @@ const (
 	defaultCollectorProxyImage = "envoyproxy/envoy:v1.21.4"
 
 	defaultCCMGoImage       = "purestorage/ccm-go:1.0.3"
-	defaultCollectorImage   = "purestorage/realtime-metrics:1.0.15"
+	defaultCollectorImage   = "purestorage/realtime-metrics:1.0.23"
 	defaultCCMGoProxyImage  = "purestorage/telemetry-envoy:1.1.6"
 	defaultLogUploaderImage = "purestorage/log-upload:px-1.0.12"
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
In master, we already reconcile the metrics collector.

This PR
- Remove the reconcile checks for metrics collector
- Updates the metrics collector to the latest version.

**Which issue(s) this PR fixes** (optional)
PWX-35377

**Special notes for your reviewer**:

Testing note:

Used local cluster with custom operator image. It successfully created the px-telemetry-metrics-collector pod and has logs with success upload below:
```
{"bytes":3431,"level":"info","metrics_identifier":"portworx","msg":"Forwarding complete","package":"forwarder","response":"{\"context\":{\"request_uuid\":\"a652d72a-938a-4d9a-80b9-494d92a6609c\",\"product_name\":\"portworx\",\"appliance_id\":\"8afc048e-1818-4b17-a41c-0923f49ac2de\",\"component_sn\":\"portworx-metrics-node\"},\"response\":[\"Metrics upload success\"]}","service":"pure1-metrics-collector","status_code":200,"time":"2024-02-26T23:54:49Z"}
```

