### PR TITLE
Support OCP prometheus for OCP versions GTE 4.12

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -4607,7 +4607,7 @@ func TestIsUserWorkloadSupportedForSupportedVersionOpenshift(t *testing.T) {
 
 }
 
-// test if install can be enabled on 4.13 version of openshift for AutoPilot
+// test if install can be enabled on 4.11 version of openshift for AutoPilot
 func TestIsUserWorkloadSupportedForUnsupportedVersionOpenshift(t *testing.T) {
 	versionClient := fakek8sclient.NewSimpleClientset()
 	versionClient.Resources = []*metav1.APIResourceList{
@@ -4634,7 +4634,7 @@ func TestIsUserWorkloadSupportedForUnsupportedVersionOpenshift(t *testing.T) {
 			Versions: []ocpconfig.OperandVersion{
 				{
 					Name:    component.OpenshiftAPIServer,
-					Version: "4.13",
+					Version: "4.11",
 				},
 			},
 		},
@@ -4647,6 +4647,7 @@ func TestIsUserWorkloadSupportedForUnsupportedVersionOpenshift(t *testing.T) {
 	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
 	require.NoError(t, err)
 
+	// from operator 23.10.4, openshift prometheus will be supported on OCP versions GTE 4.12
 	enabled, err := pxutil.IsSupportedOCPVersion(k8sClient, pxutil.OpenshiftPrometheusSupportedVersion)
 	require.Equal(t, false, enabled)
 	require.NoError(t, err)

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2703,7 +2703,7 @@ func TestStorageClusterDefaultsForAutopilot(t *testing.T) {
 	require.Equal(t, "prometheus", providers[0].Type)
 	require.Equal(t, component.AutopilotDefaultProviderEndpoint, providers[0].Params["url"])
 
-	// Do not set the default provider if OCP > 4.14 and we fail to get the Prometheus endpoint
+	// Do not set the default provider if OCP > 4.12 and we fail to get the Prometheus endpoint
 	operator := &ocpconfig.ClusterOperator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: component.OpenshiftAPIServer,
@@ -2727,7 +2727,7 @@ func TestStorageClusterDefaultsForAutopilot(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cluster.Spec.Autopilot.Providers)
 
-	// Set the default provider for OCP prometheus for OCP > 4.14 if Prometheus endpoint is found
+	// Set the default provider for OCP prometheus for OCP > 4.12 if Prometheus endpoint is found
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pxutil.OpenshiftMonitoringRouteName,
@@ -3226,7 +3226,7 @@ func TestStorageClusterDefaultsForPrometheus(t *testing.T) {
 	require.Empty(t, cluster.Status.DesiredImages.PrometheusConfigReloader)
 	require.Empty(t, cluster.Status.DesiredImages.PrometheusConfigMapReload)
 
-	// Disable prometheus on new install for OCP 4.14+, even if set by the user
+	// Disable prometheus on new install for OCP 4.12+, even if set by the user
 	operator := &ocpconfig.ClusterOperator{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: component.OpenshiftAPIServer,

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -3253,7 +3253,7 @@ func TestStorageClusterDefaultsForPrometheus(t *testing.T) {
 	require.NotEmpty(t, recorder.Events)
 	require.Contains(t, <-recorder.Events,
 		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedComponentReason,
-			"Disabling Portworx managed Prometheus in lieu of OpenShift managed Prometheus starting OpenShift 4.14"))
+			"Disabling Portworx managed Prometheus in lieu of OpenShift managed Prometheus starting OpenShift 4.12"))
 
 	// Do not disable prometheus on existing install if set by the user
 	cluster.Spec.Monitoring.Prometheus.Enabled = true

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -260,7 +260,7 @@ const (
 	ClusterOperatorVersion              = "config.openshift.io/v1"
 	ClusterOperatorKind                 = "ClusterOperator"
 	OpenshiftAPIServer                  = "openshift-apiserver"
-	OpenshiftPrometheusSupportedVersion = "4.14"
+	OpenshiftPrometheusSupportedVersion = "4.12"
 	// OpenshiftMonitoringRouteName name of OCP user-workload route
 	OpenshiftMonitoringRouteName = "thanos-querier"
 	// OpenshiftMonitoringRouteName namespace of OCP user-workload route


### PR DESCRIPTION
**What this PR does / why we need it**: This PR is to add support for Openshift Prometheus with Portworx on Redhat Versions greater or equal 4.12. Currently, this is supported on minimum OCP version 4.14.

**Which issue(s) this PR fixes** (optional)
Closes #  https://portworx.atlassian.net/browse/PWX-36274

