### PR TITLE
PWX-35007, PWX-35008 _rel-24.1.0: kube-scheduler image updates (#1376)

### DIFF
--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -312,11 +312,7 @@ func (c *pvcController) createDeployment(
 		return err
 	}
 
-	imageName := "gcr.io/google_containers/kube-controller-manager-amd64"
-	if k8sutil.IsNewKubernetesRegistry(&c.k8sVersion) {
-		imageName = k8sutil.DefaultK8SRegistryPath + "/kube-controller-manager-amd64"
-	}
-	imageName = imageName + ":v" + c.k8sVersion.String()
+	imageName := k8sutil.GetDefaultKubeControllerManagerImage(&c.k8sVersion)
 	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.KubeControllerManager != "" {
 		imageName = cluster.Status.DesiredImages.KubeControllerManager
 	}

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -239,10 +239,12 @@ func defaultRelease(
 			DynamicPluginProxy: DefaultDynamicPluginProxyImage,
 		},
 	}
+	fillStorkDefaults(rel, k8sVersion)
 	fillCSIDefaults(rel, k8sVersion)
 	fillPrometheusDefaults(rel, k8sVersion)
 	fillGrafanaDefaults(rel, k8sVersion)
 	fillTelemetryDefaults(rel)
+	fillK8sDefaults(rel, k8sVersion)
 	return rel
 }
 
@@ -250,9 +252,6 @@ func fillDefaults(
 	rel *Version,
 	k8sVersion *version.Version,
 ) {
-	if rel.Components.Stork == "" {
-		rel.Components.Stork = defaultStorkImage
-	}
 	if rel.Components.Autopilot == "" {
 		rel.Components.Autopilot = defaultAutopilotImage
 	}
@@ -269,11 +268,38 @@ func fillDefaults(
 	if rel.Components.DynamicPluginProxy == "" {
 		rel.Components.DynamicPluginProxy = DefaultDynamicPluginProxyImage
 	}
-
+	fillStorkDefaults(rel, k8sVersion)
 	fillCSIDefaults(rel, k8sVersion)
 	fillPrometheusDefaults(rel, k8sVersion)
 	fillGrafanaDefaults(rel, k8sVersion)
 	fillTelemetryDefaults(rel)
+	fillK8sDefaults(rel, k8sVersion)
+}
+
+func fillStorkDefaults(
+	rel *Version,
+	k8sVersion *version.Version,
+) {
+	if rel.Components.Stork == "" {
+		rel.Components.Stork = defaultStorkImage
+	}
+
+	if rel.Components.KubeScheduler == "" {
+		rel.Components.KubeScheduler = k8sutil.GetDefaultKubeSchedulerImage(k8sVersion)
+	}
+}
+
+func fillK8sDefaults(
+	rel *Version,
+	k8sVersion *version.Version,
+) {
+	if rel.Components.KubeControllerManager == "" {
+		rel.Components.KubeControllerManager = k8sutil.GetDefaultKubeControllerManagerImage(k8sVersion)
+	}
+
+	if rel.Components.Pause == "" {
+		rel.Components.Pause = pxutil.ImageNamePause
+	}
 }
 
 func fillCSIDefaults(

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -43,6 +43,9 @@ func TestManifestWithNewerPortworxVersion(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			KubeScheduler:             "gcr.io/google_containers/kube-scheduler-amd64:v1.15.0",
+			KubeControllerManager:     "gcr.io/google_containers/kube-controller-manager-amd64:v1.15.0",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -83,6 +86,7 @@ func TestManifestWithNewerPortworxVersionAndConfigMapPresent(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 
@@ -175,6 +179,7 @@ func TestManifestWithOlderPortworxVersion(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -267,6 +272,9 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			KubeScheduler:             "gcr.io/google_containers/kube-scheduler-amd64:v1.15.0",
+			KubeControllerManager:     "gcr.io/google_containers/kube-controller-manager-amd64:v1.15.0",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -389,6 +397,7 @@ func TestManifestWithoutPortworxVersion(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	cluster := &corev1.StorageCluster{

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -385,6 +385,9 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
 			toUpdate.Status.DesiredImages.Stork = release.Components.Stork
+			if toUpdate.Status.DesiredImages.KubeScheduler == "" {
+				toUpdate.Status.DesiredImages.KubeScheduler = release.Components.KubeScheduler
+			}
 		}
 
 		if autoUpdateAutopilot(toUpdate) &&
@@ -494,7 +497,6 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			releaseImage string
 		}{
 			{&toUpdate.Status.DesiredImages.KubeControllerManager, release.Components.KubeControllerManager},
-			{&toUpdate.Status.DesiredImages.KubeScheduler, release.Components.KubeScheduler},
 			{&toUpdate.Status.DesiredImages.Pause, release.Components.Pause},
 		}
 		for _, v := range imagesData {
@@ -513,6 +515,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 
 	if !autoUpdateStork(toUpdate) {
 		toUpdate.Status.DesiredImages.Stork = ""
+		toUpdate.Status.DesiredImages.KubeScheduler = ""
 	}
 
 	if !autoUpdateAutopilot(toUpdate) {

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -104,10 +104,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 
 	require.NoError(t, err)
 
-	k8sMinVersionForKubeSchedulerConfiguration, err := version.NewVersion(minK8sVersionForKubeSchedulerConfiguration)
-	require.NoError(t, err)
-
-	if k8sVersion.GreaterThanOrEqual(k8sMinVersionForKubeSchedulerConfiguration) {
+	if k8sVersion.GreaterThanOrEqual(k8s.MinVersionForKubeSchedulerConfiguration) {
 		// Stork ConfigMap
 		leaderElect := true
 		schedulerName := storkDeploymentName
@@ -313,7 +310,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 	require.Equal(t, expectedStorkDeployment.Spec, storkDeployment.Spec)
 
 	// Sched Scheduler Deployment
-	if k8sVersion.GreaterThanOrEqual(k8sMinVersionForKubeSchedulerConfiguration) {
+	if k8sVersion.GreaterThanOrEqual(k8s.MinVersionForKubeSchedulerConfiguration) {
 		expectedSchedDeployment := testutil.GetExpectedDeployment(t, "storkSchedKubeSchedConfigDeployment.yaml")
 		schedDeployment := &appsv1.Deployment{}
 		err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
@@ -327,7 +324,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 		schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 		require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
 		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
-			expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minK8sVersionForKubeSchedulerConfiguration, k8sVersionStr, -1)
+			expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, k8s.MinVersionForKubeSchedulerConfiguration.String(), k8sVersionStr, -1)
 		require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
 	} else {
 		expectedSchedDeployment := testutil.GetExpectedDeployment(t, "storkSchedDeployment.yaml")
@@ -496,7 +493,7 @@ func TestStorkSchedulerK8SVersions(t *testing.T) {
 	schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 	require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
 	expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
-		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minK8sVersionForKubeSchedulerConfiguration, k8sVersionStr, -1)
+		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, k8s.MinVersionForKubeSchedulerConfiguration.String(), k8sVersionStr, -1)
 	require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
 
 	k8sVersionStr = "1.25.0"
@@ -515,7 +512,7 @@ func TestStorkSchedulerK8SVersions(t *testing.T) {
 	schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 	require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
 	expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
-		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minK8sVersionForKubeSchedulerConfiguration, k8sVersionStr, -1)
+		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, k8s.MinVersionForKubeSchedulerConfiguration.String(), k8sVersionStr, -1)
 	require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
 }
 

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -70,6 +70,10 @@ var (
 
 	// ErrDoSkipUpdate used by update callback functions, to skip the StorageCluster updates
 	ErrDoSkipUpdate = fmt.Errorf("update skipped")
+	// K8sVer1_26 k8s 1.26
+	K8sVer1_26, _ = version.NewVersion("1.26")
+	// MinVersionForKubeSchedulerConfiguration k8s 1.23.0
+	MinVersionForKubeSchedulerConfiguration, _ = version.NewVersion("1.23.0")
 )
 
 // NewK8sClient returns a new controller runtime Kubernetes client
@@ -2320,4 +2324,34 @@ func AddManagedByOperatorLabel(om metav1.ObjectMeta) metav1.ObjectMeta {
 	}
 	om.Labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
 	return om
+}
+
+func GetDefaultKubeControllerManagerImage(k8sVersion *version.Version) string {
+	if k8sVersion == nil {
+		return ""
+	}
+	prefix := "gcr.io/google_containers"
+	if IsNewKubernetesRegistry(k8sVersion) {
+		prefix = DefaultK8SRegistryPath
+	}
+	return prefix + "/kube-controller-manager-amd64:v" + k8sVersion.String()
+}
+
+func GetDefaultKubeSchedulerImage(k8sVersion *version.Version) string {
+	if k8sVersion == nil {
+		return ""
+	}
+	minVersionForPinnedStorkScheduler, _ := version.NewVersion("1.22.0")
+	prefix := "gcr.io/google_containers"
+	if IsNewKubernetesRegistry(k8sVersion) {
+		prefix = DefaultK8SRegistryPath
+	}
+	prefix += "/kube-scheduler-amd64:v"
+
+	if k8sVersion.GreaterThanOrEqual(minVersionForPinnedStorkScheduler) &&
+		k8sVersion.LessThan(MinVersionForKubeSchedulerConfiguration) {
+		// Stork scheduler cannot run with kube-scheduler image > v1.22
+		return prefix + "1.21.4"
+	}
+	return prefix + k8sVersion.String()
 }


### PR DESCRIPTION

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1376 into `release-24.1.0` branch

**Which issue(s) this PR fixes** (optional)
PWX-35007, PWX-35008  (rel-24.1.0)

**Special notes for your reviewer**:

