### PR TITLE
PWX-35007, PWX-35008 _rel-23.10.4: kube-scheduler image updates (#1376)

### DIFF
--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -303,11 +303,7 @@ func (c *pvcController) createDeployment(
 		return err
 	}
 
-	imageName := "gcr.io/google_containers/kube-controller-manager-amd64"
-	if k8sutil.IsNewKubernetesRegistry(&c.k8sVersion) {
-		imageName = k8sutil.DefaultK8SRegistryPath + "/kube-controller-manager-amd64"
-	}
-	imageName = imageName + ":v" + c.k8sVersion.String()
+	imageName := k8sutil.GetDefaultKubeControllerManagerImage(&c.k8sVersion)
 	if cluster.Status.DesiredImages != nil && cluster.Status.DesiredImages.KubeControllerManager != "" {
 		imageName = cluster.Status.DesiredImages.KubeControllerManager
 	}

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -239,10 +239,12 @@ func defaultRelease(
 			DynamicPluginProxy: DefaultDynamicPluginProxyImage,
 		},
 	}
+	fillStorkDefaults(rel, k8sVersion)
 	fillCSIDefaults(rel, k8sVersion)
 	fillPrometheusDefaults(rel, k8sVersion)
 	fillGrafanaDefaults(rel, k8sVersion)
 	fillTelemetryDefaults(rel)
+	fillK8sDefaults(rel, k8sVersion)
 	return rel
 }
 
@@ -250,9 +252,6 @@ func fillDefaults(
 	rel *Version,
 	k8sVersion *version.Version,
 ) {
-	if rel.Components.Stork == "" {
-		rel.Components.Stork = defaultStorkImage
-	}
 	if rel.Components.Autopilot == "" {
 		rel.Components.Autopilot = defaultAutopilotImage
 	}
@@ -269,11 +268,38 @@ func fillDefaults(
 	if rel.Components.DynamicPluginProxy == "" {
 		rel.Components.DynamicPluginProxy = DefaultDynamicPluginProxyImage
 	}
-
+	fillStorkDefaults(rel, k8sVersion)
 	fillCSIDefaults(rel, k8sVersion)
 	fillPrometheusDefaults(rel, k8sVersion)
 	fillGrafanaDefaults(rel, k8sVersion)
 	fillTelemetryDefaults(rel)
+	fillK8sDefaults(rel, k8sVersion)
+}
+
+func fillStorkDefaults(
+	rel *Version,
+	k8sVersion *version.Version,
+) {
+	if rel.Components.Stork == "" {
+		rel.Components.Stork = defaultStorkImage
+	}
+
+	if rel.Components.KubeScheduler == "" {
+		rel.Components.KubeScheduler = k8sutil.GetDefaultKubeSchedulerImage(k8sVersion)
+	}
+}
+
+func fillK8sDefaults(
+	rel *Version,
+	k8sVersion *version.Version,
+) {
+	if rel.Components.KubeControllerManager == "" {
+		rel.Components.KubeControllerManager = k8sutil.GetDefaultKubeControllerManagerImage(k8sVersion)
+	}
+
+	if rel.Components.Pause == "" {
+		rel.Components.Pause = pxutil.ImageNamePause
+	}
 }
 
 func fillCSIDefaults(

--- a/drivers/storage/portworx/manifest/manifest_test.go
+++ b/drivers/storage/portworx/manifest/manifest_test.go
@@ -43,6 +43,9 @@ func TestManifestWithNewerPortworxVersion(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			KubeScheduler:             "gcr.io/google_containers/kube-scheduler-amd64:v1.15.0",
+			KubeControllerManager:     "gcr.io/google_containers/kube-controller-manager-amd64:v1.15.0",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -83,6 +86,7 @@ func TestManifestWithNewerPortworxVersionAndConfigMapPresent(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 
@@ -175,6 +179,7 @@ func TestManifestWithOlderPortworxVersion(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -267,6 +272,9 @@ func TestManifestWithKnownNonSemvarPortworxVersion(t *testing.T) {
 			MetricsCollector:          "purestorage/realtime-metrics:1.0.1",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			KubeScheduler:             "gcr.io/google_containers/kube-scheduler-amd64:v1.15.0",
+			KubeControllerManager:     "gcr.io/google_containers/kube-controller-manager-amd64:v1.15.0",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	httpGet = func(url string) (*http.Response, error) {
@@ -389,6 +397,7 @@ func TestManifestWithoutPortworxVersion(t *testing.T) {
 			MetricsCollectorProxy:     "envoyproxy/envoy:v1.21.4",
 			DynamicPlugin:             "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:        "nginxinc/nginx-unprivileged:1.23",
+			Pause:                     "registry.k8s.io/pause:3.1",
 		},
 	}
 	cluster := &corev1.StorageCluster{

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -385,6 +385,9 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
 			toUpdate.Status.DesiredImages.Stork = release.Components.Stork
+			if toUpdate.Status.DesiredImages.KubeScheduler == "" {
+				toUpdate.Status.DesiredImages.KubeScheduler = release.Components.KubeScheduler
+			}
 		}
 
 		if autoUpdateAutopilot(toUpdate) &&
@@ -494,7 +497,6 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			releaseImage string
 		}{
 			{&toUpdate.Status.DesiredImages.KubeControllerManager, release.Components.KubeControllerManager},
-			{&toUpdate.Status.DesiredImages.KubeScheduler, release.Components.KubeScheduler},
 			{&toUpdate.Status.DesiredImages.Pause, release.Components.Pause},
 		}
 		for _, v := range imagesData {
@@ -513,6 +515,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 
 	if !autoUpdateStork(toUpdate) {
 		toUpdate.Status.DesiredImages.Stork = ""
+		toUpdate.Status.DesiredImages.KubeScheduler = ""
 	}
 
 	if !autoUpdateAutopilot(toUpdate) {

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2106,8 +2106,16 @@ func TestStorageClusterDefaultsForAutopilot(t *testing.T) {
 }
 
 func TestStorageClusterDefaultsForStork(t *testing.T) {
-	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	versionClient := fakek8sclient.NewSimpleClientset()
+	coreops.SetInstance(coreops.New(versionClient))
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{
+		GitVersion: "v1.28.0",
+	}
+	k8sClient := testutil.FakeK8sClient()
 	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
 	cluster := &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "px-cluster",
@@ -2119,7 +2127,7 @@ func TestStorageClusterDefaultsForStork(t *testing.T) {
 	}
 
 	// Stork should be enabled by default
-	err := driver.SetDefaultsOnStorageCluster(cluster)
+	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 	require.True(t, cluster.Spec.Stork.Enabled)
 
@@ -2134,6 +2142,7 @@ func TestStorageClusterDefaultsForStork(t *testing.T) {
 	require.Empty(t, cluster.Spec.Stork.Image)
 	require.False(t, cluster.Spec.Stork.LockImage)
 	require.Empty(t, cluster.Status.DesiredImages.Stork)
+	require.Empty(t, cluster.Status.DesiredImages.KubeScheduler)
 
 	// Use image from release manifest if no image present
 	cluster.Spec.Stork = &corev1.StorkSpec{
@@ -2143,6 +2152,10 @@ func TestStorageClusterDefaultsForStork(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cluster.Spec.Stork.Image)
 	require.Equal(t, "openstorage/stork:"+compVersion(), cluster.Status.DesiredImages.Stork)
+	require.Equal(t, "registry.k8s.io/kube-scheduler-amd64:v1.28.0",
+		cluster.Status.DesiredImages.KubeScheduler)
+	require.Equal(t, "registry.k8s.io/kube-controller-manager-amd64:v1.28.0",
+		cluster.Status.DesiredImages.KubeControllerManager)
 
 	// Use given spec image if specified and reset desired image in status
 	cluster.Spec.Stork = &corev1.StorkSpec{
@@ -10148,6 +10161,8 @@ func (m *fakeManifest) GetVersions(
 			TelemetryProxy:             "purestorage/envoy:1.2.3",
 			DynamicPlugin:              "portworx/portworx-dynamic-plugin:1.1.0",
 			DynamicPluginProxy:         "nginxinc/nginx-unprivileged:1.23",
+			KubeScheduler:              k8sutil.GetDefaultKubeSchedulerImage(m.k8sVersion),
+			KubeControllerManager:      k8sutil.GetDefaultKubeControllerManagerImage(m.k8sVersion),
 		},
 	}
 	if m.k8sVersion != nil && m.k8sVersion.GreaterThanOrEqual(k8sutil.K8sVer1_22) {

--- a/pkg/controller/storagecluster/stork_test.go
+++ b/pkg/controller/storagecluster/stork_test.go
@@ -106,12 +106,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 
 	require.NoError(t, err)
 
-	k8sMinVersionForKubeSchedulerV1Configuration, err := version.NewVersion(minK8sVersionForKubeSchedulerV1Configuration)
-	require.NoError(t, err)
-	k8sMinVersionForKubeSchedulerV1BetaConfiguration, err := version.NewVersion(minK8sVersionForKubeSchedulerV1BetaConfiguration)
-	require.NoError(t, err)
-
-	if k8sVersion.GreaterThanOrEqual(k8sMinVersionForKubeSchedulerV1BetaConfiguration) {
+	if k8sVersion.GreaterThanOrEqual(k8s.MinVersionForKubeSchedulerV1BetaConfiguration) {
 		// Stork ConfigMap
 		leaderElect := true
 		schedulerName := storkDeploymentName
@@ -132,7 +127,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 		require.Len(t, storkConfigMap.OwnerReferences, 1)
 		require.Equal(t, cluster.Name, storkConfigMap.OwnerReferences[0].Name)
 
-		if k8sVersion.GreaterThanOrEqual(k8sMinVersionForKubeSchedulerV1Configuration) {
+		if k8sVersion.GreaterThanOrEqual(k8s.MinVersionForKubeSchedulerV1Configuration) {
 			expectedKubeSchedulerConfiguration := schedconfig.KubeSchedulerConfiguration{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "KubeSchedulerConfiguration",
@@ -354,7 +349,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 	require.Equal(t, expectedStorkDeployment.Spec, storkDeployment.Spec)
 
 	// Sched Scheduler Deployment
-	if k8sVersion.GreaterThanOrEqual(k8sMinVersionForKubeSchedulerV1BetaConfiguration) {
+	if k8sVersion.GreaterThanOrEqual(k8s.MinVersionForKubeSchedulerV1BetaConfiguration) {
 		expectedSchedDeployment := testutil.GetExpectedDeployment(t, "storkSchedKubeSchedConfigDeployment.yaml")
 		schedDeployment := &appsv1.Deployment{}
 		err = testutil.Get(k8sClient, schedDeployment, storkSchedDeploymentName, cluster.Namespace)
@@ -368,7 +363,7 @@ func testStorkInstallation(t *testing.T, k8sVersionStr string) {
 		schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 		require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
 		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
-			expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minK8sVersionForKubeSchedulerV1BetaConfiguration, k8sVersionStr, -1)
+			expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, k8s.MinVersionForKubeSchedulerV1BetaConfiguration.String(), k8sVersionStr, -1)
 		require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
 	} else {
 		expectedSchedDeployment := testutil.GetExpectedDeployment(t, "storkSchedDeployment.yaml")
@@ -537,7 +532,7 @@ func TestStorkSchedulerK8SVersions(t *testing.T) {
 	schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 	require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
 	expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
-		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minK8sVersionForKubeSchedulerV1BetaConfiguration, k8sVersionStr, -1)
+		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, k8s.MinVersionForKubeSchedulerV1BetaConfiguration.String(), k8sVersionStr, -1)
 	require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
 
 	k8sVersionStr = "1.25.0"
@@ -556,7 +551,7 @@ func TestStorkSchedulerK8SVersions(t *testing.T) {
 	schedDeployment.Spec.Template.Spec.Containers[0].Resources.Requests = nil
 	require.Equal(t, expectedSchedDeployment.Labels, schedDeployment.Labels)
 	expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image = strings.Replace(
-		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, minK8sVersionForKubeSchedulerV1BetaConfiguration, k8sVersionStr, -1)
+		expectedSchedDeployment.Spec.Template.Spec.Containers[0].Image, k8s.MinVersionForKubeSchedulerV1BetaConfiguration.String(), k8sVersionStr, -1)
 	require.Equal(t, expectedSchedDeployment.Spec, schedDeployment.Spec)
 }
 


### PR DESCRIPTION
* PWX-35007: kube-scheduler image handling fix

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

Manually fixed Conflicts:
	drivers/storage/portworx/manifest/manifest.go
	drivers/storage/portworx/manifest/manifest_test.go
	drivers/storage/portworx/portworx_test.go
	pkg/controller/storagecluster/stork.go
	pkg/controller/storagecluster/stork_test.go
	pkg/util/k8s/k8s.go

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1376 into `release-23.10.4` branch

**Which issue(s) this PR fixes** (optional)

PWX-35007, PWX-35008  (rel-23.10.4)

**Special notes for your reviewer**:

