### PR TITLE
Support Openshift Prometheus on OCP 4.15

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -47,8 +47,10 @@ const (
 	AutopilotDefaultProviderEndpoint = "http://px-prometheus:9090"
 	// AutopilotDefaultReviewersKey is a key for default reviewers array in gitops config map
 	AutopilotDefaultReviewersKey = "defaultReviewers"
-	// OCPPrometheusUserWorkloadSecretPrefix name of OCP user-workload Prometheus secret
+	// OCPPrometheusUserWorkloadSecretPrefix name of OCP user-workload Prometheus secret for OCP < 4.15
 	OCPPrometheusUserWorkloadSecretPrefix = "prometheus-user-workload-token"
+	// OCPThanosRulerSecretPrefix name of OCP thanos-ruler secret for OCP 4.15+
+	OCPThanosRulerSecretPrefix = "thanos-ruler-token"
 	// Autopilot Secret name for prometheus-user-workload-token
 	AutopilotSecretName = "autopilot-prometheus-auth"
 	defaultAutopilotCPU = "0.1"
@@ -773,6 +775,18 @@ func (c *autopilot) isAutopilotSecretCreated(namespace string) bool {
 }
 
 func (c *autopilot) getPrometheusTokenAndCert() (encodedToken, caCert string, err error) {
+
+	var secretName string
+	ocp_415, err := pxutil.IsSupportedOCPVersion(c.k8sClient, pxutil.Openshift_4_15_Version)
+	if err != nil {
+		return "", "", err
+	}
+	if ocp_415 {
+		secretName = OCPThanosRulerSecretPrefix
+	} else {
+		secretName = OCPPrometheusUserWorkloadSecretPrefix
+	}
+
 	secrets := &v1.SecretList{}
 	err = c.k8sClient.List(
 		context.TODO(),
@@ -788,7 +802,7 @@ func (c *autopilot) getPrometheusTokenAndCert() (encodedToken, caCert string, er
 	var secretFound bool
 	for _, secret := range secrets.Items {
 
-		if strings.HasPrefix(secret.Name, OCPPrometheusUserWorkloadSecretPrefix) {
+		if strings.HasPrefix(secret.Name, secretName) {
 			secretFound = true
 			// Retrieve the token data from the secret as []byte
 			tokenBytes, ok := secret.Data["token"]

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -5264,6 +5264,185 @@ func TestAutopilotProviderURLOnOCP414(t *testing.T) {
 
 }
 
+// test Autopilot install and Uninstall on ocp cluster 4.15
+func TestAutopilotInstallAndUninstallOnOpenshift415(t *testing.T) {
+
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: component.ClusterOperatorVersion,
+			APIResources: []metav1.APIResource{
+				{
+					Kind: component.ClusterOperatorKind,
+				},
+			},
+		},
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+
+	reregisterComponents()
+	operator := &ocpconfig.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: component.OpenshiftAPIServer,
+		},
+		Status: ocpconfig.ClusterOperatorStatus{
+			RelatedObjects: []ocpconfig.ObjectReference{
+				{Name: component.OpenshiftAPIServer},
+			},
+			Versions: []ocpconfig.OperandVersion{
+				{
+					Name:    component.OpenshiftAPIServer,
+					Version: "4.15",
+				},
+			},
+		},
+	}
+	k8sClient := testutil.FakeK8sClient()
+	err := k8sClient.Create(context.TODO(), operator)
+	require.NoError(t, err)
+
+	driver := portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	stcSpec := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "true",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Monitoring: &corev1.MonitoringSpec{Telemetry: &corev1.TelemetrySpec{}},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: true,
+				Image:   "portworx/autopilot:1.1.1",
+				Providers: []corev1.DataProviderSpec{
+					{
+						Name: "default",
+						Type: "prometheus",
+						Params: map[string]string{
+							"url": "http://prometheus:9090",
+						},
+					},
+					{
+						Name: "second",
+						Type: "datadog",
+						Params: map[string]string{
+							"url":  "http://datadog:9090",
+							"auth": "foobar",
+						},
+					},
+				},
+				GitOps: &corev1.GitOpsSpec{
+					Name: "test",
+					Type: "bitbucket-scm",
+					Params: map[string]interface{}{
+						"defaultReviewers": []interface{}{"user1", "user2"},
+						"user":             "oksana",
+						"repo":             "autopilot-bb",
+						"folder":           "workloads",
+						"baseUrl":          "http://10.13.108.10:7990",
+						"projectKey":       "PXAUT",
+						"branch":           "master",
+					},
+				},
+				Args: map[string]string{
+					"min_poll_interval": "4",
+					"log-level":         "info",
+				},
+			},
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					SelfSigned: &corev1.SelfSignedSpec{
+						Issuer:        stringPtr(defaultSelfSignedIssuer),
+						TokenLifetime: stringPtr(defaultTokenLifetime),
+						SharedSecret:  stringPtr(pxutil.SecurityPXSharedSecretSecretName),
+					},
+				},
+			},
+		},
+	}
+
+	cluster := stcSpec.DeepCopy()
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	// on OCP 4.15+ , thanos-ruler-token secret will be used for certificate and token
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "thanos-ruler-token-abcd",
+			Namespace: "openshift-user-workload-monitoring",
+		},
+		Data: map[string][]byte{
+			"token":  []byte("dG9rZW4tdmFsdWU="),
+			"ca.crt": []byte("Y2VydGlmaWNhdGUtdmFsdWU="),
+		},
+	}
+
+	err = k8sClient.Create(context.TODO(), secret)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Autopilot ConfigMap
+	expectedConfigMap := testutil.GetExpectedConfigMap(t, "autopilotConfigMap.yaml")
+	autopilotConfigMap := &v1.ConfigMap{}
+	err = testutil.Get(k8sClient, autopilotConfigMap, component.AutopilotConfigMapName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedConfigMap.Name, autopilotConfigMap.Name)
+	require.Equal(t, expectedConfigMap.Namespace, autopilotConfigMap.Namespace)
+	require.Len(t, autopilotConfigMap.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, autopilotConfigMap.OwnerReferences[0].Name)
+	require.Equal(t, expectedConfigMap.Data, autopilotConfigMap.Data)
+
+	// Autopilot ServiceAccount
+	sa := &v1.ServiceAccount{}
+	err = testutil.Get(k8sClient, sa, component.AutopilotServiceAccountName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, component.AutopilotServiceAccountName, sa.Name)
+	require.Equal(t, cluster.Namespace, sa.Namespace)
+	require.Len(t, sa.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, sa.OwnerReferences[0].Name)
+
+	// Autopilot ClusterRoleBinding
+	expectedCRB := testutil.GetExpectedClusterRoleBinding(t, "autopilotClusterRoleBinding.yaml")
+	actualCRB := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, actualCRB, component.AutopilotClusterRoleBindingName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedCRB.Name, actualCRB.Name)
+	require.Empty(t, actualCRB.OwnerReferences)
+	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
+	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
+
+	// Autopilot Secret
+	expectedSecret := testutil.GetExpectedSecret(t, "autopilot-auth-token-secret.yaml")
+	actualSecret := &v1.Secret{}
+	err = testutil.Get(k8sClient, actualSecret, component.AutopilotSecretName, cluster.Namespace)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedSecret.Data, actualSecret.Data)
+
+	// Autopilot Deployment
+	expectedDeployment := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_14.yaml")
+	autopilotDeployment := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedDeployment.Spec.Template.Spec.Volumes, autopilotDeployment.Spec.Template.Spec.Volumes)
+	require.Equal(t, expectedDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts)
+
+	autopilotComponent, _ := component.Get(component.AutopilotComponentName)
+	err = autopilotComponent.Delete(cluster)
+	autopilotComponent.MarkDeleted()
+	require.NoError(t, err)
+
+}
+
 func TestSecurityInstall(t *testing.T) {
 	// auth enabled through security.enabled
 	cluster := &corev1.StorageCluster{

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1853,5 +1853,5 @@ func isVersionSupported(current, target string) bool {
 		return false
 	}
 
-	return currentVersion.GreaterThanOrEqual(targetVersion)
+	return currentVersion.Core().GreaterThanOrEqual(targetVersion)
 }

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -261,6 +261,7 @@ const (
 	ClusterOperatorKind                 = "ClusterOperator"
 	OpenshiftAPIServer                  = "openshift-apiserver"
 	OpenshiftPrometheusSupportedVersion = "4.12"
+	Openshift_4_15_Version              = "4.15"
 	// OpenshiftMonitoringRouteName name of OCP user-workload route
 	OpenshiftMonitoringRouteName = "thanos-querier"
 	// OpenshiftMonitoringRouteName namespace of OCP user-workload route

--- a/drivers/storage/portworx/util/util_test.go
+++ b/drivers/storage/portworx/util/util_test.go
@@ -724,3 +724,23 @@ func TestAppendUserVolumeMounts(t *testing.T) {
 	assert.Equal(t, podSpecReference.Containers[0].VolumeMounts[1].MountPath, podSpec.Containers[0].VolumeMounts[1].MountPath)
 	assert.Equal(t, podSpecReference.Containers[0].VolumeMounts[2].MountPath, podSpec.Containers[0].VolumeMounts[2].MountPath)
 }
+
+func TestIsVersionSupported(t *testing.T) {
+	supported := isVersionSupported("4.12.0", "4.15.0")
+	require.False(t, supported)
+
+	supported = isVersionSupported("4.14.1-beta.1", "4.15.0")
+	require.False(t, supported)
+
+	supported = isVersionSupported("4.15.0", "4.15.0")
+	require.True(t, supported)
+
+	supported = isVersionSupported("4.15.0-rc.5", "4.15.0")
+	require.True(t, supported)
+
+	supported = isVersionSupported("4.16.0-alpha.5", "4.15.0")
+	require.True(t, supported)
+
+	supported = isVersionSupported("4.16.0", "4.15.0")
+	require.True(t, supported)
+}


### PR DESCRIPTION
**What this PR does / why we need it**: 
> Using ca.crt and token doesn't authenticate openshift's Prometheus endpoint on OCP 4.15.
> As per suggestion from Redhat, using ca.crt and token of thanos-ruler-token secret rather than prometheus-user-workload-token secret.
> For other OCP supported versions ( < 4.15) , there will be no change.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-35994

**Testing**:
> Tested on vsphere OCP 4.14 and OCP 4.15
