### PR TITLE
PWX-35007,PWX-36364: fixing re-validation of DesiredImages.Kube*

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -600,9 +600,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
 			toUpdate.Status.DesiredImages.Stork = release.Components.Stork
-			if toUpdate.Status.DesiredImages.KubeScheduler == "" {
-				toUpdate.Status.DesiredImages.KubeScheduler = release.Components.KubeScheduler
-			}
+			toUpdate.Status.DesiredImages.KubeScheduler = release.Components.KubeScheduler
 		}
 
 		if autoUpdateAutopilot(toUpdate) &&
@@ -716,18 +714,17 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			toUpdate.Status.DesiredImages.DynamicPluginProxy = release.Components.DynamicPluginProxy
 		}
 
-		// set misc image defaults
-		imagesData := []struct {
-			desiredImage *string
-			releaseImage string
-		}{
-			{&toUpdate.Status.DesiredImages.KubeControllerManager, release.Components.KubeControllerManager},
-			{&toUpdate.Status.DesiredImages.Pause, release.Components.Pause},
+		needK8sDepComponentUpdate := pxVersionChanged || p.hasKubernetesVersionChanged(toUpdate) || autoUpdateComponents(toUpdate)
+		if toUpdate.Status.DesiredImages.KubeControllerManager == "" || needK8sDepComponentUpdate {
+			toUpdate.Status.DesiredImages.KubeControllerManager = release.Components.KubeControllerManager
 		}
-		for _, v := range imagesData {
-			if *v.desiredImage == "" {
-				*v.desiredImage = v.releaseImage
-			}
+
+		if toUpdate.Status.DesiredImages.KubeScheduler == "" || needK8sDepComponentUpdate {
+			toUpdate.Status.DesiredImages.KubeScheduler = release.Components.KubeScheduler
+		}
+
+		if toUpdate.Status.DesiredImages.Pause == "" || needK8sDepComponentUpdate {
+			toUpdate.Status.DesiredImages.Pause = release.Components.Pause
 		}
 
 		// Reset the component update strategy if it is 'Once', so that we don't

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2809,6 +2809,35 @@ func TestStorageClusterDefaultsForStork(t *testing.T) {
 	require.Equal(t, "registry.k8s.io/kube-controller-manager-amd64:v1.28.0",
 		cluster.Status.DesiredImages.KubeControllerManager)
 
+	// check if K8s-dependent images updated when PX version changes
+	cluster.Status.DesiredImages.KubeScheduler = "px/foo:v1.28.0"
+	cluster.Status.DesiredImages.KubeControllerManager = "px/bar:v1.28.0"
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, "px/foo:v1.28.0", cluster.Status.DesiredImages.KubeScheduler)
+	assert.Equal(t, "px/bar:v1.28.0", cluster.Status.DesiredImages.KubeControllerManager)
+
+	cluster.Spec.Image = "px/image:4.5.6"
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.k8s.io/kube-scheduler-amd64:v1.28.0",
+		cluster.Status.DesiredImages.KubeScheduler)
+	assert.Equal(t, "registry.k8s.io/kube-controller-manager-amd64:v1.28.0",
+		cluster.Status.DesiredImages.KubeControllerManager)
+
+	// let's change the K8 version, and check if this caused the K8s-dependent images to be updated
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{
+		GitVersion: "v1.29.9",
+	}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.k8s.io/kube-scheduler-amd64:v1.29.9",
+		cluster.Status.DesiredImages.KubeScheduler)
+	assert.Equal(t, "registry.k8s.io/kube-controller-manager-amd64:v1.29.9",
+		cluster.Status.DesiredImages.KubeControllerManager)
+
 	// Use given spec image if specified and reset desired image in status
 	cluster.Spec.Stork = &corev1.StorkSpec{
 		Enabled: true,


### PR DESCRIPTION
* the `Status.DesiredImages.{KubeControllerManager,KubeScheduler,Pause}` will get re-validated every time
  - portworx version changes, or
  - kubernetes version changes, or
  - StorageCluster `spec.autoUpdateComponents` is used

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The `Status.DesiredImages.{KubeControllerManager,KubeScheduler,Pause}` are the "sticky image versions" which once set, will be preferred when generating K8s deployments and pods

ISSUE:
* however, once these images are set, we never invalidated them (they never changed)
  - this means the image did not change when K8s version updated or,
  - when PX version for updated, nor
  - when `spec.autoUpdateComponents` was used

FIX:
* as a fix, we'll reset the `Status.DesiredImages.{KubeControllerManager,KubeScheduler,Pause}` when K8s or PX version changes, or when `spec.autoUpdateComponents` was used

**Which issue(s) this PR fixes** (optional)

PWX-35007
PWX-36364

**Special notes for your reviewer**:

Note, the `PWX-35007` was slightly different -- the `px-versions` ConfigMap would be used to set the `Status.DesiredImages.KubeControllerManager` initially, but it was not possible to update if any longer
* now when `spec.autoUpdateComponents: Once` is used, the image will be reset from the latest `px-versions` CM