### PR TITLE
PWX-35007,PWX-36364_23.10.4: fixing re-validation of DesiredImages.Kube* (#1473)

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -385,9 +385,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 				pxVersionChanged ||
 				autoUpdateComponents(toUpdate)) {
 			toUpdate.Status.DesiredImages.Stork = release.Components.Stork
-			if toUpdate.Status.DesiredImages.KubeScheduler == "" {
-				toUpdate.Status.DesiredImages.KubeScheduler = release.Components.KubeScheduler
-			}
+			toUpdate.Status.DesiredImages.KubeScheduler = release.Components.KubeScheduler
 		}
 
 		if autoUpdateAutopilot(toUpdate) &&
@@ -491,18 +489,17 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			toUpdate.Status.DesiredImages.DynamicPluginProxy = release.Components.DynamicPluginProxy
 		}
 
-		// set misc image defaults
-		imagesData := []struct {
-			desiredImage *string
-			releaseImage string
-		}{
-			{&toUpdate.Status.DesiredImages.KubeControllerManager, release.Components.KubeControllerManager},
-			{&toUpdate.Status.DesiredImages.Pause, release.Components.Pause},
+		needK8sDepComponentUpdate := pxVersionChanged || p.hasKubernetesVersionChanged(toUpdate) || autoUpdateComponents(toUpdate)
+		if toUpdate.Status.DesiredImages.KubeControllerManager == "" || needK8sDepComponentUpdate {
+			toUpdate.Status.DesiredImages.KubeControllerManager = release.Components.KubeControllerManager
 		}
-		for _, v := range imagesData {
-			if *v.desiredImage == "" {
-				*v.desiredImage = v.releaseImage
-			}
+
+		if toUpdate.Status.DesiredImages.KubeScheduler == "" || needK8sDepComponentUpdate {
+			toUpdate.Status.DesiredImages.KubeScheduler = release.Components.KubeScheduler
+		}
+
+		if toUpdate.Status.DesiredImages.Pause == "" || needK8sDepComponentUpdate {
+			toUpdate.Status.DesiredImages.Pause = release.Components.Pause
 		}
 
 		// Reset the component update strategy if it is 'Once', so that we don't

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -25,6 +25,7 @@ import (
 	operatorops "github.com/portworx/sched-ops/k8s/operator"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -2157,6 +2157,83 @@ func TestStorageClusterDefaultsForStork(t *testing.T) {
 	require.Equal(t, "registry.k8s.io/kube-controller-manager-amd64:v1.28.0",
 		cluster.Status.DesiredImages.KubeControllerManager)
 
+	// check if K8s-dependent images updated when PX version changes
+	cluster.Status.DesiredImages.KubeScheduler = "px/foo:v1.28.0"
+	cluster.Status.DesiredImages.KubeControllerManager = "px/bar:v1.28.0"
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, "px/foo:v1.28.0", cluster.Status.DesiredImages.KubeScheduler)
+	assert.Equal(t, "px/bar:v1.28.0", cluster.Status.DesiredImages.KubeControllerManager)
+
+	cluster.Spec.Image = "px/image:4.5.6"
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.k8s.io/kube-scheduler-amd64:v1.28.0",
+		cluster.Status.DesiredImages.KubeScheduler)
+	assert.Equal(t, "registry.k8s.io/kube-controller-manager-amd64:v1.28.0",
+		cluster.Status.DesiredImages.KubeControllerManager)
+
+	// check if K8s-dependent images updated (or not) when autoUpdateComponents used
+	testData := []struct {
+		kind                    corev1.AutoUpdateComponentStrategyType
+		expectUpdated           bool
+		expectAutoUpdateCleared bool
+	}{
+		{corev1.OnceAutoUpdate, true, true},
+		{corev1.AlwaysAutoUpdate, true, false},
+		{corev1.NeverAutoUpdate, false, false},
+	}
+
+	for i, td := range testData {
+		cluster.Spec.AutoUpdateComponents = nil
+		cluster.Status.DesiredImages.KubeScheduler = "px/foo:v1.28.0"
+		cluster.Status.DesiredImages.KubeControllerManager = "px/bar:v1.28.0"
+		err = driver.SetDefaultsOnStorageCluster(cluster)
+		require.NoError(t, err)
+		assert.Equal(t, "px/foo:v1.28.0", cluster.Status.DesiredImages.KubeScheduler,
+			"failed expectations for test %d / %v", i+1, td)
+		assert.Equal(t, "px/bar:v1.28.0", cluster.Status.DesiredImages.KubeControllerManager,
+			"failed expectations for test %d / %v", i+1, td)
+
+		cluster.Spec.AutoUpdateComponents = &td.kind
+		err = driver.SetDefaultsOnStorageCluster(cluster)
+		require.NoError(t, err)
+		if td.expectUpdated {
+			assert.Equal(t, "registry.k8s.io/kube-scheduler-amd64:v1.28.0",
+				cluster.Status.DesiredImages.KubeScheduler,
+				"failed expectations for test %d / %v", i+1, td)
+			assert.Equal(t, "registry.k8s.io/kube-controller-manager-amd64:v1.28.0",
+				cluster.Status.DesiredImages.KubeControllerManager,
+				"failed expectations for test %d / %v", i+1, td)
+		} else {
+			assert.Equal(t, "px/foo:v1.28.0", cluster.Status.DesiredImages.KubeScheduler,
+				"failed expectations for test %d / %v", i+1, td)
+			assert.Equal(t, "px/bar:v1.28.0", cluster.Status.DesiredImages.KubeControllerManager,
+				"failed expectations for test %d / %v", i+1, td)
+		}
+		if td.expectAutoUpdateCleared {
+			assert.Empty(t, cluster.Spec.AutoUpdateComponents,
+				"failed expectations for test %d / %v", i+1, td)
+		} else {
+			assert.NotEmpty(t, cluster.Spec.AutoUpdateComponents,
+				"failed expectations for test %d / %v", i+1, td)
+		}
+	}
+	cluster.Spec.AutoUpdateComponents = nil
+
+	// let's change the K8 version, and check if this caused the K8s-dependent images to be updated
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &k8sversion.Info{
+		GitVersion: "v1.29.9",
+	}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, "registry.k8s.io/kube-scheduler-amd64:v1.29.9",
+		cluster.Status.DesiredImages.KubeScheduler)
+	assert.Equal(t, "registry.k8s.io/kube-controller-manager-amd64:v1.29.9",
+		cluster.Status.DesiredImages.KubeControllerManager)
+
 	// Use given spec image if specified and reset desired image in status
 	cluster.Spec.Stork = &corev1.StorkSpec{
 		Enabled: true,


### PR DESCRIPTION
* the `Status.DesiredImages.{KubeControllerManager,KubeScheduler,Pause}` will get re-validated every time
  - portworx version changes, or
  - kubernetes version changes, or
  - StorageCluster `spec.autoUpdateComponents` is used

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1473 into `release-23.10.4` branch

**Which issue(s) this PR fixes** (optional)
PWX-35007,PWX-36364

**Special notes for your reviewer**:

