### PR TITLE
[23.10.4] PWX-36428 : Add metadata annotations in CSV for openshift catalog

### DIFF
--- a/deploy/olm-catalog/portworx/23.10.4/portworx-certified.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/portworx/23.10.4/portworx-certified.clusterserviceversion.yaml
@@ -13,6 +13,13 @@ metadata:
     support: Portworx, Inc
     certified: "true"
     console.openshift.io/plugins: '["portworx"]'
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/initialization-resource: |-
       {
         "apiVersion": "core.libopenstorage.org/v1",


### PR DESCRIPTION
**What this PR does / why we need it**:
Redhat has enforced the presence of following metadata. Their certification pipelines will FAIL for all new operator bundle releases that DO NOT use this metadata format. 
Here's the meaning of each of the fields added

-   **features.operators.openshift.io/disconnected**: Specify whether an Operator leverages the spec.relatedImages CSV field and can run without an internet connection by referring to any related image by its digest.

-   _**_features.operators.openshift.io/fips-compliant_**_: Specify whether an Operator accepts the FIPS-140 configuration of the underlying platform and works on nodes that are booted into FIPS mode. In this mode, the Operator and any workloads it manages (operands) are solely calling the Red Hat Enterprise Linux (RHEL) cryptographic library submitted for FIPS-140 validation.

-  **features.operators.openshift.io/proxy-aware**: Specify whether an Operator supports running on a cluster behind a proxy by accepting the standard HTTP_PROXY and HTTPS_PROXY proxy environment variables. If applicable, the Operator passes this information to the workload it manages (operands).

-  **features.operators.openshift.io/tls-profiles**: Specify whether an Operator implements well-known tunables to modify the TLS cipher suite used by the Operator and, if applicable, any of the workloads it manages (operands).
   
-  **features.operators.openshift.io/token-auth-aws**: Specify whether an Operator supports configuration for tokenzied authentication with AWS APIs via AWS Secure Token Service (STS) by using the Cloud Credential Operator (CCO).

-  **features.operators.openshift.io/token-auth-azure**: Specify whether an Operator supports configuration for tokenzied authentication with Azure APIs via Azure Managed Identity by using the Cloud Credential Operator (CCO).

-  **features.operators.openshift.io/token-auth-gcp**: Specify whether an Operator supports configuration for tokenzied authentication with Google Cloud APIs via GCP Workload Identity Foundation (WIF) by using the Cloud Credential Operator (CCO).

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-36428

Note : In 23.10.4 bundle of operator, we have following in spec (not in master)
spec:
    relatedImages:
    - name: portworx-operator
      image: portworx/px-operator:23.10.4-dev

