### PR TITLE
BlueGreen license integration test fix  [trivial]

### DIFF
--- a/test/integration_test/bluegreen_test.go
+++ b/test/integration_test/bluegreen_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	/* crippldTestLicense is a crippled test license  (lot worse than free PX-Developer or PX-Essentials)
+	/*
+	 * crippldTestLicense is a crippled test license  (lot worse than free PX-Developer or PX-Essentials)
 	   - license generated via:
 	   ../bin/tools/capresponseutil -id IdentityBackOffice.bin -lifetime 157680000 -host ANY -idtype Any -server ANY -serverIdType Any /dev/stdin lic-ANY.bin << _EOF
 	   INCREMENT  Nodes                portworx  1.0  07-feb-2028  3  HOSTID=ANY VENDOR_STRING=type="Torpedo_TEST_license"  START=07-feb-2023

--- a/test/integration_test/bluegreen_test.go
+++ b/test/integration_test/bluegreen_test.go
@@ -128,12 +128,12 @@ var bgTestCases = []types.TestCase{
 				require.NoError(t, err)
 				require.Equal(t, numLicensedNodes, len(pl.Items))
 
-				logrus.Infof("Attempt license extend on Trial via node %s", pl.Items[0].Spec.NodeName)
+				logrus.Infof("Attempt license expand on Trial via node %s", pl.Items[0].Spec.NodeName)
 				var stdout, stderr bytes.Buffer
 				err = runInPortworxPod(&pl.Items[0],
 					nil, &stdout, &stderr,
-					"/bin/sh", "-c", "/opt/pwx/bin/pxctl license trial; exec /opt/pwx/bin/pxctl license extend --start")
-				require.Contains(t, stdout.String(), "license extension not supported for Trial licenses")
+					"/bin/sh", "-c", "/opt/pwx/bin/pxctl license trial; exec /opt/pwx/bin/pxctl license expand --start")
+				require.Contains(t, stdout.String(), " not supported for Trial licenses")
 
 				logrus.Infof("Installing license via node %s", pl.Items[0].Spec.NodeName)
 				err = runInPortworxPod(&pl.Items[0],
@@ -262,7 +262,7 @@ var bgTestCases = []types.TestCase{
 				logrus.Infof("Extending license via node %s", pl.Items[0].Spec.NodeName)
 				var stdout, stderr bytes.Buffer
 				err = runInPortworxPod(&pl.Items[0], nil, &stdout, &stderr,
-					"/opt/pwx/bin/pxctl", "license", "extend", "--start")
+					"/opt/pwx/bin/pxctl", "license", "expand", "--start")
 				require.NoError(t, err)
 				require.Contains(t, stdout.String(), "Successfully initiated license extension")
 
@@ -446,7 +446,7 @@ var bgTestCases = []types.TestCase{
 				logrus.Infof("End license extension while cluster over-allocated")
 				var stdout, stderr bytes.Buffer
 				err = runInPortworxPod(&pl.Items[0], nil, &stdout, &stderr,
-					"/opt/pwx/bin/pxctl", "license", "extend", "--end")
+					"/opt/pwx/bin/pxctl", "license", "expand", "--end")
 				assert.Equal(t, "", stderr.String())
 				assert.Contains(t, stdout.String(), "Successfully turned off license extension")
 				require.NoError(t, err)


### PR DESCRIPTION
* replacing ..
  - "pxctl license extend", with
  - "pxctl license expand"

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

We changed the CLI keyword, and forgot to update the test

Note:

* the `extend` triggers usage, while `expand` keyword works OK

```
# /opt/pwx/bin/pxctl license extend
Error: Subcommand is missing or invalid. This command requires a valid sub-command.
Usage:
  pxctl license [flags]
...
Use "pxctl license [command] --help" for more information about a command.

# /opt/pwx/bin/pxctl license expand
License expansion status: not active
```

**Which issue(s) this PR fixes** (optional)
Closes # --

**Special notes for your reviewer**:

