### PR TITLE
PWX-36321: Update the cluster status condition before updating the cl…

### DIFF
--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -632,19 +632,31 @@ func (c *Controller) runPreflightCheck(cluster *corev1.StorageCluster) error {
 
 	// Update the cluster only if anything has changed
 	if !reflect.DeepEqual(cluster, toUpdate) {
+		// Get the latest cluster object to preserve the 'ResourceVersion'
+		latestCluster, gerr := operatorops.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
+		if gerr != nil {
+			return fmt.Errorf("UpdateStorageClusterStatus GetStorageCluster failure, %v", gerr)
+		}
+		toUpdate.ResourceVersion = latestCluster.ResourceVersion // Preserve resource version
+
 		toUpdate.DeepCopyInto(cluster)
-		if err := k8s.UpdateStorageCluster(c.client, cluster); err != nil {
-			return fmt.Errorf("UpdateStorageCluster failure, %v", err)
+
+		if _, err := operatorops.Instance().UpdateStorageClusterStatus(cluster); err != nil {
+			k8s.WarningEvent(c.recorder, cluster, util.FailedPreFlight,
+				"preflight check failed to update storage cluster status. Need to rerun preflight or skip it")
+			return fmt.Errorf("update storage cluster status failure, %v", err)
 		}
 
-		cluster.Status = *toUpdate.Status.DeepCopy()
-		if err := k8s.UpdateStorageClusterStatus(c.client, cluster); err != nil {
-			logrus.Errorf("preflight updateStorageClusterStatus failed trying again...")
-			if err := k8s.UpdateStorageClusterStatus(c.client, cluster); err != nil {
-				k8s.WarningEvent(c.recorder, cluster, util.FailedPreFlight,
-					"preflight check failed to update storage cluster status. Need to rerun preflight or skip it")
-				return fmt.Errorf("UpdateStorageClusterStatus failure, %v", err)
-			}
+		latestCluster, gerr = operatorops.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
+		if gerr != nil {
+			return fmt.Errorf("UpdateStorageCluster GetStorageCluster failure, %v", gerr)
+		}
+		cluster.ResourceVersion = latestCluster.ResourceVersion // Preserve resource version
+
+		if _, err := operatorops.Instance().UpdateStorageCluster(cluster); err != nil {
+			k8s.WarningEvent(c.recorder, cluster, util.FailedPreFlight,
+				"preflight check failed to update storage cluster. Need to rerun preflight or skip it")
+			return fmt.Errorf("UpdateStorageCluster failure, %v", err)
 		}
 	}
 	return err


### PR DESCRIPTION
…… (#1468)

* PWX-36321: Update the cluster status condition before updating the cluster spec. Add condition to handle the cluster spec update failure.



* PWX-36321: Use 'sched-ops/k8s/operator' api to update storage cluster and storage cluster status when handling results of preflight run.



* PWX-36321: Remove unused condition.



* PWX-36321: Add log line for in progress pre-flight and annotation is false.



* PWX-36321: Get and use the latest storage cluster object, preserve resourceVersion.



* PWX-36321: Make storage cluster updates using the cluster object which was passd in and sync up the resource versions after each update.



---------

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

