### PR TITLE
PWX-36298 - Set node tolerations before maxStorageNodesPerZone

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -2351,7 +2351,7 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 	driver.EXPECT().GetKVDBMembers(gomock.Any()).Return(nil, nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).Return(nil).AnyTimes()
 	gomock.InOrder(
-	driver.EXPECT().GetStoragePodSpec(gomock.Any(), "k8s-node-1").
+		driver.EXPECT().GetStoragePodSpec(gomock.Any(), "k8s-node-1").
 			DoAndReturn(func(c *corev1.StorageCluster, _ string) (v1.PodSpec, error) {
 				require.Equal(t, cluster.Spec.Nodes[0].Storage, c.Spec.Storage)
 				require.Equal(t, cluster.Spec.Nodes[0].CloudStorage.CloudStorageCommon,
@@ -2390,14 +2390,13 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 			DoAndReturn(func(c *corev1.StorageCluster, _ string) (v1.PodSpec, error) {
 				require.Equal(t, cluster.Spec.CommonConfig, c.Spec.CommonConfig)
 				hash := computeHash(&c.Spec, nil)
-			expectedPodTemplates[0].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
-			expectedPodTemplates[1].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
-			expectedPodTemplates[2].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+				expectedPodTemplates[0].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+				expectedPodTemplates[1].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+				expectedPodTemplates[2].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
 				return expectedPodSpec, nil
 			}).
 			Times(1),
 	)
-
 
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -2349,15 +2349,9 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil)
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 	driver.EXPECT().GetKVDBMembers(gomock.Any()).Return(nil, nil).AnyTimes()
-	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).
-		Do(func(c *corev1.StorageCluster) {
-			hash := computeHash(&c.Spec, nil)
-			expectedPodTemplates[0].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
-			expectedPodTemplates[1].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
-			expectedPodTemplates[2].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
-		})
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).Return(nil).AnyTimes()
 	gomock.InOrder(
-		driver.EXPECT().GetStoragePodSpec(gomock.Any(), "k8s-node-1").
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), "k8s-node-1").
 			DoAndReturn(func(c *corev1.StorageCluster, _ string) (v1.PodSpec, error) {
 				require.Equal(t, cluster.Spec.Nodes[0].Storage, c.Spec.Storage)
 				require.Equal(t, cluster.Spec.Nodes[0].CloudStorage.CloudStorageCommon,
@@ -2395,10 +2389,15 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 		driver.EXPECT().GetStoragePodSpec(gomock.Any(), "k8s-node-3").
 			DoAndReturn(func(c *corev1.StorageCluster, _ string) (v1.PodSpec, error) {
 				require.Equal(t, cluster.Spec.CommonConfig, c.Spec.CommonConfig)
+				hash := computeHash(&c.Spec, nil)
+			expectedPodTemplates[0].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+			expectedPodTemplates[1].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
+			expectedPodTemplates[2].Labels[util.DefaultStorageClusterUniqueLabelKey] = hash
 				return expectedPodSpec, nil
 			}).
 			Times(1),
 	)
+
 
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -2409,7 +2408,6 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 	result, err := controller.Reconcile(context.TODO(), request)
 	require.NoError(t, err)
 	require.Empty(t, result)
-
 	// Verify there is no event raised
 	require.Empty(t, recorder.Events)
 

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1684,6 +1684,11 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 		logrus.Debugf("Failed to update driver: %v", err)
 	}
 
+	if err := c.Driver.SetDefaultsOnStorageCluster(toUpdate); err != nil {
+		// TODO: investigate update failure
+		return err
+	}
+
 	// if no value is set for any of max_storage_nodes*, try to see if can set a default value
 	if toUpdate.Spec.CloudStorage != nil &&
 		toUpdate.Spec.CloudStorage.MaxStorageNodesPerZonePerNodeGroup == nil &&
@@ -1711,11 +1716,6 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 			toUpdate.Spec.CloudStorage.MaxStorageNodesPerZone = &maxStorageNodesPerZone
 			logrus.Infof("setting spec.cloudStorage.maxStorageNodesPerZone %v", maxStorageNodesPerZone)
 		}
-	}
-
-	if err := c.Driver.SetDefaultsOnStorageCluster(toUpdate); err != nil {
-		// TODO: investigate update failure
-		return err
 	}
 
 	// Update the cluster only if anything has changed


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Previously, default value of maxStorageNodesPerZone was being set before the tolerations were added to the storagecluster. This caused a problem when the annotation to run on master was set. The toleration to noSchedule on master was not added to the storagecluster and thus when setting maxStorageNodesPerZone, it was considered that the master node is not schedulable and hence not counted for setting the value. 

**Which issue(s) this PR fixes** (optional)
Closes # PWX-36298

**Special notes for your reviewer**: This PR cannot be merged to master as it has diverged

**Testing steps** : 
Testing to see all nodes run portworx
1) In OCP cluster, deploy the operator with this change. 
2) In the storage cluster stc, add annotation - ` portworx.io/run-on-master: "true"`
3) Apply the spec file and wait till storage cluster is running. There will be 1 storage pod created for every node including master nodes.
4) Check the yaml file of the stc - the field `maxStorageNodesPerZone` will  have a value equal number of worker nodes + master nodes
5) Exec into a storage pod and run `pxctl status` - All nodes will be shown to have storage including master nodes

Testing to see only worker nodes run portworx
1) In an OCP cluster, deploy operator and storagecluster without the run-on-master annotation.
2) There will be no storage pods scheduled on master nodes
3) MaxStorageNodesPerZone will be number of worker nodes
4) Exec into storage pod and run pxctl status - all worker nodes will have storage

