### PR TITLE
Fix for build catalog using internal artifactory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # set defaults
 ifndef DOCKER_HUB_REPO
-    DOCKER_HUB_REPO := portworx
+    DOCKER_HUB_REPO := docker.io/portworx
     $(warning DOCKER_HUB_REPO not defined, using '$(DOCKER_HUB_REPO)' instead)
 endif
 ifndef DOCKER_HUB_OPERATOR_IMG
@@ -242,7 +242,7 @@ catalog: build-catalog deploy-catalog
 build-catalog:
 	@echo "Building operator registry image $(REGISTRY_IMG)"
 	opm index add -u docker -p docker \
-		--bundles docker.io/$(BUNDLE_IMG) \
+		--bundles $(BUNDLE_IMG) \
 		--from-index $(BASE_REGISTRY_IMG) \
 		--tag $(REGISTRY_IMG)
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fix for build catalog using internal artifactory

**Special notes for your reviewer**:
Tested locally:
```
[root@maxb-dev operator]# DOCKER_HUB_REPO=pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx DOCKER_HUB_OPERATOR_TAG=36e102b make catalog
Makefile:8: DOCKER_HUB_OPERATOR_IMG not defined, using 'px-operator' instead
Makefile:16: DOCKER_HUB_OPERATOR_TEST_IMG not defined, using 'px-operator-test' instead
Makefile:20: DOCKER_HUB_OPERATOR_TEST_TAG not defined, using 'latest' instead
Makefile:24: DOCKER_HUB_BUNDLE_IMG not defined, using 'portworx-certified-bundle' instead
Makefile:28: DOCKER_HUB_REGISTRY_IMG not defined, using 'px-operator-registry' instead
Makefile:32: BASE_REGISTRY_IMG not defined, using 'docker.io/portworx/px-operator-registry:23.7.0' instead
Building operator registry image pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/px-operator-registry:99.9.9
opm index add -u docker -p docker \
        --bundles pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9 \
        --from-index docker.io/portworx/px-operator-registry:23.7.0 \
        --tag pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/px-operator-registry:99.9.9
WARN[0000] DEPRECATION NOTICE:
Sqlite-based catalogs and their related subcommands are deprecated. Support for
them will be removed in a future release. Please migrate your catalog workflows
to the new file-based catalog format.
INFO[0000] building the index                            bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0000] Pulling previous image docker.io/portworx/px-operator-registry:23.7.0 to get metadata  bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-cert
ified-bundle:99.9.9]"
INFO[0000] running /usr/bin/docker pull docker.io/portworx/px-operator-registry:23.7.0  bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bund
le:99.9.9]"
INFO[0000] running /usr/bin/docker pull docker.io/portworx/px-operator-registry:23.7.0  bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bund
le:99.9.9]"
INFO[0000] Getting label data from previous image        bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0000] running docker inspect                        bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0000] running docker create                         bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0000] running docker cp                             bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0000] running docker rm                             bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0001] running /usr/bin/docker pull pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9  bundles="[pure-artifactory.dev.purestorage.com/
px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0001] running docker create                         bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0001] running docker cp                             bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0001] running docker rm                             bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0001] Could not find optional dependencies file     file=bundle_tmp2154506815/metadata load=annotations with=./bundle_tmp2154506815
INFO[0001] Could not find optional properties file       file=bundle_tmp2154506815/metadata load=annotations with=./bundle_tmp2154506815
INFO[0001] Could not find optional dependencies file     file=bundle_tmp2154506815/metadata load=annotations with=./bundle_tmp2154506815
INFO[0001] Could not find optional properties file       file=bundle_tmp2154506815/metadata load=annotations with=./bundle_tmp2154506815
INFO[0001] Generating dockerfile                         bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0001] writing dockerfile: ./index.Dockerfile441983460  bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0001] running docker build                          bundles="[pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
INFO[0001] [docker build -f ./index.Dockerfile441983460 -t pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/px-operator-registry:99.9.9 .]  bundles="[pure-artifactory.dev
.purestorage.com/px-docker-prod-virtual/portworx/portworx-certified-bundle:99.9.9]"
Pushing operator registry image pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/px-operator-registry:99.9.9
docker push pure-artifactory.dev.purestorage.com/px-docker-prod-virtual/portworx/px-operator-registry:99.9.9
```
