### PR TITLE
[PTX-17953] Allow to pass namespace param where the operator is deployed

### DIFF
--- a/test/integration_test/main_test.go
+++ b/test/integration_test/main_test.go
@@ -116,6 +116,10 @@ func setup() error {
 		"log-level",
 		"",
 		"Log level")
+	flag.StringVar(&ci_utils.PxNamespace,
+		"px-namespace",
+		"kube-system",
+		"Namespace where the operator will be deployed")
 	flag.Parse()
 
 	// Set log level
@@ -150,7 +154,7 @@ func setup() error {
 	pxOperatorDep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "portworx-operator",
-			Namespace: "kube-system",
+			Namespace: ci_utils.PxNamespace,
 		},
 	}
 

--- a/test/integration_test/operator-test-pod-template.yaml
+++ b/test/integration_test/operator-test-pod-template.yaml
@@ -72,6 +72,7 @@ spec:
     - -operator-upgrade-hops-image-list=OPERATOR_UPGRADE_HOPS_IMAGE_LIST
     - -log-level=LOG_LEVEL
     - -test.run=FOCUS_TESTS
+    - -px-namespace=PX_NAMESPACE
     imagePullPolicy: Always
     image: openstorage/px-operator-test:latest
     securityContext:

--- a/test/integration_test/portworx_diag_test.go
+++ b/test/integration_test/portworx_diag_test.go
@@ -36,8 +36,6 @@ type diagTestSpec struct {
 }
 
 const (
-	DiagTestNamespace = "kube-system"
-
 	diagVolumeLabelKey = "diag-label"
 	diagVolumeLabelVal = "true"
 
@@ -46,6 +44,8 @@ const (
 )
 
 var (
+	DiagTestNamespace = ci_utils.PxNamespace
+
 	workerNodeCount = -1
 
 	testStorageClasses = []*storagev1.StorageClass{

--- a/test/integration_test/utils/constants.go
+++ b/test/integration_test/utils/constants.go
@@ -69,6 +69,9 @@ var (
 
 	// IsOke is an indication that this is OKE cluster or not
 	IsOke bool
+
+	// PxNamespace is a default namespace for StorageCluster
+	PxNamespace string
 )
 
 const (
@@ -112,8 +115,6 @@ const (
 	// NodeReplacePrefix is used for replacing node name during the test
 	NodeReplacePrefix = "replaceWithNodeNumber"
 
-	// PxNamespace is a default namespace for StorageCluster
-	PxNamespace = "kube-system"
 	// PortworxOperatorDeploymentName name of portworx operator deployment
 	PortworxOperatorDeploymentName = "portworx-operator"
 	// PortworxOperatorContainerName name of portworx operator container


### PR DESCRIPTION
- Allow to pass namespace param where the operator is deployed
- Also improved error handling for PTX-22684


**What this PR does / why we need it**:
Operator Integration tests always used hard coded "kube-system" as the namespace for operator deployment. With this change, we can pass the namespace as a variable explicitly specifying where the px-operator is deployed and also where the operator-test pod will be deployed. This will be useful when we want to run integration tests along with torpedo tests from a single pipeline job. 
Also this PR improves error handling in cases where operator version might return nil resulting in null pointer exception in util/test/util.go

**Which issue(s) this PR fixes** (optional)
Closes # PTX-17953, PTX-22684

**Special notes for your reviewer**:

