### PR TITLE
PWX-36649 Keep the required-scc annotation if added during creation

### DIFF
--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -32,8 +32,6 @@ const (
 	PxRestrictedSCCName = "portworx-restricted"
 	// PxNodeWiperServiceAccountName name of portworx node wiper service account
 	PxNodeWiperServiceAccountName = "px-node-wiper"
-	// OpenshiftSCCAnnotation name of annotation for SCC in Openshift
-	OpenshiftRequiredSCCAnnotation = "openshift.io/required-scc"
 )
 
 type scc struct {

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -30,6 +30,8 @@ const (
 	// AnnotationPodSafeToEvict annotation tells cluster autoscaler whether the
 	// pod is safe to be evicted when scaling down a node
 	AnnotationPodSafeToEvict = "cluster-autoscaler.kubernetes.io/safe-to-evict"
+	// AnnotationOpenshiftRequiredSCC is the annotation for the required SCC (Security Context Constraints) in OpenShift
+	AnnotationOpenshiftRequiredSCC = "openshift.io/required-scc"
 	// AnnotationForceContinueUpdate annotation to force continue paused updates of storage pods (default: false)
 	AnnotationForceContinueUpdate = OperatorPrefix + "/force-continue-update"
 	// AnnotationCommonImageRegistries annotation contains the common image registries, separated by comma.
@@ -57,5 +59,6 @@ var (
 	KnownStoragePodAnnotations = []string{
 		AnnotationNodeLabels,
 		AnnotationPodSafeToEvict,
+		AnnotationOpenshiftRequiredSCC,
 	}
 )

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/libopenstorage/cloudops"
 	storageapi "github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/operator/drivers/storage"
+	"github.com/libopenstorage/operator/drivers/storage/portworx/component"
 	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
 	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
 	"github.com/libopenstorage/operator/pkg/client/clientset/versioned/fake"
@@ -8119,7 +8120,6 @@ func TestUpdateStorageClusterSecurity(t *testing.T) {
 
 func TestUpdateStorageCustomAnnotations(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 
 	driverName := "mock-driver"
 	cluster := createStorageCluster()
@@ -8170,9 +8170,9 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 	// Pods that are already running on the k8s nodes with same hash
 	storageLabels[util.DefaultStorageClusterUniqueLabelKey] = rev1Hash
 	oldPod := createStoragePod(cluster, "old-pod", k8sNode.Name, storageLabels)
-	knownAnnotationKey := constants.AnnotationPodSafeToEvict
 	oldPod.Annotations = map[string]string{
-		knownAnnotationKey: "false",
+		constants.AnnotationPodSafeToEvict:       "false",
+		constants.AnnotationOpenshiftRequiredSCC: "portworx",
 	}
 	err = k8sClient.Create(context.TODO(), oldPod)
 	require.NoError(t, err)
@@ -8210,8 +8210,12 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 	val, ok := oldPod.Annotations[customAnnotationKey]
 	require.True(t, ok)
 	require.Equal(t, customAnnotationVal1, val)
-	_, ok = oldPod.Annotations[knownAnnotationKey]
+	val, ok = oldPod.Annotations[constants.AnnotationPodSafeToEvict]
 	require.True(t, ok)
+	require.Equal(t, "false", val)
+	val, ok = oldPod.Annotations[constants.AnnotationOpenshiftRequiredSCC]
+	require.True(t, ok)
+	require.Equal(t, "portworx", val)
 
 	// TestCase: Update existing custom annotations
 	err = testutil.Get(k8sClient, cluster, cluster.Name, cluster.Namespace)
@@ -8240,8 +8244,12 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 	val, ok = oldPod.Annotations[customAnnotationKey]
 	require.True(t, ok)
 	require.Equal(t, customAnnotationVal2, val)
-	_, ok = oldPod.Annotations[knownAnnotationKey]
+	val, ok = oldPod.Annotations[constants.AnnotationPodSafeToEvict]
 	require.True(t, ok)
+	require.Equal(t, "false", val)
+	val, ok = oldPod.Annotations[constants.AnnotationOpenshiftRequiredSCC]
+	require.True(t, ok)
+	require.Equal(t, "portworx", val)
 
 	// TestCase: Add malformed custom annotation key
 	err = testutil.Get(k8sClient, cluster, cluster.Name, cluster.Namespace)
@@ -8267,8 +8275,12 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 	err = testutil.Get(k8sClient, oldPod, oldPod.Name, oldPod.Namespace)
 	require.NoError(t, err)
 	require.NotEmpty(t, oldPod.Annotations)
-	_, ok = oldPod.Annotations[knownAnnotationKey]
+	val, ok = oldPod.Annotations[constants.AnnotationPodSafeToEvict]
 	require.True(t, ok)
+	require.Equal(t, "false", val)
+	val, ok = oldPod.Annotations[constants.AnnotationOpenshiftRequiredSCC]
+	require.True(t, ok)
+	require.Equal(t, "portworx", val)
 
 	updatedCluster := &corev1.StorageCluster{}
 	err = testutil.Get(k8sClient, updatedCluster, cluster.Name, cluster.Namespace)
@@ -8300,8 +8312,12 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 	require.NotEmpty(t, oldPod.Annotations)
 	_, ok = oldPod.Annotations[customAnnotationKey]
 	require.False(t, ok)
-	_, ok = oldPod.Annotations[knownAnnotationKey]
+	val, ok = oldPod.Annotations[constants.AnnotationPodSafeToEvict]
 	require.True(t, ok)
+	require.Equal(t, "false", val)
+	val, ok = oldPod.Annotations[constants.AnnotationOpenshiftRequiredSCC]
+	require.True(t, ok)
+	require.Equal(t, "portworx", val)
 
 	// TestCase: Newly created pod will pick up custom annotations
 	err = testutil.Get(k8sClient, cluster, cluster.Name, cluster.Namespace)
@@ -8321,8 +8337,12 @@ func TestUpdateStorageCustomAnnotations(t *testing.T) {
 	val, ok = newPod.Annotations[customAnnotationKey]
 	require.True(t, ok)
 	require.Equal(t, customAnnotationVal1, val)
-	_, ok = oldPod.Annotations[knownAnnotationKey]
+	val, ok = oldPod.Annotations[constants.AnnotationPodSafeToEvict]
 	require.True(t, ok)
+	require.Equal(t, "false", val)
+	val, ok = oldPod.Annotations[constants.AnnotationOpenshiftRequiredSCC]
+	require.True(t, ok)
+	require.Equal(t, "portworx", val)
 }
 
 func TestUpdateClusterShouldDedupOlderRevisionsInHistory(t *testing.T) {
@@ -9630,6 +9650,67 @@ func TestStorageClusterStateDuringValidation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, string(corev1.ClusterStateDegraded), updatedCluster.Status.Phase)
 	require.False(t, pxutil.IsFreshInstall(updatedCluster))
+}
+
+func TestRequiredSCCAnnotationOnPortworxPods(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+
+	cluster := createStorageCluster()
+	cluster.Annotations = map[string]string{
+		"portworx.io/is-openshift": "true",
+	}
+	k8sNode := createK8sNode("k8s-node", 10)
+
+	driverName := "mock-driver"
+	k8sVersion, _ := version.NewVersion(minSupportedK8sVersion)
+	driver := testutil.MockDriver(mockCtrl)
+	k8sClient := testutil.FakeK8sClient(cluster, k8sNode)
+	podControl := &k8scontroller.FakePodControl{}
+	recorder := record.NewFakeRecorder(10)
+	controller := Controller{
+		client:            k8sClient,
+		Driver:            driver,
+		podControl:        podControl,
+		recorder:          recorder,
+		kubernetesVersion: k8sVersion,
+		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
+	}
+
+	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return(driverName).AnyTimes()
+	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
+	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
+	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+
+	// TestCase: Pod template should have the required SCC annotation when running on OpenShift
+	request := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      cluster.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+	result, err := controller.Reconcile(context.TODO(), request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+	require.Len(t, podControl.Templates, 1)
+	require.Equal(t, component.PxSCCName, podControl.Templates[0].Annotations[constants.AnnotationOpenshiftRequiredSCC])
+
+	// TestCase: Pod template should not have the required SCC annotation when not running on OpenShift
+	podControl.Templates = nil
+	cluster.Annotations = nil
+	err = testutil.Update(k8sClient, cluster)
+	require.NoError(t, err)
+
+	result, err = controller.Reconcile(context.TODO(), request)
+	require.NoError(t, err)
+	require.Empty(t, result)
+	require.Len(t, podControl.Templates, 1)
+	require.Empty(t, podControl.Templates[0].Annotations)
 }
 
 func replaceOldPod(

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1401,7 +1401,7 @@ func (c *Controller) CreatePodTemplate(
 	}
 
 	if pxutil.IsOpenshift(cluster) {
-		newTemplate.Annotations[component.OpenshiftRequiredSCCAnnotation] = component.PxSCCName
+		newTemplate.Annotations[constants.AnnotationOpenshiftRequiredSCC] = component.PxSCCName
 	}
 
 	if len(node.Labels) > 0 {
@@ -1424,6 +1424,7 @@ func (c *Controller) CreatePodTemplate(
 	}
 	return newTemplate, nil
 }
+
 func (c *Controller) getCurrentMaxStorageNodesPerZone(
 	cluster *corev1.StorageCluster,
 	nodeList *v1.NodeList,

--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -27,13 +27,6 @@ import (
 	"strconv"
 	"strings"
 
-	storageapi "github.com/libopenstorage/openstorage/api"
-	"github.com/libopenstorage/operator/drivers/storage/portworx/util"
-	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
-	"github.com/libopenstorage/operator/pkg/constants"
-	operatorutil "github.com/libopenstorage/operator/pkg/util"
-	"github.com/libopenstorage/operator/pkg/util/k8s"
-
 	operatorops "github.com/portworx/sched-ops/k8s/operator"
 	"github.com/sirupsen/logrus"
 	apps "k8s.io/api/apps/v1"
@@ -47,6 +40,13 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	storageapi "github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/libopenstorage/operator/pkg/constants"
+	operatorutil "github.com/libopenstorage/operator/pkg/util"
+	"github.com/libopenstorage/operator/pkg/util/k8s"
 )
 
 // rollingUpdate deletes old storage cluster pods making sure that no more than


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- The `openshift.io/required-scc` was added to the portworx pod during creation. But it was getting removed during updating the custom annotations on the px pod. Fixed this by adding it to known pod annotation so we don't skip it.
- Added UTs for all required-scc changes.

**Which issue(s) this PR fixes** (optional)
Closes # https://portworx.atlassian.net/browse/PWX-36649

**Special notes for your reviewer**:

