### PR TITLE
PWX-36170: Adding k8s node name as label to all px pods

### DIFF
--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -44,6 +44,9 @@ const (
 	OperatorLabelManagedByKey = OperatorPrefix + "/managed-by"
 	// OperatorLabelManagedByValue indicates that the object is managed by portworx.
 	OperatorLabelManagedByValue = "portworx"
+	// K8sNodeRunningPxPod hold the value of the kubernetes node on whcih the portworx pod is running
+    // Used for creating a Node PDB
+    K8sNodeRunningPxPod = "k8s-node-running-px-pod"
 )
 
 const (

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -45,8 +45,8 @@ const (
 	// OperatorLabelManagedByValue indicates that the object is managed by portworx.
 	OperatorLabelManagedByValue = "portworx"
 	// K8sNodeRunningPxPod hold the value of the kubernetes node on whcih the portworx pod is running
-    // Used for creating a Node PDB
-    K8sNodeRunningPxPod = "k8s-node-running-px-pod"
+	// Used for creating a Node PDB
+	K8sNodeRunningPxPod = "k8s-node-running-px-pod"
 )
 
 const (

--- a/pkg/constants/metadata.go
+++ b/pkg/constants/metadata.go
@@ -44,9 +44,9 @@ const (
 	OperatorLabelManagedByKey = OperatorPrefix + "/managed-by"
 	// OperatorLabelManagedByValue indicates that the object is managed by portworx.
 	OperatorLabelManagedByValue = "portworx"
-	// K8sNodeRunningPxPod hold the value of the kubernetes node on whcih the portworx pod is running
+	// OperatorLabelNodeNameKey holds the value of the kubernetes node on whcih the portworx pod is running
 	// Used for creating a Node PDB
-	K8sNodeRunningPxPod = "k8s-node-running-px-pod"
+	OperatorLabelNodeNameKey = OperatorPrefix + "/node-name"
 )
 
 const (

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -1443,8 +1443,10 @@ func TestStoragePodGetsScheduled(t *testing.T) {
 	require.Len(t, podControl.Templates, 2)
 	podTemplate1 := expectedPodTemplate.DeepCopy()
 	podTemplate1.Spec.NodeName = "k8s-node-1"
+	podTemplate1.Labels["k8s-node-running-px-pod"] = "k8s-node-1"
 	podTemplate2 := expectedPodTemplate.DeepCopy()
 	podTemplate2.Spec.NodeName = "k8s-node-2"
+	podTemplate2.Labels["k8s-node-running-px-pod"] = "k8s-node-2"
 	expectedPodTemplates := []v1.PodTemplateSpec{
 		*podTemplate1, *podTemplate2,
 	}
@@ -1560,8 +1562,10 @@ func TestStoragePodGetsScheduledK8s1_24(t *testing.T) {
 	require.Len(t, podControl.Templates, 2)
 	podTemplate1 := expectedPodTemplate.DeepCopy()
 	podTemplate1.Spec.NodeName = "k8s-node-1"
+	podTemplate1.Labels["k8s-node-running-px-pod"] = "k8s-node-1"
 	podTemplate2 := expectedPodTemplate.DeepCopy()
 	podTemplate2.Spec.NodeName = "k8s-node-2"
+	podTemplate2.Labels["k8s-node-running-px-pod"] = "k8s-node-2"
 	expectedPodTemplates := []v1.PodTemplateSpec{
 		*podTemplate1, *podTemplate2,
 	}
@@ -1900,10 +1904,13 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 	}
 	podTemplate1 := expectedPodTemplate.DeepCopy()
 	podTemplate1.Spec.NodeName = "k8s-node-1"
+	podTemplate1.Labels["k8s-node-running-px-pod"] = "k8s-node-1"
 	podTemplate2 := expectedPodTemplate.DeepCopy()
 	podTemplate2.Spec.NodeName = "k8s-node-2"
+	podTemplate2.Labels["k8s-node-running-px-pod"] = "k8s-node-2"
 	podTemplate3 := expectedPodTemplate.DeepCopy()
 	podTemplate3.Spec.NodeName = "k8s-node-3"
+	podTemplate3.Labels["k8s-node-running-px-pod"] = "k8s-node-3"
 	expectedPodTemplates := []v1.PodTemplateSpec{
 		*podTemplate1, *podTemplate2, *podTemplate3,
 	}

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -1443,10 +1443,10 @@ func TestStoragePodGetsScheduled(t *testing.T) {
 	require.Len(t, podControl.Templates, 2)
 	podTemplate1 := expectedPodTemplate.DeepCopy()
 	podTemplate1.Spec.NodeName = "k8s-node-1"
-	podTemplate1.Labels["k8s-node-running-px-pod"] = "k8s-node-1"
+	podTemplate1.Labels[constants.OperatorLabelNodeNameKey] = "k8s-node-1"
 	podTemplate2 := expectedPodTemplate.DeepCopy()
 	podTemplate2.Spec.NodeName = "k8s-node-2"
-	podTemplate2.Labels["k8s-node-running-px-pod"] = "k8s-node-2"
+	podTemplate2.Labels[constants.OperatorLabelNodeNameKey] = "k8s-node-2"
 	expectedPodTemplates := []v1.PodTemplateSpec{
 		*podTemplate1, *podTemplate2,
 	}
@@ -1562,10 +1562,10 @@ func TestStoragePodGetsScheduledK8s1_24(t *testing.T) {
 	require.Len(t, podControl.Templates, 2)
 	podTemplate1 := expectedPodTemplate.DeepCopy()
 	podTemplate1.Spec.NodeName = "k8s-node-1"
-	podTemplate1.Labels["k8s-node-running-px-pod"] = "k8s-node-1"
+	podTemplate1.Labels[constants.OperatorLabelNodeNameKey] = "k8s-node-1"
 	podTemplate2 := expectedPodTemplate.DeepCopy()
 	podTemplate2.Spec.NodeName = "k8s-node-2"
-	podTemplate2.Labels["k8s-node-running-px-pod"] = "k8s-node-2"
+	podTemplate2.Labels[constants.OperatorLabelNodeNameKey] = "k8s-node-2"
 	expectedPodTemplates := []v1.PodTemplateSpec{
 		*podTemplate1, *podTemplate2,
 	}
@@ -1904,13 +1904,13 @@ func TestStoragePodGetsScheduledWithCustomNodeSpecs(t *testing.T) {
 	}
 	podTemplate1 := expectedPodTemplate.DeepCopy()
 	podTemplate1.Spec.NodeName = "k8s-node-1"
-	podTemplate1.Labels["k8s-node-running-px-pod"] = "k8s-node-1"
+	podTemplate1.Labels[constants.OperatorLabelNodeNameKey] = "k8s-node-1"
 	podTemplate2 := expectedPodTemplate.DeepCopy()
 	podTemplate2.Spec.NodeName = "k8s-node-2"
-	podTemplate2.Labels["k8s-node-running-px-pod"] = "k8s-node-2"
+	podTemplate2.Labels[constants.OperatorLabelNodeNameKey] = "k8s-node-2"
 	podTemplate3 := expectedPodTemplate.DeepCopy()
 	podTemplate3.Spec.NodeName = "k8s-node-3"
-	podTemplate3.Labels["k8s-node-running-px-pod"] = "k8s-node-3"
+	podTemplate3.Labels[constants.OperatorLabelNodeNameKey] = "k8s-node-3"
 	expectedPodTemplates := []v1.PodTemplateSpec{
 		*podTemplate1, *podTemplate2, *podTemplate3,
 	}

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1441,7 +1441,7 @@ func (c *Controller) CreatePodTemplate(
 	podSpec.NodeName = node.Name
 	labels := c.StorageClusterSelectorLabels(cluster)
 	labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
-	labels[constants.K8sNodeRunningPxPod] = node.Name
+	labels[constants.OperatorLabelNodeNameKey] = node.Name
 	newTemplate := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   cluster.Namespace,

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1441,6 +1441,7 @@ func (c *Controller) CreatePodTemplate(
 	podSpec.NodeName = node.Name
 	labels := c.StorageClusterSelectorLabels(cluster)
 	labels[constants.OperatorLabelManagedByKey] = constants.OperatorLabelManagedByValue
+	labels[constants.K8sNodeRunningPxPod] = node.Name
 	newTemplate := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   cluster.Namespace,


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:This change is to help in the parallel upgrade feature and is a part of [this](https://purestorage.atlassian.net/browse/PWX-25414) epic. A unique label, in this case kubernetes node name that the portworx pod is running in is added to all the portworx pods.

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-36170


