### PR TITLE
PTX-16508 Aetos Wrap for Operator Integration Test

### DIFF
--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -17,6 +17,7 @@ import (
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
 	"github.com/libopenstorage/operator/test/integration_test/types"
 	ci_utils "github.com/libopenstorage/operator/test/integration_test/utils"
+	aetos "github.com/libopenstorage/operator/test/integration_test/utils/aetos"
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	"github.com/portworx/sched-ops/k8s/operator"
 	"github.com/sirupsen/logrus"
@@ -304,6 +305,49 @@ func BasicInstall(tc *types.TestCase) func(*testing.T) {
 
 		// Deploy PX and validate
 		cluster = ci_utils.DeployAndValidateStorageCluster(cluster, ci_utils.PxSpecImages, t)
+	}
+}
+
+func TestBasicInstall(t *testing.T) {
+	testCase := &types.TestCase{
+		TestName: "BasicInstall",
+		TestSpec: func(t *testing.T) interface{} {
+			objects, err := ci_utils.ParseSpecs("storagecluster/storagecluster-with-all-components.yaml")
+			require.NoError(t, err)
+			cluster, ok := objects[0].(*corev1.StorageCluster)
+			require.True(t, ok)
+			cluster.Name = "test-basic-stc"
+			cluster.Namespace = ci_utils.PxNamespace
+			return cluster
+		},
+		TestFunc: BasicInstallAetosDemo,
+	}
+	BasicInstallAetosDemo(testCase)(t)
+}
+
+func BasicInstallAetosDemo(tc *types.TestCase) func(*testing.T) {
+	return func(t *testing.T) {
+		testSpec := tc.TestSpec(t)
+		cluster, ok := testSpec.(*corev1.StorageCluster)
+		dash.VerifyFatal(t, ok, true, fmt.Sprintf("Get StorageCluster from test spec"))
+
+		defer dash.TestCaseEnd()
+		dash.TestCaseBegin("BasicInstall", "Deploying and validating StorageCluster", "", nil)
+
+		// Construct StorageCluster
+		aetos.Infof("Constructing StorageCluster %s", cluster.Name)
+		err := ci_utils.ConstructStorageCluster(cluster, ci_utils.PxSpecGenURL, ci_utils.PxSpecImages)
+		dash.VerifyFatal(t, err, nil, fmt.Sprintf("Constructed StorageCluster %s? %v", cluster.Name, err))
+
+		// Deploy PX and validate
+		aetos.Infof("Deploying & Validating StorageCluster %s", cluster.Name)
+		_, err = ci_utils.DeployAndValidateStorageClusterAetosDemo(cluster, ci_utils.PxSpecImages)
+		dash.VerifyFatal(t, err, nil, fmt.Sprintf("Deployed and validated StorageCluster %s? %v", cluster.Name, err))
+
+		// Uninstall and validate
+		aetos.Infof("Uninstalling & Validating StorageCluster %s", cluster.Name)
+		err = ci_utils.UninstallAndValidateStorageClusterAetosDemo(cluster)
+		dash.VerifyFatal(t, err, nil, fmt.Sprintf("Uninstalled and validate StorageCluster %s? %v", cluster.Name, err))
 	}
 }
 

--- a/test/integration_test/main_test.go
+++ b/test/integration_test/main_test.go
@@ -4,28 +4,72 @@
 package integrationtest
 
 import (
+	"bufio"
+	"crypto/tls"
+	"encoding/csv"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
 	test_util "github.com/libopenstorage/operator/pkg/util/test"
 	"github.com/libopenstorage/operator/test/integration_test/types"
 	ci_utils "github.com/libopenstorage/operator/test/integration_test/utils"
+	aetosutil "github.com/libopenstorage/operator/test/integration_test/utils/aetos"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const (
+	logLevelFlag            = "log-level"
+	vSphereUsernameFlag     = "portworx-vsphere-username"
+	vSpherePasswordFlag     = "portworx-vsphere-password"
+	dockerUsernameFlag      = "portworx-docker-username"
+	dockerPasswordFlag      = "portworx-docker-password"
+	isOKEFlag               = "is-oke"
+	isGKEFlag               = "is-gke"
+	isAKSFlag               = "is-aks"
+	isEKSFlag               = "is-eks"
+	isOCPFlag               = "is-ocp"
+	pxKVDBSpecFlag          = "portworx-kvdb-spec"
+	pxDeviceSpecsFlag       = "portworx-device-specs"
+	pxUpgradeHopsURLsFlag   = "px-upgrade-hops-url-list"
+	operatorUpgradeHopsFlag = "operator-upgrade-hops-image-list"
+	pxOperatorTagFlag       = "operator-image-tag"
+	cloudProviderFlag       = "cloud-provider"
+	pxEnvVarsFlag           = "portworx-env-vars"
+	pxCustomAnnotationsFlag = "portworx-custom-annotations"
+	pxImageOverrideFlag     = "portworx-image-override"
+	pxSpecGenURLFlag        = "portworx-spec-gen-url"
+	pxNamespaceFlag         = "px-namespace"
+	enableDashBoardFlag     = "enable-dash"
+	userFlag                = "user"
+	testTypeFlag            = "test-type"
+	testDescriptionFlag     = "test-desc"
+	testTagsFlag            = "test-tags"
+	testSetIDFlag           = "testset-id"
+	testBranchFlag          = "branch"
+	testProductFlag         = "product"
+)
+
+var dash *aetosutil.Dashboard
 
 func TestMain(m *testing.M) {
 	if err := setup(); err != nil {
 		logrus.Errorf("Setup failed with error: %v", err)
 		os.Exit(1)
 	}
+	logrus.Infof("Setup completed successfully, starting tests...")
+	dash.TestSetBegin(dash.TestSet)
 	exitCode := m.Run()
 	types.TestReporterInstance().PrintTestResult()
+	dash.TestSetEnd()
 	os.Exit(exitCode)
 }
 
@@ -35,91 +79,126 @@ func setup() error {
 	var operatorUpgradeHopsImages string
 	var logLevel string
 	var err error
+	var enableDash bool
+	var user, testBranch, testProduct, testType, testDescription, testTags string
+	var testsetID int
 
 	flag.StringVar(&ci_utils.PxDockerUsername,
-		"portworx-docker-username",
+		dockerUsernameFlag,
 		"",
 		"Portworx Docker username used for pull")
 	flag.StringVar(&ci_utils.PxDockerPassword,
-		"portworx-docker-password",
+		dockerPasswordFlag,
 		"",
 		"Portworx Docker password used for pull")
 	flag.StringVar(&ci_utils.PxVsphereUsername,
-		"portworx-vsphere-username",
+		vSphereUsernameFlag,
 		"",
 		"Encoded base64 Portworx vSphere username")
 	flag.StringVar(&ci_utils.PxVspherePassword,
-		"portworx-vsphere-password",
+		vSpherePasswordFlag,
 		"",
 		"Encoded base64 Portworx vSphere password")
 	flag.StringVar(&ci_utils.PxSpecGenURL,
-		"portworx-spec-gen-url",
+		pxSpecGenURLFlag,
 		"",
 		"Portworx Spec Generator URL, defines what Portworx version will be deployed")
 	flag.StringVar(&ci_utils.PxImageOverride,
-		"portworx-image-override",
+		pxImageOverrideFlag,
 		"",
 		"Portworx Image override, defines what Portworx version will be deployed")
 	flag.StringVar(&pxUpgradeHopsURLs,
-		"px-upgrade-hops-url-list",
+		pxUpgradeHopsURLsFlag,
 		"",
 		"List of Portworx Spec Generator URLs separated by commas used for upgrade hops")
 	flag.StringVar(&ci_utils.PxOperatorTag,
-		"operator-image-tag",
+		pxOperatorTagFlag,
 		"",
 		"Operator tag that is needed for deploying PX Operator via Openshift MarketPlace")
 	flag.StringVar(&operatorUpgradeHopsImages,
-		"operator-upgrade-hops-image-list",
+		operatorUpgradeHopsFlag,
 		"",
 		"List of Portworx Operator images separated by commas used for operator upgrade hops")
 	flag.StringVar(&ci_utils.CloudProvider,
-		"cloud-provider",
+		cloudProviderFlag,
 		"",
 		"Type of cloud provider")
 	flag.StringVar(&ci_utils.PxEnvVars,
-		"portworx-env-vars",
+		pxEnvVarsFlag,
 		"",
 		"List of comma separated environment variables that will be added to StorageCluster spec")
 	flag.StringVar(&ci_utils.PxCustomAnnotations,
-		"portworx-custom-annotations",
+		pxCustomAnnotationsFlag,
 		"",
 		"List of comma separated custom annotations that will be added to StorageCluster spec")
 	flag.StringVar(&ci_utils.PxDeviceSpecs,
-		"portworx-device-specs",
+		pxDeviceSpecsFlag,
 		"",
 		"List of `;` separated PX device specs")
 	flag.StringVar(&ci_utils.PxKvdbSpec,
-		"portworx-kvdb-spec",
+		pxKVDBSpecFlag,
 		"",
 		"PX KVDB device spec")
 	flag.BoolVar(&ci_utils.IsOcp,
-		"is-ocp",
+		isOCPFlag,
 		false,
 		"Is this OpenShift")
 	flag.BoolVar(&ci_utils.IsEks,
-		"is-eks",
+		isEKSFlag,
 		false,
 		"Is this EKS")
 	flag.BoolVar(&ci_utils.IsAks,
-		"is-aks",
+		isAKSFlag,
 		false,
 		"Is this AKS")
 	flag.BoolVar(&ci_utils.IsGke,
-		"is-gke",
+		isGKEFlag,
 		false,
 		"Is this GKE")
 	flag.BoolVar(&ci_utils.IsOke,
-		"is-oke",
+		isOKEFlag,
 		false,
 		"Is this OKE")
 	flag.StringVar(&logLevel,
-		"log-level",
+		logLevelFlag,
 		"",
 		"Log level")
 	flag.StringVar(&ci_utils.PxNamespace,
-		"px-namespace",
+		pxNamespaceFlag,
 		"kube-system",
 		"Namespace where the operator will be deployed")
+	flag.BoolVar(&enableDash,
+		enableDashBoardFlag,
+		true,
+		"To enable/disable aetos dashboard reporting")
+	flag.StringVar(&user,
+		userFlag,
+		"nouser",
+		"user name running the tests")
+	flag.StringVar(&testDescription,
+		testDescriptionFlag,
+		"Operator Integration Workflows",
+		"test suite description")
+	flag.StringVar(&testType,
+		testTypeFlag,
+		"integration",
+		"test types like system-test,functional,integration")
+	flag.StringVar(&testTags,
+		testTagsFlag,
+		"",
+		"tags running the tests. Eg: key1:val1,key2:val2")
+	flag.IntVar(&testsetID,
+		testSetIDFlag,
+		0,
+		"testset id to post the results")
+	flag.StringVar(&testBranch,
+		testBranchFlag,
+		"master",
+		"branch of the product")
+	flag.StringVar(&testProduct,
+		testProductFlag,
+		"PxOperator",
+		"Portworx product under test")
 	flag.Parse()
 
 	// Set log level
@@ -129,6 +208,12 @@ func setup() error {
 	}
 	logrus.SetLevel(logrusLevel)
 	logrus.SetOutput(os.Stdout)
+
+	// Setup Aetos
+	err = initAetosDashboard(enableDash, user, testDescription, testType, testTags, testBranch, testProduct, testsetID)
+	if err != nil {
+		return err
+	}
 
 	ci_utils.K8sVersion, err = test_util.GetK8SVersion()
 	if err != nil {
@@ -148,9 +233,6 @@ func setup() error {
 		ci_utils.OperatorUpgradeHopsImageList = strings.Split(operatorUpgradeHopsImages, ",")
 	}
 
-	// TODO: Right now we do not pass any namespaces parameters
-	// and we currently do not support initial operator deployment to be outside of kube-system
-	// will add this functionality in PTX-17953
 	pxOperatorDep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "portworx-operator",
@@ -169,4 +251,126 @@ func setup() error {
 	}
 
 	return nil
+}
+
+func initAetosDashboard(enableDash bool, user string, testDescription string, testType string,
+	testTags string, testBranch string, testProduct string, testsetID int) error {
+	logrus.Infof("Initializing Aetos Dashboard!")
+	dash = aetosutil.Get()
+	if enableDash && !isDashboardReachable() {
+		enableDash = false
+		logrus.Infof("Aetos Dashboard is not reachable. Disabling dashboard reporting.")
+	}
+
+	dash.IsEnabled = enableDash
+	testSet := aetosutil.TestSet{
+		User:        user,
+		Product:     testProduct,
+		Description: testDescription,
+		Branch:      testBranch,
+		TestType:    testType,
+		Tags:        make(map[string]string),
+		Status:      aetosutil.NOTSTARTED,
+	}
+	if testTags != "" {
+		tags, err := splitCsv(testTags)
+		if err != nil {
+			logrus.Fatalf("failed to parse tags: %v. err: %v", testTags, err)
+		} else {
+			for _, tag := range tags {
+				var key, value string
+				if !strings.Contains(tag, ":") {
+					logrus.Infof("Invalid tag %s. Please provide tag in key:value format skipping provided tag", tag)
+				} else {
+					key = strings.SplitN(tag, ":", 2)[0]
+					value = strings.SplitN(tag, ":", 2)[1]
+					testSet.Tags[key] = value
+				}
+			}
+		}
+	}
+
+	/*
+		Get TestSetID based on below precedence
+		1. Check if user has passed in command line and use
+		2. Check if user has set it has an env variable and use
+		3. Check if build.properties available with TestSetID
+		4. If not present create a new one
+	*/
+	val, ok := os.LookupEnv("DASH_UID")
+	if testsetID != 0 {
+		dash.TestSetID = testsetID
+	} else if ok && (val != "" && val != "0") {
+		_, err := strconv.Atoi(val)
+		logrus.Infof(fmt.Sprintf("Using TestSetID: %s set as enviornment variable", val))
+		if err != nil {
+			logrus.Warnf("Failed to convert environment testset id  %v to int, err: %v", val, err)
+		}
+	} else {
+		fileName := "/build.properties"
+		readFile, err := os.Open(fileName)
+		if err == nil {
+			fileScanner := bufio.NewScanner(readFile)
+			fileScanner.Split(bufio.ScanLines)
+			for fileScanner.Scan() {
+				line := fileScanner.Text()
+				if strings.Contains(line, "DASH_UID") {
+					testsetToUse := strings.Split(line, "=")[1]
+					logrus.Infof("Using TestSetID: %s found in build.properties", testsetToUse)
+					dash.TestSetID, err = strconv.Atoi(testsetToUse)
+					if err != nil {
+						logrus.Errorf("Error in getting DASH_UID variable, %v", err)
+					}
+					break
+				}
+			}
+		}
+	}
+	if testsetID != 0 {
+		dash.TestSetID = testsetID
+		err := os.Setenv("DASH_UID", fmt.Sprint(testsetID))
+		if err != nil {
+			logrus.Errorf("Error in setting DASH_UID as env variable, %v", err)
+			return err
+		}
+	}
+
+	dash.TestSet = &testSet
+	return nil
+}
+
+func isDashboardReachable() bool {
+	timeout := 15 * time.Second
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	aboutURL := strings.Replace(aetosutil.DashBoardBaseURL, "dashboard", "datamodel/about", -1)
+	logrus.Infof("Checking URL: %s", aboutURL)
+	response, err := client.Get(aboutURL)
+
+	if err != nil {
+		logrus.Warn(err.Error())
+		return false
+	}
+	if response.StatusCode == 200 {
+		return true
+	}
+	return false
+}
+
+func splitCsv(in string) ([]string, error) {
+	r := csv.NewReader(strings.NewReader(in))
+	r.TrimLeadingSpace = true
+	records, err := r.ReadAll()
+	if err != nil || len(records) < 1 {
+		return []string{}, err
+	} else if len(records) > 1 {
+		return []string{}, fmt.Errorf("multiline CSV not supported")
+	}
+	return records[0], err
 }

--- a/test/integration_test/operator-test-pod-template.yaml
+++ b/test/integration_test/operator-test-pod-template.yaml
@@ -73,6 +73,14 @@ spec:
     - -log-level=LOG_LEVEL
     - -test.run=FOCUS_TESTS
     - -px-namespace=PX_NAMESPACE
+    - -enable-dash=ENABLE_DASH
+    - -testset-id=TESTSET_ID
+    - -user=USER
+    - -product=PRODUCT
+    - -branch=TEST_BRANCH
+    - -test-type=TEST_TYPE
+    - -test-tags=TEST_TAG
+    - -test-desc=TEST_DESCRIPTION
     imagePullPolicy: Always
     image: openstorage/px-operator-test:latest
     securityContext:

--- a/test/integration_test/test-deploy.sh
+++ b/test/integration_test/test-deploy.sh
@@ -174,6 +174,54 @@ case $i in
        shift
        shift
        ;;
+   --enable-dash)
+       echo "Enable Portworx Dashboard: $2"
+       enable_dashboard=$2
+       shift
+       shift
+       ;;
+   --testset-id)
+      echo "testset_id: $2"
+      testset_id=$2
+      shift
+      shift
+      ;;
+   --user)
+      echo "user: $2"
+      user=$2
+      shift
+      shift
+      ;;
+   --product)
+      echo "product: $2"
+      product=$2
+      shift
+      shift
+      ;;
+   --branch)
+      echo "test_branch: $2"
+      test_branch=$2
+      shift
+      shift
+      ;;
+   --test-type)
+      echo "test_type: $2"
+      test_type=$2
+      shift
+      shift
+      ;;
+   --test-tags)
+      echo "test_tags: $2"
+      test_tag=$2
+      shift
+      shift
+      ;;
+   --test_desc)
+      echo "test_description: $2"
+      test_description=$2
+      shift
+      shift
+      ;;
 esac
 done
 
@@ -324,6 +372,63 @@ if [ "$portworx_vsphere_username" != "" ] && [ "$portworx_vsphere_password" != "
 else
     sed -i '/PORTWORX_VSPHERE_USERNAME/d' $test_pod_spec
     sed -i '/PORTWORX_VSPHERE_PASSWORD/d' $test_pod_spec
+fi
+
+if [ "$enable_dashboard" != "" ]; then
+	sed -i 's/'ENABLE_DASH'/'"$enable_dashboard"'/g' $test_pod_spec
+else
+  sed -i 's/'ENABLE_DASH'/true/g' $test_pod_spec
+fi
+
+if [ -e /build.properties ]; then
+    testset_id=$(< /build.properties grep -i "DASH_UID=" | grep -Eo '[0-9]+')
+else
+    testset_id=""
+fi
+
+if [ "$testset_id" != "" ]; then
+	sed -i 's/'TESTSET_ID'/'"$testset_id"'/g' $test_pod_spec
+else
+  sed -i 's/'TESTSET_ID'/0/g' $test_pod_spec
+fi
+
+if [ "$user" != "" ]; then
+	# shellcheck disable=SC2026
+	sed -i 's/'USER'/'"$user"'/g' $test_pod_spec
+else
+  # shellcheck disable=SC2026
+  sed -i 's/'USER'/"nouser"/g' $test_pod_spec
+fi
+
+if [ "$product" != "" ]; then
+	# shellcheck disable=SC2026
+	sed -i 's|'PRODUCT'|'"$product"'|g' $test_pod_spec
+else
+  sed -i 's|"PRODUCT"|"operator"|g' $test_pod_spec
+fi
+
+if [ "$test_branch" != "" ]; then
+	sed -i 's/'TEST_BRANCH'/'"$test_branch"'/g' $test_pod_spec
+else
+  sed -i 's/'TEST_BRANCH'/"master"/g' $test_pod_spec
+fi
+
+if [ "$test_type" != "" ]; then
+	sed -i 's/'TEST_TYPE'/'"$test_type"'/g' $test_pod_spec
+else
+  sed -i 's/'TEST_TYPE'/"operator-integration-test"/g' $test_pod_spec
+fi
+
+if [ "$test_tag" != "" ]; then
+	sed -i 's/'TEST_TAG'/'"$test_tag"'/g' $test_pod_spec
+else
+  sed -i 's/'TEST_TAG'/""/g' $test_pod_spec
+fi
+
+if [ "$test_description" != "" ]; then
+	sed -i 's/'TEST_DESCRIPTION'/'"$test_description"'/g' $test_pod_spec
+else
+  sed -i 's/'TEST_DESCRIPTION'/"operator-integration-test workflows"/g' $test_pod_spec
 fi
 
 # Set test image

--- a/test/integration_test/utils/aetos/dashboardutil.go
+++ b/test/integration_test/utils/aetos/dashboardutil.go
@@ -1,0 +1,555 @@
+package aetos
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	testCasesStack = make([]int, 0)
+	testCase       TestCase
+
+	dash *Dashboard
+	lock = &sync.Mutex{}
+)
+
+const (
+	//DashBoardBaseURL for posting logs
+	DashBoardBaseURL = "https://aetos.pwx.purestorage.com/dashboard"
+	AetosBaseURL     = "https://aetos.pwx.purestorage.com"
+)
+
+const (
+	//PASS status for testset/testcase
+	PASS = "PASS"
+	//FAIL status for testset/testcase
+	FAIL = "FAIL"
+	//ABORT status for testset/testcase
+	ABORT = "ABORT"
+	//TIMEOUT status for testset/testcase
+	TIMEOUT = "TIMEOUT"
+	//ERROR status for testset/testcase
+	ERROR = "ERROR"
+	// NOTSTARTED  status for testset/testcase
+	NOTSTARTED = "NOT_STARTED"
+	// INPROGRESS  status for testset/testcase
+	INPROGRESS = "IN_PROGRESS"
+)
+
+type testCaseUpdateResponse struct {
+	Status         string `json:"status"`
+	TestCaseStatus string `json:"testCaseStatus"`
+}
+
+// Dashboard aetos dashboard structure
+type Dashboard struct {
+	//IsEnabled enable/disable dashboard logging
+	IsEnabled bool
+	//TestSetID test set ID to post the test logs and results
+	TestSetID int
+	//TestSet object created during initialization
+	TestSet           *TestSet
+	testcaseID        int
+	testSetStartTime  time.Time
+	testCaseStartTime time.Time
+}
+
+// TestSet struct
+type TestSet struct {
+	CommitID    string            `json:"commitId"`
+	User        string            `json:"user"`
+	Product     string            `json:"product"`
+	Description string            `json:"description"`
+	HostOs      string            `json:"hostOs"`
+	Branch      string            `json:"branch"`
+	TestType    string            `json:"testType"`
+	Tags        map[string]string `json:"nTags"`
+	Status      string            `json:"status"`
+}
+
+// TestCase struct
+type TestCase struct {
+	Name       string `json:"name"`
+	ShortName  string `json:"shortName"`
+	ModuleName string `json:"moduleName"`
+
+	Status      string            `json:"status"`
+	Errors      []string          `json:"errors"`
+	LogFile     string            `json:"logFile"`
+	Description string            `json:"description"`
+	Command     string            `json:"command"`
+	HostOs      string            `json:"hostOs"`
+	Tags        map[string]string `json:"nTags"`
+	TestSetID   int               `json:"testSetID"`
+	TestRailID  string            `json:"testRepoID"`
+	Duration    string            `json:"duration"`
+	TestType    string            `json:"testType"`
+}
+
+type result struct {
+	TestCaseID   int    `json:"testCaseID"`
+	Description  string `json:"description"`
+	Actual       string `json:"actual"`
+	Expected     string `json:"expected"`
+	ResultType   string `json:"type"`
+	ResultStatus bool   `json:"result"`
+}
+
+type comment struct {
+	TestCaseID  int    `json:"testCaseID"`
+	Description string `json:"description"`
+	ResultType  string `json:"type"`
+}
+
+type stats struct {
+	Name      string            `json:"name"`
+	Product   string            `json:"product"`
+	StatsType string            `json:"statsType"`
+	Version   string            `json:"version"`
+	Data      map[string]string `json:"data"`
+}
+
+// TestSetBegin start testset and push data to dashboard DB
+func (d *Dashboard) TestSetBegin(testSet *TestSet) {
+	dashURL := "Dash is disabled"
+	if d.IsEnabled && d.TestSetID == 0 {
+
+		if testSet.Description == "" {
+			testSet.Description = "Operator Integration Workflows"
+		}
+
+		if testSet.User == "" {
+			testSet.User = "nouser"
+		}
+
+		if testSet.TestType == "" {
+			testSet.TestType = "SystemTest"
+		}
+
+		if testSet.Product == "" {
+			testSet.Product = "px-operator"
+		}
+
+		if testSet.HostOs == "" {
+			testSet.HostOs = runtime.GOOS
+		}
+
+		createTestSetURL := fmt.Sprintf("%s/testset", DashBoardBaseURL)
+		resp, respStatusCode, err := POST(createTestSetURL, testSet, nil, nil)
+		if err != nil {
+			logrus.Errorf("error in starting TestSet, Cause: %v", err)
+		} else if respStatusCode != http.StatusOK {
+			logrus.Errorf("failed to create TestSet, resp : %s", string(resp))
+		} else {
+			d.TestSetID, err = strconv.Atoi(string(resp))
+			if err != nil {
+				logrus.Errorf("TestSetId creation failed. Cause : %v", err)
+			}
+		}
+	}
+	if d.TestSetID != 0 {
+		dashURL = fmt.Sprintf("Dashboard URL : %s/resultSet/testSetID/%d", AetosBaseURL, d.TestSetID)
+		err := os.Setenv("DASH_UID", fmt.Sprint(d.TestSetID))
+		if err != nil {
+			logrus.Errorf("Error setting DASH_UID, Cause: %v", err)
+			return
+		}
+	}
+	logrus.Infof(dashURL)
+}
+
+// TestSetEnd end testset and update  to dashboard DB
+func (d *Dashboard) TestSetEnd() {
+
+	if d.IsEnabled {
+		if d.TestSetID == 0 {
+			return
+		}
+		if len(testCasesStack) > 0 {
+			for _, v := range testCasesStack {
+				d.testcaseID = v
+				d.TestCaseEnd()
+			}
+			testCasesStack = nil
+		}
+
+		updateTestSetURL := fmt.Sprintf("%s/testset/%d/end", DashBoardBaseURL, d.TestSetID)
+		resp, respStatusCode, err := PUT(updateTestSetURL, nil, nil, nil)
+
+		if err != nil {
+			logrus.Errorf("Error in updating TestSet, Cause: %v", err)
+		} else if respStatusCode != http.StatusOK {
+			logrus.Errorf("Failed to end TestSet, Resp : %s", string(resp))
+		}
+		logrus.Infof("Dashboard URL : %s", fmt.Sprintf("%s/resultSet/testSetID/%d", AetosBaseURL, d.TestSetID))
+	}
+}
+
+// TestCaseEnd update testcase  to dashboard DB
+func (d *Dashboard) TestCaseEnd() {
+	if d.IsEnabled {
+
+		if d.testcaseID == 0 {
+			return
+		}
+
+		url := fmt.Sprintf("%s/testcase/%d/end", DashBoardBaseURL, d.testcaseID)
+		resp, respStatusCode, err := PUT(url, nil, nil, nil)
+
+		if err != nil {
+			logrus.Errorf("Error in updating TestCase, Cause: %v", err)
+		} else if respStatusCode != http.StatusOK {
+			logrus.Errorf("Failed to end TestCase, Resp : %s", string(resp))
+		}
+
+		removeTestCaseFromStack(d.testcaseID)
+
+		var updateResponse testCaseUpdateResponse
+		err = json.Unmarshal(resp, &updateResponse)
+		if err != nil {
+			logrus.Errorf("Error parsing update test output, %v", err)
+		}
+		testCaseResult := updateResponse.TestCaseStatus
+		d.VerifySafely(testCaseResult, "PASS", "Test completed successfully ?")
+	}
+
+	logrus.Info("--------Test End------")
+	logrus.Infof("#Test: %s ", testCase.Name)
+	logrus.Infof("#Description: %s ", testCase.Description)
+	logrus.Info("------------------------")
+}
+
+func removeTestCaseFromStack(testcaseID int) {
+
+	removeIndex := -1
+	for i, v := range testCasesStack {
+		if v == testcaseID {
+			removeIndex = i
+			break
+		}
+	}
+
+	if removeIndex != -1 {
+		testCasesStack = append(testCasesStack[:removeIndex], testCasesStack[removeIndex+1:]...)
+	}
+
+}
+
+// TestSetUpdate update test set  to dashboard DB
+func (d *Dashboard) TestSetUpdate(testSet *TestSet) {
+
+	if d.IsEnabled {
+
+		if d.TestSetID == 0 {
+			return
+		}
+
+		updateTestSetURL := fmt.Sprintf("%s/testset/%d", DashBoardBaseURL, d.TestSetID)
+		resp, respStatusCode, err := PUT(updateTestSetURL, testSet, nil, nil)
+
+		if err != nil {
+			logrus.Errorf("Error in updating TestSet, Cause: %v", err)
+		} else if respStatusCode != http.StatusOK {
+			logrus.Errorf("Failed to update TestSet, Resp : %s", string(resp))
+		}
+	}
+}
+
+// TestCaseBegin start the test case and push data to dashboard DB
+func (d *Dashboard) TestCaseBegin(testName, description, testRailID string, tags map[string]string) {
+
+	logrus.Info("--------Test Start------")
+	logrus.Infof("#Test: %s ", testName)
+	logrus.Infof("#Description: %s ", description)
+	logrus.Info("------------------------")
+	if d.IsEnabled {
+		if d.TestSetID == 0 {
+			return
+		}
+
+		testCase = TestCase{}
+		testCase.Tags = make(map[string]string)
+		testCase.Name = testName
+
+		_, file, _, ok := runtime.Caller(1)
+		if ok {
+
+			m := regexp.MustCompile(`operator`)
+
+			r := m.FindStringIndex(file)
+			if r != nil {
+				fp := file[r[0]:]
+				testCase.ModuleName = fp
+				files := strings.Split(fp, "/")
+				testCase.ShortName = files[len(files)-1]
+
+				logrus.Infof("Running test from file %s, module: %s", fp, testName)
+
+			}
+
+		}
+		//t.StartTime = time.Now().Format(time.RFC3339)
+		testCase.Status = INPROGRESS
+		testCase.Description = description
+		testCase.HostOs = runtime.GOOS
+		testCase.TestType = "TEST"
+
+		testCase.TestSetID = d.TestSetID
+		testCase.TestRailID = testRailID
+
+		// Check for common env variables and add as tags
+		testCase.Tags["operator-integration-test"] = "true"
+		if os.Getenv("JOB_NAME") != "" {
+			testCase.Tags["JOB_NAME"] = os.Getenv("JOB_NAME")
+		}
+		if os.Getenv("BUILD_URL") != "" {
+			testCase.Tags["BUILD_URL"] = os.Getenv("BUILD_URL")
+		}
+
+		for key, val := range tags {
+			testCase.Tags[key] = val
+		}
+		dash.testCaseStartTime = time.Now()
+
+		createTestCaseURL := fmt.Sprintf("%s/testcase", DashBoardBaseURL)
+
+		resp, respStatusCode, err := POST(createTestCaseURL, testCase, nil, nil)
+		if err != nil {
+			logrus.Errorf("Error in starting TesteCase, Cause: %v", err)
+		} else if respStatusCode != http.StatusOK {
+			logrus.Errorf("Error creating test case, resp :%s", string(resp))
+		} else {
+			d.testcaseID, err = strconv.Atoi(string(resp))
+			if err != nil {
+				logrus.Errorf("TestCase creation failed. Cause : %v", err)
+			}
+		}
+		d.Infof("Integration Test Command: %s", os.Args)
+		testCasesStack = append(testCasesStack, d.testcaseID)
+
+	}
+}
+
+func (d *Dashboard) verify(r result) {
+	if d.IsEnabled {
+
+		if r.TestCaseID == 0 {
+			return
+		}
+
+		commentURL := fmt.Sprintf("%s/result", DashBoardBaseURL)
+
+		resp, respStatusCode, err := POST(commentURL, r, nil, nil)
+		if err != nil {
+			logrus.Errorf("Error in updating verification to dashboard, Cause: %v", err)
+		} else if respStatusCode != http.StatusOK {
+			logrus.Errorf("Error updating the verify comment, resp : %s", string(resp))
+		}
+	}
+}
+
+// VerifyFatal verify test and abort operation upon failure
+func (d *Dashboard) VerifyFatal(t *testing.T, actual, expected interface{}, description string) {
+	actualVal := fmt.Sprintf("%v", actual)
+	expectedVal := fmt.Sprintf("%v", expected)
+
+	d.VerifySafely(actual, expected, description)
+
+	if actualVal != expectedVal {
+		d.TestSetEnd()
+		d.Error(fmt.Sprintf("Fatal error occurred in %v", description))
+		t.FailNow()
+	}
+}
+
+// VerifySafely verify test without aborting the execution
+func (d *Dashboard) VerifySafely(actual, expected interface{}, description string) {
+	if actual == nil && expected == nil {
+		actual = true
+		expected = true
+	}
+
+	actualVal := fmt.Sprintf("%v", actual)
+	expectedVal := fmt.Sprintf("%v", expected)
+	res := result{}
+
+	res.Actual = actualVal
+	res.Expected = expectedVal
+	res.Description = description
+	res.TestCaseID = d.testcaseID
+
+	logrus.Infof("Verifying : Description : %s", description)
+	if actualVal == expectedVal {
+		res.ResultType = "info"
+		res.ResultStatus = true
+		logrus.Infof("Actual:%v, Expected: %v", actual, expected)
+	} else {
+		res.ResultType = "error"
+		res.ResultStatus = false
+		if actual != nil && reflect.TypeOf(actual).String() == "*errors.errorString" {
+			d.Errorf(fmt.Sprintf("%v", actual))
+			logrus.Errorf(fmt.Sprintf("%v", actual))
+			res.Actual = "Error"
+			res.Expected = "nil"
+		} else {
+			logrus.Errorf("Actual:%v, Expected: %v", actual, expected)
+		}
+	}
+	if d.IsEnabled {
+		d.verify(res)
+	}
+}
+
+func (d *Dashboard) Fatal(description string, args ...interface{}) {
+	res := result{}
+	res.Actual = "false"
+	res.Expected = "true"
+	res.Description = fmt.Sprintf(description, args...)
+	res.TestCaseID = d.testcaseID
+	res.ResultStatus = false
+	res.ResultType = "error"
+	if d.IsEnabled {
+		d.verify(res)
+	}
+}
+
+// Info logging info message
+func (d *Dashboard) Info(message string) {
+	if d.IsEnabled {
+		res := comment{}
+		res.TestCaseID = d.testcaseID
+		res.Description = message
+		res.ResultType = "info"
+		d.addComment(res)
+	}
+}
+
+// Infof logging info with formated message
+func (d *Dashboard) Infof(message string, args ...interface{}) {
+	if d.IsEnabled {
+		fmtMsg := fmt.Sprintf(message, args...)
+		res := comment{}
+		res.TestCaseID = d.testcaseID
+		res.Description = fmtMsg
+		res.ResultType = "info"
+		d.addComment(res)
+	}
+}
+
+// Warnf logging formatted warn message
+func (d *Dashboard) Warnf(message string, args ...interface{}) {
+	if d.IsEnabled {
+		fmtMsg := fmt.Sprintf(message, args...)
+		res := comment{}
+		res.TestCaseID = d.testcaseID
+		res.Description = fmtMsg
+		res.ResultType = "warning"
+		d.addComment(res)
+	}
+}
+
+// Warn logging warn message
+func (d *Dashboard) Warn(message string) {
+	if d.IsEnabled {
+		res := comment{}
+		res.TestCaseID = d.testcaseID
+		res.Description = message
+		res.ResultType = "warning"
+		d.addComment(res)
+	}
+}
+
+// Error logging error message
+func (d *Dashboard) Error(message string) {
+	if d.IsEnabled {
+		res := comment{}
+		res.TestCaseID = d.testcaseID
+		res.Description = message
+		res.ResultType = "error"
+		d.addComment(res)
+	}
+}
+
+// Errorf logging formatted error message
+func (d *Dashboard) Errorf(message string, args ...interface{}) {
+	if d.IsEnabled {
+		fmtMsg := fmt.Sprintf(message, args...)
+		res := comment{}
+		res.TestCaseID = d.testcaseID
+		res.Description = fmtMsg
+		res.ResultType = "error"
+		d.addComment(res)
+	}
+}
+
+func (d *Dashboard) addComment(c comment) {
+	if d.IsEnabled {
+
+		if c.TestCaseID == 0 {
+			return
+		}
+
+		commentURL := fmt.Sprintf("%s/result", DashBoardBaseURL)
+
+		resp, respStatusCode, err := POST(commentURL, c, nil, nil)
+		if err != nil {
+			logrus.Errorf("Error in adding log message to dashboard, Cause: %v", err)
+		} else if respStatusCode != http.StatusOK {
+			logrus.Errorf("Error updating the vrify comment, resp : %s", string(resp))
+		}
+	}
+}
+
+// Get returns the dashboard struct instance
+func Get() *Dashboard {
+	if dash == nil {
+		lock.Lock()
+		defer lock.Unlock()
+		if dash == nil {
+			fmt.Println("Creating new Dashboard instance.")
+			dash = &Dashboard{}
+		}
+	}
+	dash.testSetStartTime = time.Now()
+	return dash
+}
+
+func (d *Dashboard) UpdateStats(name, product, statType, version string, dashStats map[string]string) {
+	if d.IsEnabled {
+
+		dashStats["dash-url"] = fmt.Sprintf("%s/resultSet/testSetID/%d", AetosBaseURL, d.TestSetID)
+		st := stats{
+			Name:      name,
+			Product:   product,
+			StatsType: statType,
+			Version:   version,
+			Data:      dashStats,
+		}
+
+		statsURL := fmt.Sprintf("%s/stats", DashBoardBaseURL)
+		logrus.Infof("pushing stats to aetos: %v", st)
+
+		resp, respStatusCode, err := POST(statsURL, st, nil, nil)
+		if err != nil {
+			logrus.Errorf("Error in updating stats to dashboard, Cause: %v", err)
+		} else if respStatusCode != http.StatusOK {
+			logrus.Errorf("Error updating the stats, resp : %s", string(resp))
+		} else {
+			logrus.Infof("stats response: %v", resp)
+			logrus.Infof("stats status code: %d", respStatusCode)
+		}
+
+	}
+}

--- a/test/integration_test/utils/aetos/log.go
+++ b/test/integration_test/utils/aetos/log.go
@@ -1,0 +1,16 @@
+package aetos
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+//
+//func init() {
+//	dash = Get()
+//}
+
+// Infof logs the message to the dashboard and log
+func Infof(format string, args ...interface{}) {
+	dash.Infof(format, args...)
+	logrus.Infof(format, args...)
+}

--- a/test/integration_test/utils/storagecluster.go
+++ b/test/integration_test/utils/storagecluster.go
@@ -280,6 +280,30 @@ func DeployAndValidateStorageCluster(cluster *corev1.StorageCluster, pxSpecImage
 	return liveCluster
 }
 
+// DeployAndValidateStorageClusterAetosDemo creates and validates StorageCluster for Aetos Wrapper Demo
+func DeployAndValidateStorageClusterAetosDemo(cluster *corev1.StorageCluster, pxSpecImages map[string]string) (*corev1.StorageCluster, error) {
+	// Create StorageCluster
+	cluster, err := DeployStorageCluster(cluster, pxSpecImages)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate StorageCluster deployment
+	logrus.Infof("Validate StorageCluster %s", cluster.Name)
+	err = testutil.ValidateStorageCluster(pxSpecImages, cluster, DefaultValidateDeployTimeout, DefaultValidateDeployRetryInterval, true, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the latest version of StorageCluster
+	liveCluster, err := operator.Instance().GetStorageCluster(cluster.Name, cluster.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return liveCluster, nil
+
+}
+
 // UpdateStorageCluster updates the given StorageCluster and return latest live version of it
 func UpdateStorageCluster(cluster *corev1.StorageCluster) (*corev1.StorageCluster, error) {
 	logrus.Infof("Update StorageCluster %s in %s", cluster.Name, cluster.Namespace)
@@ -500,6 +524,25 @@ func UninstallAndValidateStorageCluster(cluster *corev1.StorageCluster, t *testi
 	logrus.Infof("Validate StorageCluster [%s] deletion", cluster.Name)
 	err = testutil.ValidateUninstallStorageCluster(cluster, DefaultValidateUninstallTimeout, DefaultValidateUninstallRetryInterval)
 	require.NoError(t, err)
+
+}
+
+// UninstallAndValidateStorageClusterAetosDemo uninstall and validate the cluster deletion for Aetos wrapper demo
+func UninstallAndValidateStorageClusterAetosDemo(cluster *corev1.StorageCluster) error {
+	// Delete cluster
+	logrus.Infof("Delete StorageCluster [%s]", cluster.Name)
+	err := testutil.UninstallStorageCluster(cluster)
+	if err != nil {
+		return err
+	}
+	// Validate cluster deletion
+	logrus.Infof("Validate StorageCluster [%s] deletion", cluster.Name)
+	err = testutil.ValidateUninstallStorageCluster(cluster, DefaultValidateUninstallTimeout, DefaultValidateUninstallRetryInterval)
+	if err != nil {
+		return err
+	}
+
+	return err
 }
 
 // ValidateStorageClusterComponents validates storage cluster components


### PR DESCRIPTION
This purpose of this PR is to integrate Aétos with operator integration tests.

main_test.go is modified to init the Aetos Dashboard (functions defined under `test/integration_test/utils/aetos`)
run time flags are also modified as constants to beautify the code. No change to parsing logic for these flags.

basic_test.go has 2 additions: testCase `BasicInstallAetosDemo` and test `TestBasicInstall`
We would need to update other testCases as per `BasicInstallAetosDemo` and test `TestStorageClusterBasic` as per `TestBasicInstall` for correct reporting into Aétos. 

storagecluster.go has 2 additions as well: functions `DeployAndValidateStorageClusterAetosDemo` and `UninstallAndValidateStorageClusterAetosDemo`
The reason for putting these Demo functions is that the current implementation for testSteps have `require.NoError(t, err)` checks instead of returning err to caller functions in basic_test.go -> this makes it hard/impossible to catch the error at testCase level. 

The reason for adding new functions is to not cause any regression and keep these as placeholder for future changes. 
This would require a major revamp of the integration test code to integrate all of the tests to Aétos.