### PR TITLE
PWX-36730 : Add namespace resource access permission to Portworx clusterrole

### DIFF
--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -412,6 +412,11 @@ func (c *portworxBasic) createClusterRole() error {
 					Resources: []string{"virtualmachineinstancemigrations"},
 					Verbs:     []string{"get", "list", "create", "watch", "delete", "update"},
 				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"namespaces"},
+					Verbs:     []string{"get", "list"},
+				},
 			},
 		},
 	)

--- a/drivers/storage/portworx/testspec/portworxClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/portworxClusterRole.yaml
@@ -68,3 +68,6 @@ rules:
 - apiGroups: ["kubevirt.io"]
   resources: ["virtualmachineinstancemigrations"]
   verbs: ["get", "list", "create", "watch", "delete", "update"]
+- apiGroups: [ "" ]
+  resources: [ "namespaces" ]
+  verbs: [ "get", "list" ]


### PR DESCRIPTION
**What this PR does / why we need it**: There are few error logs seen in Portworx like **cannot get resource \"namespaces\" in API group \"\" in the namespace** , because Portworx Clusterrole does not have namespace resource permission. This PR adds the permission for namespace resource to Portworx Clusterrole.

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-36730

**Special notes for your reviewer**:
- Verified on OCP 4.14 and OCP 4.15
- Verified by creating apps and volume encryption, which hits the code path where it needs namespace resource access.
- No Forbidden error is seen.
