### PR TITLE
PWX-36159: Use different port for PVC deployment on k3s

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -2197,9 +2197,6 @@ func verifyPVCControllerInstall(
 	serviceAccountList := &v1.ServiceAccountList{}
 	err := testutil.List(k8sClient, serviceAccountList)
 	require.NoError(t, err)
-	fmt.Println(serviceAccountList.Items[0].Name)
-	fmt.Println(serviceAccountList.Items[1].Name)
-
 	require.Len(t, serviceAccountList.Items, 2)
 
 	sa := &v1.ServiceAccount{}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -2198,7 +2198,7 @@ func verifyPVCControllerInstall(
 	err := testutil.List(k8sClient, serviceAccountList)
 	require.NoError(t, err)
 	fmt.Println(serviceAccountList.Items[0].Name)
-	// fmt.Println(serviceAccountList.Items[1].Name)
+	fmt.Println(serviceAccountList.Items[1].Name)
 
 	require.Len(t, serviceAccountList.Items, 2)
 

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -2037,10 +2037,10 @@ func TestPVCControllerInstallForAKS(t *testing.T) {
 	specFileName := "pvcControllerDeployment.yaml"
 	pvcControllerDeployment := testutil.GetExpectedDeployment(t, specFileName)
 	command := pvcControllerDeployment.Spec.Template.Spec.Containers[0].Command
-	command = append(command, "--port="+component.AksPVCControllerInsecurePort)
-	command = append(command, "--secure-port="+component.AksPVCControllerSecurePort)
+	command = append(command, "--port="+component.CustomPVCControllerInsecurePort)
+	command = append(command, "--secure-port="+component.CustomPVCControllerSecurePort)
 	pvcControllerDeployment.Spec.Template.Spec.Containers[0].Command = command
-	pvcControllerDeployment.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet.Port = intstr.Parse(component.AksPVCControllerInsecurePort)
+	pvcControllerDeployment.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet.Port = intstr.Parse(component.CustomPVCControllerInsecurePort)
 
 	verifyPVCControllerDeploymentObject(t, cluster, k8sClient, pvcControllerDeployment)
 
@@ -2058,15 +2058,12 @@ func TestPVCControllerInstallForK3s(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()
 
-	fakeK8sNodes := &v1.NodeList{Items: []v1.Node{
-		{ObjectMeta: metav1.ObjectMeta{Name: "node1"}, Status: v1.NodeStatus{NodeInfo: v1.NodeSystemInfo{KubeletVersion: "v1.27.5+k3s1"}}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "node2"}, Status: v1.NodeStatus{NodeInfo: v1.NodeSystemInfo{KubeletVersion: "v1.26.5+k3s1"}}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "node3"}, Status: v1.NodeStatus{NodeInfo: v1.NodeSystemInfo{KubeletVersion: "v1.27.5+k3s1"}}},
-	}}
+	k8sClient := testutil.FakeK8sClient()
 
-	k8sClient := testutil.FakeK8sClient(fakeK8sNodes)
-
-	versionClient := fakek8sclient.NewSimpleClientset(fakeK8sNodes)
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.18.0+k3s1",
+	}
 	coreops.SetInstance(coreops.New(versionClient))
 
 	driver := portworx{}
@@ -2091,10 +2088,11 @@ func TestPVCControllerInstallForK3s(t *testing.T) {
 	specFileName := "pvcControllerDeployment.yaml"
 	pvcControllerDeployment := testutil.GetExpectedDeployment(t, specFileName)
 	command := pvcControllerDeployment.Spec.Template.Spec.Containers[0].Command
-	command = append(command, "--port="+component.K3sPVCControllerInsecurePort)
-	command = append(command, "--secure-port="+component.K3sPVCControllerSecurePort)
+	command = append(command, "--port="+component.CustomPVCControllerInsecurePort)
+	command = append(command, "--secure-port="+component.CustomPVCControllerSecurePort)
 	pvcControllerDeployment.Spec.Template.Spec.Containers[0].Command = command
-	pvcControllerDeployment.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet.Port = intstr.Parse(component.K3sPVCControllerInsecurePort)
+	pvcControllerDeployment.Spec.Template.Spec.Containers[0].Image = "gcr.io/google_containers/kube-controller-manager-amd64:v1.18.0"
+	pvcControllerDeployment.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet.Port = intstr.Parse(component.CustomPVCControllerInsecurePort)
 
 	verifyPVCControllerDeploymentObject(t, cluster, k8sClient, pvcControllerDeployment)
 }

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1950,7 +1950,7 @@ func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 
 func isK3sClusterExt(ext string) bool {
 	if len(ext) > 0 {
-		return strings.HasPrefix(ext[1:], "k3s") || strings.HasPrefix(ext[1:], "rke2")
+		return pxutil.IsK3sClusterExt(ext)
 	}
 	return false
 }

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1950,7 +1950,7 @@ func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 
 func isK3sClusterExt(ext string) bool {
 	if len(ext) > 0 {
-		return pxutil.IsK3sClusterExt(ext)
+		return pxutil.IsK3sClusterExt(ext) || strings.HasPrefix(ext[1:], "rke2")
 	}
 	return false
 }

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -328,7 +328,7 @@ var (
 	// flag in the node object of the PX SDK response.
 	MinimumPxVersionQuorumFlag, _ = version.NewVersion("3.1.0")
 
-	//MinimumPxVersionClusterDomain is a minimal PX version that exposes cluster domain field in enumerate nodes response
+	// MinimumPxVersionClusterDomain is a minimal PX version that exposes cluster domain field in enumerate nodes response
 	MinimumPxVersionClusterDomain, _ = version.NewVersion("3.1.1")
 
 	// ConfigMapNameRegex regex of configMap.
@@ -1901,4 +1901,8 @@ func isVersionSupported(current, target string) bool {
 	}
 
 	return currentVersion.Core().GreaterThanOrEqual(targetVersion)
+}
+
+func IsK3sClusterExt(ext string) bool {
+	return strings.HasPrefix(ext[1:], "k3s") || strings.HasPrefix(ext[1:], "rke2")
 }

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1904,5 +1904,5 @@ func isVersionSupported(current, target string) bool {
 }
 
 func IsK3sClusterExt(ext string) bool {
-	return strings.HasPrefix(ext[1:], "k3s") || strings.HasPrefix(ext[1:], "rke2")
+	return strings.HasPrefix(ext[1:], "k3s")
 }


### PR DESCRIPTION
**What this PR does / why we need it**: PVC controller is in CrashLoopBackOff when deployed on k3s master node because of  following error.
**failed to create listener: failed to listen on 0.0.0.0:10257: listen tcp 0.0.0.0:10257: bind: address already in use"**

The default ports 10252 and 10257 for PVC are already in use on k3s clusters. This PR chenges the default config, and uses port numbers 10260 and 10261 on k3s deployment.

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-36159

**Special notes for your reviewer**:
- Verified on k3s cluster, with pvc annotation enabled.
-  All 3 PVCs pods are running fine
I0403 12:46:30.728036       1 secure_serving.go:213] Serving securely on 0.0.0.0:10261
