### PR TITLE
PWX-36838 : Failed to validate PX node after StorageCluster update, Access denied without authentication token 

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -990,7 +990,9 @@ func (p *portworx) GetKVDBMembers(cluster *corev1.StorageCluster) (map[string]bo
 		return nil, fmt.Errorf("error in connecting to portworx sdk server: %s", err)
 	}
 	serviceClient := pxapi.NewPortworxServiceClient(p.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -993,12 +993,9 @@ func (p *portworx) GetKVDBMembers(cluster *corev1.StorageCluster) (map[string]bo
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	// if security is enabled, use token
-	if cluster.Spec.Security != nil && cluster.Spec.Security.Enabled {
-		ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient)
-		if err != nil {
-			return nil, err
-		}
+	ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient)
+	if err != nil {
+		return nil, err
 	}
 
 	members, err := serviceClient.GetKvdbMemberInfo(ctx, &pxapi.PxKvdbMemberRequest{})

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -992,9 +992,13 @@ func (p *portworx) GetKVDBMembers(cluster *corev1.StorageCluster) (map[string]bo
 	serviceClient := pxapi.NewPortworxServiceClient(p.sdkConn)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
-	ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient)
-	if err != nil {
-		return nil, err
+
+	// if security is enabled, use token
+	if cluster.Spec.Security != nil && cluster.Spec.Security.Enabled {
+		ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	members, err := serviceClient.GetKvdbMemberInfo(ctx, &pxapi.PxKvdbMemberRequest{})

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -990,8 +990,10 @@ func (p *portworx) GetKVDBMembers(cluster *corev1.StorageCluster) (map[string]bo
 		return nil, fmt.Errorf("error in connecting to portworx sdk server: %s", err)
 	}
 	serviceClient := pxapi.NewPortworxServiceClient(p.sdkConn)
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient)
+	if err != nil {
+		return nil, err
+	}
 
 	members, err := serviceClient.GetKvdbMemberInfo(ctx, &pxapi.PxKvdbMemberRequest{})
 

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -11701,6 +11701,105 @@ func TestGetKVDBMembers(t *testing.T) {
 
 }
 
+func TestGetKVDBMembersWithSecurityEnabled(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockServiceService := mock.NewMockPortworxServiceServer(mockCtrl)
+
+	sdkServerIP := "127.0.0.1"
+	sdkServerPort := 21883
+	mockSdk := mock.NewSdkServer(mock.SdkServers{
+		PortworxService: mockServiceService,
+	})
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Status: corev1.StorageClusterStatus{
+			Phase: string(corev1.ClusterStateInit),
+		},
+		Spec: corev1.StorageClusterSpec{
+			Security: &corev1.SecuritySpec{
+				Enabled: true, // enable security
+				Auth: &corev1.AuthSpec{
+					GuestAccess: guestAccessTypePtr(corev1.GuestRoleDisabled), // guest access disabled
+				},
+			},
+		},
+	}
+
+	// Create fake k8s client with fake service that will point the client
+	// to the mock sdk server address
+	k8sClient := testutil.FakeK8sClient(
+		&v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pxutil.PortworxServiceName,
+				Namespace: "kube-test",
+			},
+			Spec: v1.ServiceSpec{
+				ClusterIP: sdkServerIP,
+				Ports: []v1.ServicePort{
+					{
+						Name: pxutil.PortworxSDKPortName,
+						Port: int32(sdkServerPort),
+					},
+				},
+			},
+		},
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "px-system-secrets",
+				Namespace: cluster.Namespace,
+			},
+			Data: map[string][]byte{
+				pxutil.SecuritySystemSecretKey: []byte("system-secret"),
+				pxutil.SecurityAppsSecretKey:   []byte("apps-secret"),
+			},
+		},
+	)
+
+	// Create driver object with the fake k8s client
+	driver := portworx{
+		k8sClient: k8sClient,
+		recorder:  record.NewFakeRecorder(10),
+	}
+
+	// Case 1: When GRPC server is not running or cannot connect to it
+	val, err := driver.GetKVDBMembers(cluster)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error connecting to GRPC server")
+	require.Empty(t, val)
+
+	// Start the server
+	sdkError := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
+	require.NoError(t, sdkError)
+	defer mockSdk.Stop()
+
+	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer testutil.RestoreEtcHosts(t)
+
+	// Case 2: When the portworx service server returns an error
+	expectedError := fmt.Errorf("test error from portworx service server")
+	mockServiceService.EXPECT().GetKvdbMemberInfo(gomock.Any(), gomock.Any()).Return(nil, expectedError).Times(1)
+
+	val, err = driver.GetKVDBMembers(cluster)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("error in getting kvdb member info from sdk: rpc error: code = Unknown desc = %s", expectedError))
+	require.Empty(t, val)
+
+	// Case 3: When there is no error from the server
+	expectedKvdbresponse := &pxapi.PxKvdbMemberResponse{}
+	mockServiceService.EXPECT().GetKvdbMemberInfo(gomock.Any(), gomock.Any()).Return(expectedKvdbresponse, nil).Times(1)
+
+	val, err = driver.GetKVDBMembers(cluster)
+	require.NoError(t, err)
+	require.Empty(t, val)
+
+}
+
 func getK8sClientWithNodesZones(
 	t *testing.T,
 	nodeCount uint32,


### PR DESCRIPTION
What this PR does / why we need it:
When security is enabled and guest access is disabled, operator fails to make API call to PX service to get KVDB members info with following error : Access denied without authentication token

As a fix, we are using context that uses token for authenticating the request with the SDK server.
Which issue(s) this PR fixes (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-36838