### PR TITLE
PTX-23694 Increase timeout for waiting for InstallPlan when deploying PX Operator via OCP Marketplace

### DIFF
--- a/test/integration_test/utils/marketplace.go
+++ b/test/integration_test/utils/marketplace.go
@@ -26,7 +26,7 @@ const (
 
 	defaultPxVsphereSecretName = "px-vsphere-secret"
 
-	getInstallPlanListTimeout       = 10 * time.Minute
+	getInstallPlanListTimeout       = 60 * time.Minute
 	getInstallPlanListRetryInterval = 20 * time.Second
 
 	getPxVsphereSecretTimeout       = 10 * time.Minute


### PR DESCRIPTION
**What this PR does / why we need it**: Increase timeout for waiting for InstallPlan when deploying PX Operator via OCP Marketplace

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PTX-23694

**Special notes for your reviewer**:

