### PR TITLE
[cherrypick 24.1.0] PWX-36663 : Remove px-prometheus user from Portworx SCC for OCP 4.12+

### DIFF
--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -227,7 +227,6 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CollectorServiceAccountName),
 			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, ServiceAccountNameTelemetry),
 			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-node-wiper"),
-			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"),
 			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "stork-scheduler"),
 		},
 	}

--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -233,7 +233,8 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 	}
 
 	if gte_ocp_412, err := pxutil.IsSupportedOCPVersion(s.k8sClient, pxutil.OpenshiftPrometheusSupportedVersion); err == nil {
-		if !gte_ocp_412 {
+		if !gte_ocp_412 || (cluster.Spec.Monitoring != nil &&
+			cluster.Spec.Monitoring.Prometheus != nil && cluster.Spec.Monitoring.Prometheus.Enabled) {
 			pxScc.Users = append(pxScc.Users, fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"))
 		}
 	}

--- a/drivers/storage/portworx/component/securitycontextconstraints.go
+++ b/drivers/storage/portworx/component/securitycontextconstraints.go
@@ -187,92 +187,99 @@ func (s *scc) getSCCs(cluster *opcorev1.StorageCluster) []ocp_secv1.SecurityCont
 		}
 	}
 
-	return []ocp_secv1.SecurityContextConstraints{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: PxSCCName,
-			},
-			AllowHostDirVolumePlugin: true,
-			AllowHostIPC:             false,
-			AllowHostNetwork:         true,
-			AllowHostPID:             false,
-			AllowHostPorts:           true,
-			AllowPrivilegeEscalation: boolPtr(true),
-			AllowPrivilegedContainer: true,
-			AllowedUnsafeSysctls:     []string{"*"},
-			AllowedCapabilities: []corev1.Capability{
-				ocp_secv1.AllowAllCapabilities,
-			},
-			FSGroup: ocp_secv1.FSGroupStrategyOptions{
-				Type: ocp_secv1.FSGroupStrategyRunAsAny,
-			},
-			Priority:               sccPriority,
-			ReadOnlyRootFilesystem: false,
-			RunAsUser: ocp_secv1.RunAsUserStrategyOptions{
-				Type: ocp_secv1.RunAsUserStrategyRunAsAny,
-			},
-			SELinuxContext: ocp_secv1.SELinuxContextStrategyOptions{
-				Type: ocp_secv1.SELinuxStrategyRunAsAny,
-			},
-			SeccompProfiles: []string{"*"},
-			SupplementalGroups: ocp_secv1.SupplementalGroupsStrategyOptions{
-				Type: ocp_secv1.SupplementalGroupsStrategyRunAsAny,
-			},
-			Volumes: []ocp_secv1.FSType{"*"},
-			Groups:  nil,
-			Users: []string{
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, pxutil.PortworxServiceAccountName(cluster)),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CSIServiceAccountName),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, LhServiceAccountName),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, PVCServiceAccountName),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CollectorServiceAccountName),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, ServiceAccountNameTelemetry),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-node-wiper"),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "stork-scheduler"),
-			},
+	pxScc := ocp_secv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: PxSCCName,
 		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: PxRestrictedSCCName,
-			},
-			AllowHostDirVolumePlugin: true,
-			AllowHostIPC:             false,
-			AllowHostNetwork:         true,
-			AllowHostPID:             false,
-			AllowHostPorts:           false,
-			AllowPrivilegeEscalation: boolPtr(false),
-			AllowPrivilegedContainer: false,
-			FSGroup: ocp_secv1.FSGroupStrategyOptions{
-				Type: ocp_secv1.FSGroupStrategyMustRunAs,
-			},
-			ReadOnlyRootFilesystem: false,
-			RunAsUser: ocp_secv1.RunAsUserStrategyOptions{
-				Type: ocp_secv1.RunAsUserStrategyMustRunAsRange,
-			},
-			SELinuxContext: ocp_secv1.SELinuxContextStrategyOptions{
-				Type: ocp_secv1.SELinuxStrategyMustRunAs,
-			},
-			SupplementalGroups: ocp_secv1.SupplementalGroupsStrategyOptions{
-				Type: ocp_secv1.SupplementalGroupsStrategyRunAsAny,
-			},
-			Volumes: []ocp_secv1.FSType{
-				ocp_secv1.FSTypeConfigMap,
-				ocp_secv1.FSTypeDownwardAPI,
-				ocp_secv1.FSTypeEmptyDir,
-				ocp_secv1.FSTypeHostPath,
-				ocp_secv1.FSTypePersistentVolumeClaim,
-				ocp_secv1.FSProjected,
-				ocp_secv1.FSTypeSecret,
-			},
-			Groups: nil,
-			Users: []string{
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CSIServiceAccountName),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, LhServiceAccountName),
-				fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, PVCServiceAccountName),
-			},
+		AllowHostDirVolumePlugin: true,
+		AllowHostIPC:             false,
+		AllowHostNetwork:         true,
+		AllowHostPID:             false,
+		AllowHostPorts:           true,
+		AllowPrivilegeEscalation: boolPtr(true),
+		AllowPrivilegedContainer: true,
+		AllowedUnsafeSysctls:     []string{"*"},
+		AllowedCapabilities: []corev1.Capability{
+			ocp_secv1.AllowAllCapabilities,
+		},
+		FSGroup: ocp_secv1.FSGroupStrategyOptions{
+			Type: ocp_secv1.FSGroupStrategyRunAsAny,
+		},
+		Priority:               sccPriority,
+		ReadOnlyRootFilesystem: false,
+		RunAsUser: ocp_secv1.RunAsUserStrategyOptions{
+			Type: ocp_secv1.RunAsUserStrategyRunAsAny,
+		},
+		SELinuxContext: ocp_secv1.SELinuxContextStrategyOptions{
+			Type: ocp_secv1.SELinuxStrategyRunAsAny,
+		},
+		SeccompProfiles: []string{"*"},
+		SupplementalGroups: ocp_secv1.SupplementalGroupsStrategyOptions{
+			Type: ocp_secv1.SupplementalGroupsStrategyRunAsAny,
+		},
+		Volumes: []ocp_secv1.FSType{"*"},
+		Groups:  nil,
+		Users: []string{
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, pxutil.PortworxServiceAccountName(cluster)),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CSIServiceAccountName),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, LhServiceAccountName),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, PVCServiceAccountName),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CollectorServiceAccountName),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, ServiceAccountNameTelemetry),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-node-wiper"),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "stork-scheduler"),
 		},
 	}
+
+	if gte_ocp_412, err := pxutil.IsSupportedOCPVersion(s.k8sClient, pxutil.OpenshiftPrometheusSupportedVersion); err == nil {
+		if !gte_ocp_412 {
+			pxScc.Users = append(pxScc.Users, fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, "px-prometheus"))
+		}
+	}
+
+	pxRestrictedScc := ocp_secv1.SecurityContextConstraints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: PxRestrictedSCCName,
+		},
+		AllowHostDirVolumePlugin: true,
+		AllowHostIPC:             false,
+		AllowHostNetwork:         true,
+		AllowHostPID:             false,
+		AllowHostPorts:           false,
+		AllowPrivilegeEscalation: boolPtr(false),
+		AllowPrivilegedContainer: false,
+		FSGroup: ocp_secv1.FSGroupStrategyOptions{
+			Type: ocp_secv1.FSGroupStrategyMustRunAs,
+		},
+		ReadOnlyRootFilesystem: false,
+		RunAsUser: ocp_secv1.RunAsUserStrategyOptions{
+			Type: ocp_secv1.RunAsUserStrategyMustRunAsRange,
+		},
+		SELinuxContext: ocp_secv1.SELinuxContextStrategyOptions{
+			Type: ocp_secv1.SELinuxStrategyMustRunAs,
+		},
+		SupplementalGroups: ocp_secv1.SupplementalGroupsStrategyOptions{
+			Type: ocp_secv1.SupplementalGroupsStrategyRunAsAny,
+		},
+		Volumes: []ocp_secv1.FSType{
+			ocp_secv1.FSTypeConfigMap,
+			ocp_secv1.FSTypeDownwardAPI,
+			ocp_secv1.FSTypeEmptyDir,
+			ocp_secv1.FSTypeHostPath,
+			ocp_secv1.FSTypePersistentVolumeClaim,
+			ocp_secv1.FSProjected,
+			ocp_secv1.FSTypeSecret,
+		},
+		Groups: nil,
+		Users: []string{
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, CSIServiceAccountName),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, LhServiceAccountName),
+			fmt.Sprintf("system:serviceaccount:%s:%s", cluster.Namespace, PVCServiceAccountName),
+		},
+	}
+
+	return []ocp_secv1.SecurityContextConstraints{pxScc, pxRestrictedScc}
 }
 
 // RegisterSCCComponent registers a component for installing scc.

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -13339,6 +13339,115 @@ func TestSCC(t *testing.T) {
 	require.Equal(t, *scc.Priority, int32(2))
 }
 
+func TestSCCOnOpenshift(t *testing.T) {
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: component.ClusterOperatorVersion,
+			APIResources: []metav1.APIResource{
+				{
+					Kind: component.ClusterOperatorKind,
+				},
+			},
+		},
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+
+	reregisterComponents()
+	operator := &ocpconfig.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: component.OpenshiftAPIServer,
+		},
+		Status: ocpconfig.ClusterOperatorStatus{
+			RelatedObjects: []ocpconfig.ObjectReference{
+				{Name: component.OpenshiftAPIServer},
+			},
+			Versions: []ocpconfig.OperandVersion{
+				{
+					Name:    component.OpenshiftAPIServer,
+					Version: "4.15",
+				},
+			},
+		},
+	}
+	k8sClient := testutil.FakeK8sClient()
+	err := k8sClient.Create(context.TODO(), operator)
+	require.NoError(t, err)
+
+	driver := portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Monitoring: &corev1.MonitoringSpec{Telemetry: &corev1.TelemetrySpec{}},
+		},
+	}
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	// Install with no SCC
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	expectedSCC := testutil.GetExpectedSCC(t, "portworxSCC_Openshift.yaml")
+	scc := &ocp_secv1.SecurityContextConstraints{}
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NotNil(t, err)
+
+	expectedPxRestrictedSCC := testutil.GetExpectedSCC(t, "portworxRestrictedSCC.yaml")
+	pxRestrictedSCC := &ocp_secv1.SecurityContextConstraints{}
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NotNil(t, err)
+
+	// Install with SCC enabled
+	crd := testutil.GetExpectedCRDV1(t, "sccCrd.yaml")
+	err = k8sClient.Create(context.TODO(), crd)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedSCC, scc)
+
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedSCC, scc)
+
+	// Update SCC
+	scc.AllowHostNetwork = false
+	err = k8sClient.Update(context.TODO(), scc)
+	require.NoError(t, err)
+
+	pxRestrictedSCC.AllowHostNetwork = true
+	err = k8sClient.Update(context.TODO(), pxRestrictedSCC)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NoError(t, err)
+
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NoError(t, err)
+
+	// Update SCC priority
+	cluster.Annotations[pxutil.AnnotationSCCPriority] = "2"
+	err = k8sClient.Update(context.TODO(), scc)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, *scc.Priority, int32(2))
+}
+
 func TestPodSecurityPoliciesEnabled(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -13508,6 +13508,7 @@ func TestSCCOnOpenshiftWithPXPrometheusEnabled(t *testing.T) {
 	}
 
 	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
 	require.False(t, cluster.Spec.Monitoring.Prometheus.Enabled)
 	require.NotEmpty(t, recorder.Events)
 	require.Contains(t, <-recorder.Events,

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -13448,6 +13448,136 @@ func TestSCCOnOpenshift(t *testing.T) {
 	require.Equal(t, *scc.Priority, int32(2))
 }
 
+func TestSCCOnOpenshiftWithPXPrometheusEnabled(t *testing.T) {
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: component.ClusterOperatorVersion,
+			APIResources: []metav1.APIResource{
+				{
+					Kind: component.ClusterOperatorKind,
+				},
+			},
+		},
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+
+	reregisterComponents()
+	operator := &ocpconfig.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: component.OpenshiftAPIServer,
+		},
+		Status: ocpconfig.ClusterOperatorStatus{
+			RelatedObjects: []ocpconfig.ObjectReference{
+				{Name: component.OpenshiftAPIServer},
+			},
+			Versions: []ocpconfig.OperandVersion{
+				{
+					Name:    component.OpenshiftAPIServer,
+					Version: "4.15",
+				},
+			},
+		},
+	}
+	k8sClient := testutil.FakeK8sClient()
+	err := k8sClient.Create(context.TODO(), operator)
+	require.NoError(t, err)
+
+	driver := portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	recorder := record.NewFakeRecorder(1)
+	err = driver.Init(k8sClient, runtime.NewScheme(), recorder)
+	require.NoError(t, err)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "px/image:2.1.5.1",
+			Monitoring: &corev1.MonitoringSpec{
+				Telemetry: &corev1.TelemetrySpec{},
+				Prometheus: &corev1.PrometheusSpec{
+					Enabled: true,
+				},
+			},
+		},
+	}
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.False(t, cluster.Spec.Monitoring.Prometheus.Enabled)
+	require.NotEmpty(t, recorder.Events)
+	require.Contains(t, <-recorder.Events,
+		fmt.Sprintf("%v %v %s", v1.EventTypeWarning, util.FailedComponentReason,
+			"Disabling Portworx managed Prometheus in lieu of OpenShift managed Prometheus starting OpenShift 4.12"))
+
+	// Do not disable prometheus on existing install if set by the user
+	// if PX Prometheus is explicitly enabled, then add px-prometheus user to Portworx SCC
+	cluster.Spec.Monitoring.Prometheus.Enabled = true
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	require.True(t, cluster.Spec.Monitoring.Prometheus.Enabled)
+
+	// Install with no SCC
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	expectedSCC := testutil.GetExpectedSCC(t, "portworxSCC.yaml")
+	scc := &ocp_secv1.SecurityContextConstraints{}
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NotNil(t, err)
+
+	expectedPxRestrictedSCC := testutil.GetExpectedSCC(t, "portworxRestrictedSCC.yaml")
+	pxRestrictedSCC := &ocp_secv1.SecurityContextConstraints{}
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NotNil(t, err)
+
+	// Install with SCC enabled
+	crd := testutil.GetExpectedCRDV1(t, "sccCrd.yaml")
+	err = k8sClient.Create(context.TODO(), crd)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedSCC, scc)
+
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedSCC, scc)
+
+	// Update SCC
+	scc.AllowHostNetwork = false
+	err = k8sClient.Update(context.TODO(), scc)
+	require.NoError(t, err)
+
+	pxRestrictedSCC.AllowHostNetwork = true
+	err = k8sClient.Update(context.TODO(), pxRestrictedSCC)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NoError(t, err)
+
+	err = testutil.Get(k8sClient, pxRestrictedSCC, expectedPxRestrictedSCC.Name, "")
+	require.NoError(t, err)
+
+	// Update SCC priority
+	cluster.Annotations[pxutil.AnnotationSCCPriority] = "2"
+	err = k8sClient.Update(context.TODO(), scc)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, scc, expectedSCC.Name, "")
+	require.NoError(t, err)
+	require.Equal(t, *scc.Priority, int32(2))
+}
+
 func TestPodSecurityPoliciesEnabled(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()

--- a/drivers/storage/portworx/testspec/portworxSCC.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC.yaml
@@ -35,7 +35,7 @@ users:
 - system:serviceaccount:kube-test:px-metrics-collector
 - system:serviceaccount:kube-test:px-telemetry
 - system:serviceaccount:kube-test:px-node-wiper
-- system:serviceaccount:kube-test:px-prometheus
 - system:serviceaccount:kube-test:stork-scheduler
+- system:serviceaccount:kube-test:px-prometheus
 volumes:
 - '*'

--- a/drivers/storage/portworx/testspec/portworxSCC_Openshift.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC_Openshift.yaml
@@ -29,6 +29,9 @@ supplementalGroups:
   type: RunAsAny
 users:
   - system:serviceaccount:kube-test:portworx
+  - system:serviceaccount:kube-test:px-csi
+  - system:serviceaccount:kube-test:px-lighthouse
+  - system:serviceaccount:kube-test:portworx-pvc-controller
   - system:serviceaccount:kube-test:px-metrics-collector
   - system:serviceaccount:kube-test:px-telemetry
   - system:serviceaccount:kube-test:px-node-wiper

--- a/drivers/storage/portworx/testspec/portworxSCC_Openshift.yaml
+++ b/drivers/storage/portworx/testspec/portworxSCC_Openshift.yaml
@@ -1,0 +1,37 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+  - '*'
+allowedUnsafeSysctls:
+  - '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+kind: SecurityContextConstraints
+metadata:
+  name: portworx
+  resourceVersion: "1"
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:kube-test:portworx
+  - system:serviceaccount:kube-test:px-metrics-collector
+  - system:serviceaccount:kube-test:px-telemetry
+  - system:serviceaccount:kube-test:px-node-wiper
+  - system:serviceaccount:kube-test:stork-scheduler
+volumes:
+  - '*'


### PR DESCRIPTION
Cherrypicking https://github.com/libopenstorage/operator/pull/1534 again to 24.1.0, as the commits are lost because of force push to 24.1.0-release branch