### PR TITLE
PWX-37153 : Skip security check while fetching KVDB members

### DIFF
--- a/drivers/storage/portworx/component/auth.go
+++ b/drivers/storage/portworx/component/auth.go
@@ -535,7 +535,7 @@ func (a *auth) updateSystemGuestRole(cluster *corev1.StorageCluster) error {
 	}
 
 	roleClient := api.NewOpenStorageRoleClient(a.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, a.k8sClient)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, a.k8sClient, false)
 	if err != nil {
 		a.closeSdkConn()
 		return err

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -993,7 +993,7 @@ func (p *portworx) GetKVDBMembers(cluster *corev1.StorageCluster) (map[string]bo
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient)
+	ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient, true)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -993,6 +993,9 @@ func (p *portworx) GetKVDBMembers(cluster *corev1.StorageCluster) (map[string]bo
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
+	// if security was previously enabled and changed to disabled now
+	// the storagenodes might not be in sync since rolling update has not completed
+	// so always pass the token while rolling update
 	ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient, true)
 	if err != nil {
 		return nil, err

--- a/drivers/storage/portworx/status.go
+++ b/drivers/storage/portworx/status.go
@@ -147,7 +147,7 @@ func (p *portworx) updatePortworxRuntimeStatus(
 	}
 
 	clusterClient := api.NewOpenStorageClusterClient(p.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, false)
 	if err != nil {
 		return err
 	}
@@ -383,7 +383,7 @@ func (p *portworx) updateStorageNodes(
 	cluster *corev1.StorageCluster,
 ) error {
 	nodeClient := api.NewOpenStorageNodeClient(p.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, false)
 	if err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -84,6 +84,8 @@ const (
 	EnvKeyKubeletDir = "KUBELET_DIR"
 	// OS name for windows node
 	WindowsOsName = "windows"
+	// Dummy Secret value for authentication when Security is disabled
+	DummySecretValue = "dummy-secret-value"
 
 	// AnnotationIsPKS annotation indicating whether it is a PKS cluster
 	AnnotationIsPKS = pxAnnotationPrefix + "/is-pks"
@@ -833,7 +835,7 @@ func GetStorageNodes(
 	}
 
 	nodeClient := api.NewOpenStorageNodeClient(sdkConn)
-	ctx, err := SetupContextWithToken(context.Background(), cluster, k8sClient)
+	ctx, err := SetupContextWithToken(context.Background(), cluster, k8sClient, false)
 	if err != nil {
 		return sdkConn, nil, err
 	}
@@ -1151,16 +1153,22 @@ func AuthEnabled(spec *corev1.StorageClusterSpec) bool {
 }
 
 // SetupContextWithToken Gets token or from secret for authenticating with the SDK server
-func SetupContextWithToken(ctx context.Context, cluster *corev1.StorageCluster, k8sClient client.Client) (context.Context, error) {
+func SetupContextWithToken(ctx context.Context, cluster *corev1.StorageCluster, k8sClient client.Client, skipSecurityCheck bool) (context.Context, error) {
 	// auth not declared in cluster spec
-	if !AuthEnabled(&cluster.Spec) {
+	if !AuthEnabled(&cluster.Spec) && !skipSecurityCheck {
 		return ctx, nil
 	}
 
 	pxAppsSecret, err := GetSecretValue(ctx, cluster, k8sClient, SecurityPXSystemSecretsSecretName, SecurityAppsSecretKey)
 	if err != nil {
-		return ctx, fmt.Errorf("failed to get portworx apps secret: %v", err.Error())
+		if !skipSecurityCheck {
+			return ctx, fmt.Errorf("failed to get portworx apps secret: %v", err.Error())
+		}
+		if errors.IsNotFound(err) && skipSecurityCheck {
+			pxAppsSecret = DummySecretValue
+		}
 	}
+
 	if pxAppsSecret == "" {
 		return ctx, nil
 	}
@@ -1387,7 +1395,7 @@ func CountStorageNodes(
 	k8sClient client.Client,
 ) (int, error) {
 	nodeClient := api.NewOpenStorageNodeClient(sdkConn)
-	ctx, err := SetupContextWithToken(context.Background(), cluster, k8sClient)
+	ctx, err := SetupContextWithToken(context.Background(), cluster, k8sClient, false)
 	if err != nil {
 		return -1, err
 	}
@@ -1523,7 +1531,7 @@ func getStorageNodeMappingFromRPC(
 	k8sClient client.Client,
 ) (map[string]string, map[string]string, error) {
 	nodeClient := api.NewOpenStorageNodeClient(sdkConn)
-	ctx, err := SetupContextWithToken(context.Background(), cluster, k8sClient)
+	ctx, err := SetupContextWithToken(context.Background(), cluster, k8sClient, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1155,6 +1155,7 @@ func AuthEnabled(spec *corev1.StorageClusterSpec) bool {
 // SetupContextWithToken Gets token or from secret for authenticating with the SDK server
 func SetupContextWithToken(ctx context.Context, cluster *corev1.StorageCluster, k8sClient client.Client, skipSecurityCheck bool) (context.Context, error) {
 	// auth not declared in cluster spec
+	// if security enabled check is skipped, proceed without returning context
 	if !AuthEnabled(&cluster.Spec) && !skipSecurityCheck {
 		return ctx, nil
 	}
@@ -1164,6 +1165,8 @@ func SetupContextWithToken(ctx context.Context, cluster *corev1.StorageCluster, 
 		if !skipSecurityCheck {
 			return ctx, fmt.Errorf("failed to get portworx apps secret: %v", err.Error())
 		}
+		// if security enabled check is skipped and secret is not present, proceed with dummy secret value
+		// this is case of fresh install where security was never enabled
 		if errors.IsNotFound(err) && skipSecurityCheck {
 			pxAppsSecret = DummySecretValue
 		}

--- a/pkg/controller/portworxdiag/portworxdiag.go
+++ b/pkg/controller/portworxdiag/portworxdiag.go
@@ -252,7 +252,7 @@ func (c *Controller) getNodeIDsWithSelectedVolumes(diag *diagv1.PortworxDiag, st
 	nodeIDMap := map[string]bool{}
 
 	volumeClient := api.NewOpenStorageVolumeClient(c.grpcConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), stc, c.client)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), stc, c.client, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: 
**Issue :** PX Security was not getting disabled even after updating spec.Security.Enabled field from true to false in Storage cluster.
**Reason :**  The change was introduced as part of PWX-25339, where one extra call to Portworx service was added during rolling update to make sure that KVDB does not go out of quorum during rolling updates. 
This introduced an issue when security was disabled from previously enabled value, the update on storagenodes is still not done at the point when this API call made, so even thought security is disabled from STC, storagenode is still not in sync and expects token to be passed by the operator during GRPC call.

**Fix**
As a fix, we are bypassing security enabled check in case of this particular GRPC call
1.  When security is disabled on STC, security check will be disabled for this GRPC call, so dummy secret value will be used to generate token, GRPC call will not require the token so it will not have issue.
2.  When security is enabled on STC, valid token will be created and used.
3.  When security is disabled again, for this specific GRPC call, we are skipping the security, so it will still generate valid token using px-system-secrets secret and proceed. Once it proceeds, it will fetch KVDB members and also complete rolling update, and the nodes will be in sync, disabling the security as point 1.  

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-37153

**Special notes for your reviewer**:
- Tested on OCP 4.12 Cluster
- Fresh install with security disabled
- Fresh install with security enabled
- Changing security enabled value from false to true
-  Changing security enabled value from false to true
- Upgrading Portworx version from 2.13.0 to 3.0.0 with security disabled
- Upgrading Portworx version 3.0.0 to 3.1.1 with security enabled 

