### PR TITLE
PWX-37237 : Revert PWX-35377 Update metrics collector version and remove metrics-collector

### DIFF
--- a/deploy/ccm/metrics-collector-deployment.yaml
+++ b/deploy/ccm/metrics-collector-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       - env:
         - name: CONFIG
           value: config/portworx.yaml
-        image: purestorage/realtime-metrics:1.0.23
+        image: purestorage/realtime-metrics:1.0.2
         imagePullPolicy: Always
         name: collector
         resources:

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -1,6 +1,7 @@
 package component
 
 import (
+	"context"
 	cryptoTls "crypto/tls"
 	"fmt"
 	"io"
@@ -17,8 +18,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -128,6 +131,7 @@ type telemetry struct {
 	isDeploymentRegistrationServiceCreated bool
 	isDaemonSetTelemetryPhonehomeCreated   bool
 	usePxProxy                             bool
+	reconcileMetricsCollector              *bool
 }
 
 func (t *telemetry) Name() string {
@@ -169,7 +173,9 @@ func (t *telemetry) Reconcile(cluster *corev1.StorageCluster) error {
 	if err := pxutil.SetTelemetryCertOwnerRef(cluster, ownerRef, t.k8sClient); err != nil {
 		return err
 	}
-
+	if err := t.shouldReconcileMetricsCollector(cluster); err != nil {
+		return err
+	}
 	t.isCCMGoSupported = pxutil.IsCCMGoSupported(pxutil.GetPortworxVersion(cluster))
 	if t.isCCMGoSupported {
 		return t.reconcileCCMGo(cluster, ownerRef)
@@ -418,10 +424,42 @@ func (t *telemetry) deleteCCMGoPhonehomeCluster(
 	return nil
 }
 
+// PWX-27401 only reconcile metrics collector if it's already running, revert once collector memory issue got resolved
+func (t *telemetry) shouldReconcileMetricsCollector(
+	cluster *corev1.StorageCluster,
+) error {
+	if t.reconcileMetricsCollector != nil {
+		return nil
+	}
+	// Check if collector V1 or V2 deployment exists
+	existingDeployment := &appsv1.Deployment{}
+	for _, deploymentName := range []string{CollectorDeploymentName, DeploymentNameTelemetryCollectorV2} {
+		err := t.k8sClient.Get(
+			context.TODO(),
+			types.NamespacedName{
+				Name:      deploymentName,
+				Namespace: cluster.Namespace,
+			},
+			existingDeployment,
+		)
+		if err == nil {
+			t.reconcileMetricsCollector = boolPtr(true)
+			return nil
+		} else if !errors.IsNotFound(err) {
+			return err
+		}
+	}
+	t.reconcileMetricsCollector = boolPtr(false)
+	return nil
+}
+
 func (t *telemetry) reconcileCCMGoTelemetryCollectorV2(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	if t.reconcileMetricsCollector == nil || !*t.reconcileMetricsCollector {
+		return nil
+	}
 
 	// Delete metrics collector V1 if exists
 	if err := t.deleteMetricsCollectorV1(cluster.Namespace, ownerRef); err != nil {

--- a/drivers/storage/portworx/component/telemetry_java.go
+++ b/drivers/storage/portworx/component/telemetry_java.go
@@ -142,6 +142,10 @@ func (t *telemetry) deployMetricsCollectorV1(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
 ) error {
+	if t.reconcileMetricsCollector == nil || !*t.reconcileMetricsCollector {
+		return nil
+	}
+
 	if err := t.createCollectorServiceAccount(cluster.Namespace, ownerRef); err != nil {
 		return err
 	}
@@ -602,7 +606,6 @@ func (t *telemetry) createCollectorConfigMap(
 	config := fmt.Sprintf(
 		`scrapeConfig:
   interval: 10
-  batchSize: 5
   k8sConfig:
     pods:
     - podSelector:%s

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -8159,6 +8159,19 @@ func TestCompleteInstallWithCustomRegistryChange(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
 	// Case: Custom registry should be added to the images
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
@@ -8994,6 +9007,19 @@ func TestCompleteInstallWithCustomRepoRegistryChange(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
 	// Case: Custom repo-registry should be added to the images
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
@@ -9788,6 +9814,19 @@ func TestCompleteInstallWithCustomRepoRegistryChangeForK8s_1_12(t *testing.T) {
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
 	// Case: Custom repo-registry should be added to the images
 	err = driver.PreInstall(cluster)
 	require.NoError(t, err)
@@ -10055,6 +10094,19 @@ func TestCompleteInstallWithImagePullSecretChange(t *testing.T) {
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      component.AlertManagerConfigSecretName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
 				Namespace: cluster.Namespace,
 			},
 		},
@@ -10454,6 +10506,19 @@ func TestCompleteInstallWithTolerationsChange(t *testing.T) {
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      component.AlertManagerConfigSecretName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
 				Namespace: cluster.Namespace,
 			},
 		},
@@ -10947,6 +11012,19 @@ func TestCompleteInstallWithNodeAffinityChange(t *testing.T) {
 		&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      component.AlertManagerConfigSecretName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
 				Namespace: cluster.Namespace,
 			},
 		},
@@ -13880,6 +13958,19 @@ func TestTelemetryEnableAndDisable(t *testing.T) {
 		},
 	}
 
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 
@@ -14214,6 +14305,19 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 
 	// This cert is created by ccm container outside of operator, let's simulate it.
 	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.DeploymentNameTelemetryCollectorV2,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
 
 	// Validate default ccm listening port
 	err = driver.SetDefaultsOnStorageCluster(cluster)
@@ -14775,6 +14879,19 @@ func TestTelemetryCCMGoUpgrade(t *testing.T) {
 	// This cert is created by ccm container outside of operator, let's simulate it.
 	createTelemetrySecret(t, k8sClient, cluster.Namespace)
 
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 	err = driver.PreInstall(cluster)
@@ -14965,6 +15082,19 @@ func TestTelemetryCCMGoHTTPProxy(t *testing.T) {
 	}
 	createTelemetrySecret(t, k8sClient, cluster.Namespace)
 
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.DeploymentNameTelemetryCollectorV2,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 
@@ -15098,6 +15228,174 @@ func TestTelemetryCCMGoHTTPProxy(t *testing.T) {
 	require.True(t, errors.IsNotFound(err))
 }
 
+// PWX-27401
+func TestTelemetryMetricsCollectorDisabledByDefault(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	// Deploy px with CCM Java enabled
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/oci-monitor:2.10.1",
+			Monitoring: &corev1.MonitoringSpec{
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: true,
+					Image:   "purestorage/telemetry:1.2.3",
+				},
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			ClusterUID: "test-clusteruid",
+		},
+	}
+	// This cert is created by ccm container outside of operator, let's simulate it.
+	err = k8sClient.Create(
+		context.TODO(),
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.TelemetryCertName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	// TestCase: enabling telemetry doesn't create metrics collector
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	serviceAccount := &v1.ServiceAccount{}
+	err = testutil.Get(k8sClient, serviceAccount, component.CollectorServiceAccountName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	clusterRole := &rbacv1.ClusterRole{}
+	err = testutil.Get(k8sClient, clusterRole, component.CollectorClusterRoleName, "")
+	require.True(t, errors.IsNotFound(err))
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, clusterRoleBinding, component.CollectorClusterRoleBindingName, "")
+	require.True(t, errors.IsNotFound(err))
+	role := &rbacv1.Role{}
+	err = testutil.Get(k8sClient, role, component.CollectorRoleName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	roleBinding := &rbacv1.RoleBinding{}
+	err = testutil.Get(k8sClient, roleBinding, component.CollectorRoleBindingName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	configMap := &v1.ConfigMap{}
+	err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	configMap = &v1.ConfigMap{}
+	err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	deployment := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+
+	// TestCase: deploy metrics collector V1 and restart operator, collector should be reconciled
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.CollectorDeploymentName,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	reregisterComponents()
+	driver = portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	err = testutil.Get(k8sClient, serviceAccount, component.CollectorServiceAccountName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, clusterRole, component.CollectorClusterRoleName, "")
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, clusterRoleBinding, component.CollectorClusterRoleBindingName, "")
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, role, component.CollectorRoleName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, roleBinding, component.CollectorRoleBindingName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+
+	// TestCase: upgrade to ccm go, new collector should be reconciled
+	cluster.Spec.Image = "portworx/oci-monitor:2.12.1"
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// old collector components got deleted
+	err = testutil.Get(k8sClient, serviceAccount, component.CollectorServiceAccountName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, clusterRole, component.CollectorClusterRoleName, "")
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, clusterRoleBinding, component.CollectorClusterRoleBindingName, "")
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, role, component.CollectorRoleName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, roleBinding, component.CollectorRoleBindingName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, configMap, component.CollectorProxyConfigMapName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, configMap, component.CollectorConfigMapName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, deployment, component.CollectorDeploymentName, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+
+	// new collector components created
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorV2, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
+	require.NoError(t, err)
+	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryCollectorV2, cluster.Namespace)
+	require.NoError(t, err)
+
+	// TestCase: disable telemetry, restart operator and re-enable telemetry, collector v2 should not be created
+	cluster.Spec.Monitoring.Telemetry.Enabled = false
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	reregisterComponents()
+	driver = portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	cluster.Spec.Monitoring.Telemetry.Enabled = true
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorV2, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, configMap, component.ConfigMapNameTelemetryCollectorProxyV2, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryCollectorV2, cluster.Namespace)
+	require.True(t, errors.IsNotFound(err))
+}
+
 func TestTelemetryCCMGoHTTPSProxy(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()
@@ -15126,6 +15424,19 @@ func TestTelemetryCCMGoHTTPSProxy(t *testing.T) {
 		},
 	}
 	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+
+	// PWX-27401 reconcile collector to validate specs
+	err = k8sClient.Create(
+		context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      component.DeploymentNameTelemetryCollectorV2,
+				Namespace: cluster.Namespace,
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
 
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)

--- a/drivers/storage/portworx/manifest/manifest.go
+++ b/drivers/storage/portworx/manifest/manifest.go
@@ -48,7 +48,7 @@ const (
 	defaultCollectorProxyImage = "envoyproxy/envoy:v1.21.4"
 
 	defaultCCMGoImage       = "purestorage/ccm-go:1.0.3"
-	defaultCollectorImage   = "purestorage/realtime-metrics:1.0.23"
+	defaultCollectorImage   = "purestorage/realtime-metrics:1.0.15"
 	defaultCCMGoProxyImage  = "purestorage/telemetry-envoy:1.1.6"
 	defaultLogUploaderImage = "purestorage/log-upload:px-1.0.12"
 

--- a/drivers/storage/portworx/testspec/ccmGoCollectorConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoCollectorConfigMap.yaml
@@ -12,7 +12,6 @@ data:
   portworx.yaml: |-
     scrapeConfig:
       interval: 10
-      batchSize: 5
       k8sConfig:
         pods:
         - podSelector:

--- a/drivers/storage/portworx/testspec/metricsCollectorConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/metricsCollectorConfigMap.yaml
@@ -8,7 +8,6 @@ data:
   portworx.yaml: |-
     scrapeConfig:
       interval: 10
-      batchSize: 5
       k8sConfig:
         pods:
         - podSelector:


### PR DESCRIPTION
**What this PR does / why we need it**: Revert https://purestorage.atlassian.net/browse/PWX-35377 from 24.1.0
Reverted PR : https://github.com/libopenstorage/operator/pull/1460

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-37237



