### PR TITLE
PWX-37274 : Adding events for setting PDB using annotation

### DIFF
--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -134,7 +134,7 @@ func (c *disruptionBudget) createPortworxPodDisruptionBudget(
 
 		// If the user provided value is invalid and it is different from the previously given value, raise an event in storagecluster
 		if cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] != "" && userProvidedMinValue != c.annotatedMinAvailable {
-			errmsg := fmt.Sprintf("Invalid annotation value for px-storage pod disruption budget: %d. Using default value: %d", userProvidedMinValue, storageNodesCount-1)
+			errmsg := fmt.Sprintf("Invalid annotation value for px-storage pod disruption budget. Using default value: %d", storageNodesCount-1)
 			c.recorder.Event(cluster, v1.EventTypeWarning, util.InvalidMinAvailable, errmsg)
 		}
 		if cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] == "" && userProvidedMinValue != c.annotatedMinAvailable {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -83,6 +83,10 @@ const (
 	StoragePartitioningEnvKey = "ENABLE_ASG_STORAGE_PARTITIONING"
 	// DefaultStorageClusterUniqueLabelKey is the controller revision hash of storage cluster
 	DefaultStorageClusterUniqueLabelKey = apps.ControllerRevisionHashLabelKey
+	// InvalidMinAvailable is added to an event when minAvailable value for PodDisruptionBudget provided by the user is invalid
+	InvalidMinAvailable = "InvalidMinAvailable"
+	// ValidMinAvailable is added to an event when minAvailable value for PodDisruptionBudget is valid
+	ValidMinAvailable = "ValidMinAvailable"
 )
 
 var (


### PR DESCRIPTION
<!--

  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: As suggested during the TOI presentation, we will add an event in the storagecluster when the user sets the value of minAvailable for px-storage PDB using annotation. An event will be logged if this value is valid, invalid, and everytime the annotated value is changed. It also gets raised once everytime an incorrect value is either changed to default or correct value is given. Here is the list of scenarios and its expected events raised

| Storage cluster state                                           | Event             |
|-----------------------------------------------------------------|-------------------|
| Fresh px install , default PDB                                  | No event          |
| Fresh px install, correct PDB annotation                        | Event raised once |
| Fresh install, incorrect PDB annotation                         | Event raised once |
| Using default PDB - &gt; override with correct PDB              | Event raised once |
| Using default PDB -&gt; Override with incorrect PDB             | Event raised once |
| Using correct PDB annotation -&gt; Remove annotation            | Event raised once |
| Using incorrect PDB annotation -&gt; Remove annotation          | Event raised once |
| Using correct PDB annotation-&gt; Override incorrect annotation | Event raised once |
| Using incorrect annotation -&gt; Override correct annotation    | Event raised once |


**Which issue(s) this PR fixes** (optional)
Closes # PWX-37274

