### PR TITLE
PWX-37266 : Upgrade should not continue when PDB value is set to 1 and there is already a PX node down

### DIFF
--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1428,12 +1428,20 @@ func CountStorageNodes(
 		}
 		useQuorumFlag, err = ShouldUseQuorumFlag(node)
 		if err != nil {
-			logrus.Errorf("error while checking quorum flag for node %s: %v", node.Id, err)
+			logrus.Errorf("failed to determine if quorum flag should be used: %v", err)
+			useQuorumFlag = false
+			useClusterDomain = false
 			break
 		}
+
+		if !useQuorumFlag {
+			useClusterDomain = false
+			break
+		}
+
 		useClusterDomain, err = ShouldUseClusterDomain(node)
 		if err != nil {
-			logrus.Errorf("error while checking cluster domain for node %s: %v", node.Id, err)
+			logrus.Errorf("failed to determine if cluster domain should be used: %v", err)
 			break
 		}
 	}

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1426,23 +1426,15 @@ func CountStorageNodes(
 		if node.Status == api.Status_STATUS_DECOMMISSION {
 			continue
 		}
-		v := node.NodeLabels[NodeLabelPortworxVersion]
-		nodeVersion, err := version.NewVersion(v)
+		useQuorumFlag, err = ShouldUseQuorumFlag(node)
 		if err != nil {
-			logrus.Warnf("Failed to parse node version %s for node %s: %v", v, node.Id, err)
-			useQuorumFlag = false
-			useClusterDomain = false
+			logrus.Errorf("error while checking quorum flag for node %s: %v", node.Id, err)
 			break
 		}
-		if nodeVersion.LessThan(MinimumPxVersionQuorumFlag) {
-			logrus.Tracef("Node %s is older than %s. Not using quorum member flag", node.Id, MinimumPxVersionQuorumFlag.String())
-			useQuorumFlag = false
-			useClusterDomain = false
+		useClusterDomain, err = ShouldUseClusterDomain(node)
+		if err != nil {
+			logrus.Errorf("error while checking cluster domain for node %s: %v", node.Id, err)
 			break
-		}
-		if nodeVersion.LessThan(MinimumPxVersionClusterDomain) {
-			logrus.Tracef("Node %s is older than %s. Cannot using cluster domain field", node.Id, MinimumPxVersionClusterDomain.String())
-			useClusterDomain = false
 		}
 	}
 
@@ -1916,4 +1908,35 @@ func isVersionSupported(current, target string) bool {
 
 func IsK3sClusterExt(ext string) bool {
 	return strings.HasPrefix(ext[1:], "k3s")
+}
+
+// ShouldUseQuorumFlag checks if the node should use the quorum member flag to decide storage status
+func ShouldUseQuorumFlag(node *api.StorageNode) (bool, error) {
+	v := node.NodeLabels[NodeLabelPortworxVersion]
+	nodeVersion, err := version.NewVersion(v)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse node version %s for node %s: %v", v, node.Id, err)
+	}
+
+	// Check if the node is older than the minimum version that supports quorum member flag
+	if nodeVersion.LessThan(MinimumPxVersionQuorumFlag) {
+		logrus.Tracef("Node %s is older than %s. Not using quorum member flag", node.Id, MinimumPxVersionQuorumFlag.String())
+		return false, nil
+	}
+	return true, nil
+}
+
+// ShouldUseClusterDomain checks if the node should use the cluster domain field to decide storage status
+func ShouldUseClusterDomain(node *api.StorageNode) (bool, error) {
+	v := node.NodeLabels[NodeLabelPortworxVersion]
+	nodeVersion, err := version.NewVersion(v)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse node version %s for node %s: %v", v, node.Id, err)
+	}
+	// Check if the node is older than the minimum version that supports cluster domain field
+	if nodeVersion.LessThan(MinimumPxVersionClusterDomain) {
+		logrus.Tracef("Node %s is older than %s. Cannot using cluster domain field", node.Id, MinimumPxVersionClusterDomain.String())
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -528,7 +528,7 @@ func (c *Controller) isStorageNode(storageNode *corev1.StorageNode, cluster *cor
 			} else {
 				isQuorumMember = len(n.Pools) > 0 && n.Pools[0] != nil
 			}
-			logrus.Infof("shouldUseQuorumMembe for node %v: %v , isQuorumMember? %v", shouldUseQuorumMember, storageNode.Name, isQuorumMember)
+			logrus.Infof("shouldUseQuorumMembe for node %v: %v , isQuorumMember? %v", storageNode.Name, shouldUseQuorumMember, isQuorumMember)
 		}
 	}
 

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -509,7 +509,13 @@ func (c *Controller) isStorageNode(storageNode *corev1.StorageNode, cluster *cor
 	}
 
 	nodeClient := api.NewOpenStorageNodeClient(c.sdkConn)
-	nodeResp, err := nodeClient.EnumerateWithFilters(context.Background(), &api.SdkNodeEnumerateWithFiltersRequest{})
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, c.client, false)
+	if err != nil {
+		logrus.Errorf("failed to setup context with token: %v", err)
+		return false, err
+	}
+
+	nodeResp, err := nodeClient.EnumerateWithFilters(ctx, &api.SdkNodeEnumerateWithFiltersRequest{})
 	if err != nil {
 		logrus.Errorf("failed to get node list: %v", err)
 		return false, err

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -503,6 +503,7 @@ func (c *Controller) isStorageNode(storageNode *corev1.StorageNode, cluster *cor
 	var err error
 
 	c.sdkConn, err = pxutil.GetPortworxConn(c.sdkConn, c.client, cluster.Namespace)
+	defer c.closeSdkConn()
 	if err != nil {
 		logrus.Errorf("failed to get portworx connection: %v", err)
 		return false, err
@@ -539,4 +540,16 @@ func (c *Controller) isStorageNode(storageNode *corev1.StorageNode, cluster *cor
 	}
 
 	return isQuorumMember, nil
+}
+
+// closeSdkConn closes the sdk connection and resets it to nil
+func (c *Controller) closeSdkConn() {
+	if c.sdkConn == nil {
+		return
+	}
+
+	if err := c.sdkConn.Close(); err != nil {
+		logrus.Errorf("Failed to close sdk connection: %s", err.Error())
+	}
+	c.sdkConn = nil
 }

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -480,7 +480,7 @@ func (c *Controller) canNodeServeStorage(storagenode *corev1.StorageNode, cluste
 	for _, cond := range storagenode.Status.Conditions {
 		if cond.Type == corev1.NodeStateCondition {
 			if cond.Status != corev1.NodeInitStatus {
-				if ok, err := c.isStorageNode(storagenode, cluster); err != nil {
+				if ok, err := c.isStorageNode(storagenode, cluster); err == nil {
 					return ok
 				}
 			}

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -528,7 +528,7 @@ func (c *Controller) isStorageNode(storageNode *corev1.StorageNode, cluster *cor
 			} else {
 				isQuorumMember = len(n.Pools) > 0 && n.Pools[0] != nil
 			}
-			logrus.Infof("shouldUseQuorumMembe for node %v: %v , isQuorumMember? %v", storageNode.Name, shouldUseQuorumMember, isQuorumMember)
+			logrus.Infof("shouldUseQuorumMember for node %v: %v , isQuorumMember? %v", storageNode.Name, shouldUseQuorumMember, isQuorumMember)
 		}
 	}
 

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -3,6 +3,9 @@ package storagenode
 import (
 	"context"
 	"fmt"
+	"github.com/libopenstorage/openstorage/api"
+	pxutil "github.com/libopenstorage/operator/drivers/storage/portworx/util"
+	"google.golang.org/grpc"
 	"strings"
 	"time"
 
@@ -59,6 +62,8 @@ type Controller struct {
 	ctrl     controller.Controller
 	// Node to NodeInfo map
 	nodeInfoMap maps.SyncMap[string, *k8s.NodeInfo]
+	// sdkConn is the grpc connection to the Portworx service
+	sdkConn *grpc.ClientConn
 }
 
 // Init initialize the storage storagenode controller
@@ -344,7 +349,7 @@ func (c *Controller) syncStorage(
 			storageNode.Name == pod.Spec.NodeName {
 			updateNeeded := false
 			value, storageLabelPresent := podCopy.GetLabels()[constants.LabelKeyStoragePod]
-			if canNodeServeStorage(storageNode) { // node has storage
+			if c.canNodeServeStorage(storageNode, cluster) { // node has storage
 				if value != constants.LabelValueTrue {
 					if podCopy.Labels == nil {
 						podCopy.Labels = make(map[string]string)
@@ -464,7 +469,7 @@ func getDeprecatedCRDBasePath() string {
 	return deprecatedCRDBasePath
 }
 
-func canNodeServeStorage(storagenode *corev1.StorageNode) bool {
+func (c *Controller) canNodeServeStorage(storagenode *corev1.StorageNode, cluster *corev1.StorageCluster) bool {
 	if storagenode.Status.NodeAttributes == nil ||
 		storagenode.Status.NodeAttributes.Storage == nil ||
 		!*storagenode.Status.NodeAttributes.Storage {
@@ -474,10 +479,10 @@ func canNodeServeStorage(storagenode *corev1.StorageNode) bool {
 	// look for node status condition
 	for _, cond := range storagenode.Status.Conditions {
 		if cond.Type == corev1.NodeStateCondition {
-			if cond.Status == corev1.NodeOnlineStatus ||
-				cond.Status == corev1.NodeMaintenanceStatus ||
-				cond.Status == corev1.NodeDegradedStatus {
-				return true
+			if cond.Status != corev1.NodeInitStatus {
+				if ok, err := c.isStorageNode(storagenode, cluster); err != nil {
+					return ok
+				}
 			}
 		}
 	}
@@ -488,4 +493,38 @@ func isNodeRunningKVDB(storagenode *corev1.StorageNode) bool {
 	return storagenode.Status.NodeAttributes != nil &&
 		storagenode.Status.NodeAttributes.KVDB != nil &&
 		*storagenode.Status.NodeAttributes.KVDB
+}
+
+// isStorageNode return true if we should use quorum memebr flag, and the node is a quorum member
+// isStorageNode return false if we should use quorum member flag, and the node is not a quorum member
+// isStorageNode return true if we should not use quorum member flag
+func (c *Controller) isStorageNode(storageNode *corev1.StorageNode, cluster *corev1.StorageCluster) (bool, error) {
+	var shouldUseQuorumMember, isQuorumMember bool
+	var err error
+
+	c.sdkConn, err = pxutil.GetPortworxConn(c.sdkConn, c.client, cluster.Namespace)
+	if err != nil {
+		logrus.Errorf("failed to get portworx connection: %v", err)
+		return false, err
+	}
+
+	nodeClient := api.NewOpenStorageNodeClient(c.sdkConn)
+	nodeResp, err := nodeClient.EnumerateWithFilters(context.Background(), &api.SdkNodeEnumerateWithFiltersRequest{})
+	if err != nil {
+		logrus.Errorf("failed to get node list: %v", err)
+		return false, err
+	}
+
+	for _, n := range nodeResp.Nodes {
+		if n.SchedulerNodeName == storageNode.Name {
+			shouldUseQuorumMember, err = pxutil.ShouldUseQuorumFlag(n)
+			if err != nil {
+				logrus.Errorf("failed to get shouldUseQuorumFlag: %v", err)
+				return false, err
+			}
+			isQuorumMember = !n.NonQuorumMember
+			logrus.Infof("shouldUseQuorumMembe for node %s: %v , isQuorumMember? %v", shouldUseQuorumMember, storageNode.Name, isQuorumMember)
+		}
+	}
+	return !shouldUseQuorumMember || isQuorumMember, nil
 }

--- a/pkg/controller/storagenode/storagenode_test.go
+++ b/pkg/controller/storagenode/storagenode_test.go
@@ -293,6 +293,9 @@ func TestReconcile(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
+	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer testutil.RestoreEtcHosts(t)
+
 	expectedNodeEnumerateResp := &osdapi.SdkNodeEnumerateWithFiltersResponse{
 		Nodes: []*osdapi.StorageNode{
 			{Pools: []*osdapi.StoragePool{{ID: 1}}, SchedulerNodeName: "node1", NodeLabels: map[string]string{pxutil.NodeLabelPortworxVersion: "3.0.0"}},
@@ -466,6 +469,9 @@ func TestReconcileForSafeToEvictAnnotation(t *testing.T) {
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer testutil.RestoreEtcHosts(t)
 
 	expectedNodeEnumerateResp := &osdapi.SdkNodeEnumerateWithFiltersResponse{
 		Nodes: []*osdapi.StorageNode{
@@ -648,6 +654,9 @@ func TestReconcileWithStorageLabel(t *testing.T) {
 	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
 	require.NoError(t, err)
 	defer mockSdk.Stop()
+
+	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	defer testutil.RestoreEtcHosts(t)
 
 	cluster := &corev1.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/storagenode/storagenode_test.go
+++ b/pkg/controller/storagenode/storagenode_test.go
@@ -810,7 +810,7 @@ func TestReconcileWithStorageLabel(t *testing.T) {
 	_, present = pod1.Annotations[constants.LabelKeyStoragePod]
 	require.True(t, present)
 
-	// TestCase 4: storage label should be added for PX >= 3.1.0 if node is not QuorumMember
+	// TestCase 4: storage label should not be added for PX >= 3.1.0 if node is not QuorumMember
 	podNode1 = createStoragePod(cluster, "pod-node1", storageNode.Name, nil, clusterRef)
 	err = k8sClient.Update(context.TODO(), podNode1)
 	require.NoError(t, err)

--- a/pkg/controller/storagenode/storagenode_test.go
+++ b/pkg/controller/storagenode/storagenode_test.go
@@ -293,7 +293,7 @@ func TestReconcile(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
-	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".test-ns")
 	defer testutil.RestoreEtcHosts(t)
 
 	expectedNodeEnumerateResp := &osdapi.SdkNodeEnumerateWithFiltersResponse{
@@ -470,7 +470,7 @@ func TestReconcileForSafeToEvictAnnotation(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
-	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".test-ns")
 	defer testutil.RestoreEtcHosts(t)
 
 	expectedNodeEnumerateResp := &osdapi.SdkNodeEnumerateWithFiltersResponse{
@@ -655,7 +655,7 @@ func TestReconcileWithStorageLabel(t *testing.T) {
 	require.NoError(t, err)
 	defer mockSdk.Stop()
 
-	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".kube-test")
+	testutil.SetupEtcHosts(t, sdkServerIP, pxutil.PortworxServiceName+".test-ns")
 	defer testutil.RestoreEtcHosts(t)
 
 	cluster := &corev1.StorageCluster{

--- a/pkg/controller/storagenode/storagenode_test.go
+++ b/pkg/controller/storagenode/storagenode_test.go
@@ -635,6 +635,218 @@ func TestReconcileForSafeToEvictAnnotation(t *testing.T) {
 	require.False(t, present)
 }
 
+func TestReconcileWithStorageLabel(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	mockNodeServer := mock.NewMockOpenStorageNodeServer(mockCtrl)
+	sdkServerIP := "127.0.0.1"
+	sdkServerPort := 21883
+	mockSdk := mock.NewSdkServer(mock.SdkServers{
+		Node: mockNodeServer,
+	})
+	err := mockSdk.StartOnAddress(sdkServerIP, strconv.Itoa(sdkServerPort))
+	require.NoError(t, err)
+	defer mockSdk.Stop()
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "test-ns",
+		},
+	}
+	controllerKind := corev1.SchemeGroupVersion.WithKind("StorageCluster")
+	clusterRef := metav1.NewControllerRef(cluster, controllerKind)
+
+	trueValue := true
+	storageNode := &corev1.StorageNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "node1",
+			Namespace:       cluster.Namespace,
+			OwnerReferences: []metav1.OwnerReference{*clusterRef},
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeStateCondition,
+					Status: corev1.NodeOnlineStatus,
+				},
+			},
+			NodeAttributes: &corev1.NodeAttributes{
+				Storage: &trueValue,
+			},
+		},
+	}
+
+	k8sClient := testutil.FakeK8sClient(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pxutil.PortworxServiceName,
+			Namespace: cluster.Namespace,
+		},
+		Spec: v1.ServiceSpec{
+			ClusterIP: sdkServerIP,
+			Ports: []v1.ServicePort{
+				{
+					Name: pxutil.PortworxSDKPortName,
+					Port: int32(sdkServerPort),
+				},
+			},
+		},
+	},
+		storageNode,
+		cluster)
+
+	recorder := record.NewFakeRecorder(10)
+	driver := testutil.MockDriver(mockCtrl)
+	controller := Controller{
+		client:      k8sClient,
+		recorder:    recorder,
+		Driver:      driver,
+		nodeInfoMap: maps.MakeSyncMap[string, *k8s.NodeInfo](),
+	}
+
+	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
+	driver.EXPECT().String().Return("ut-driver").AnyTimes()
+
+	// TestCase 1: storage label should not be added for PX < 3.1.0 if node pools are empty
+	podNode1 := createStoragePod(cluster, "pod-node1", storageNode.Name, nil, clusterRef)
+	err = k8sClient.Create(context.TODO(), podNode1)
+	require.NoError(t, err)
+	expectedNodeEnumerateResp := &osdapi.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*osdapi.StorageNode{
+			{Pools: []*osdapi.StoragePool{}, SchedulerNodeName: "node1", NodeLabels: map[string]string{pxutil.NodeLabelPortworxVersion: "3.0.0"}},
+		},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), gomock.Any()).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	storageNodeRequest := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      storageNode.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+	_, err = controller.Reconcile(context.TODO(), storageNodeRequest)
+	require.NoError(t, err)
+
+	pod1 := &v1.Pod{}
+	err = testutil.Get(controller.client, pod1, podNode1.Name, podNode1.Namespace)
+	require.NoError(t, err)
+
+	_, present := pod1.Annotations[constants.LabelKeyStoragePod]
+	require.False(t, present)
+
+	// TestCase 2: storage label should be added for PX < 3.1.0 if node pools are not empty
+	podNode1 = createStoragePod(cluster, "pod-node1", storageNode.Name, nil, clusterRef)
+	podNode1.Annotations = make(map[string]string, 0)
+	podNode1.Annotations[constants.LabelKeyStoragePod] = constants.LabelValueTrue
+	err = k8sClient.Update(context.TODO(), podNode1)
+	require.NoError(t, err)
+
+	expectedNodeEnumerateResp = &osdapi.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*osdapi.StorageNode{
+			{Pools: []*osdapi.StoragePool{{ID: 1}}, SchedulerNodeName: "node2", NodeLabels: map[string]string{pxutil.NodeLabelPortworxVersion: "3.0.0"}},
+		},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), gomock.Any()).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	storageNodeRequest = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      storageNode.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+
+	_, err = controller.Reconcile(context.TODO(), storageNodeRequest)
+	require.NoError(t, err)
+
+	pod1 = &v1.Pod{}
+	err = testutil.Get(controller.client, pod1, podNode1.Name, podNode1.Namespace)
+	require.NoError(t, err)
+
+	_, present = pod1.Annotations[constants.LabelKeyStoragePod]
+	require.True(t, present)
+
+	// TestCase 3: storage label should be added for PX >= 3.1.0 if node is QuorumMember
+	podNode1 = createStoragePod(cluster, "pod-node1", storageNode.Name, nil, clusterRef)
+	podNode1.Annotations = make(map[string]string, 0)
+	podNode1.Annotations[constants.LabelKeyStoragePod] = constants.LabelValueTrue
+	err = k8sClient.Update(context.TODO(), podNode1)
+	require.NoError(t, err)
+
+	storageNode.Annotations = nil
+	err = k8sClient.Update(context.TODO(), storageNode)
+	require.NoError(t, err)
+
+	expectedNodeEnumerateResp = &osdapi.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*osdapi.StorageNode{
+			{SchedulerNodeName: "node3", NodeLabels: map[string]string{pxutil.NodeLabelPortworxVersion: "3.1.0"}, NonQuorumMember: false},
+		},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), gomock.Any()).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	storageNodeRequest = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      storageNode.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+
+	_, err = controller.Reconcile(context.TODO(), storageNodeRequest)
+	require.NoError(t, err)
+
+	pod1 = &v1.Pod{}
+	err = testutil.Get(controller.client, pod1, podNode1.Name, podNode1.Namespace)
+	require.NoError(t, err)
+
+	_, present = pod1.Annotations[constants.LabelKeyStoragePod]
+	require.True(t, present)
+
+	// TestCase 4: storage label should be added for PX >= 3.1.0 if node is not QuorumMember
+	podNode1 = createStoragePod(cluster, "pod-node1", storageNode.Name, nil, clusterRef)
+	err = k8sClient.Update(context.TODO(), podNode1)
+	require.NoError(t, err)
+
+	storageNode.Annotations = nil
+	err = k8sClient.Update(context.TODO(), storageNode)
+	require.NoError(t, err)
+
+	expectedNodeEnumerateResp = &osdapi.SdkNodeEnumerateWithFiltersResponse{
+		Nodes: []*osdapi.StorageNode{
+			{SchedulerNodeName: "node4", NodeLabels: map[string]string{pxutil.NodeLabelPortworxVersion: "3.1.0"}, NonQuorumMember: true},
+		},
+	}
+	mockNodeServer.EXPECT().
+		EnumerateWithFilters(gomock.Any(), gomock.Any()).
+		Return(expectedNodeEnumerateResp, nil).
+		Times(1)
+
+	storageNodeRequest = reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      storageNode.Name,
+			Namespace: cluster.Namespace,
+		},
+	}
+
+	_, err = controller.Reconcile(context.TODO(), storageNodeRequest)
+	require.NoError(t, err)
+
+	pod1 = &v1.Pod{}
+	err = testutil.Get(controller.client, pod1, podNode1.Name, podNode1.Namespace)
+	require.NoError(t, err)
+
+	_, present = pod1.Annotations[constants.LabelKeyStoragePod]
+	require.False(t, present)
+}
+
 // TestReconcileKVDB focuses on reconciling a StorageNode which is running KVDB
 func TestReconcileKVDB(t *testing.T) {
 	logrus.SetLevel(logrus.TraceLevel)


### PR DESCRIPTION
**What this PR does / why we need it:**
The PDB value for px-storage is not changing if PX service is stopped on a node by labelling with px/service=stop label.

Reason :
This was happening because when we label our node with px/service=stop , the label storage=true was getting removed from PX pods, since to decide whether node can be storagenode or not, operator checks only status of the storagenode and not rely on any parameter.
The PR fixes this behaviour and uses NonQuorumMember flag to decide storage/storageless node.

- a node will be considered storage node if we PX version is >= 3.1.0 , and the node is a quorum member after Node is not in Initializing state
- a node will be considered storageless node if we PX version is >= 3.1.0 , and the node is not a quorum member after Node is not in Initializing state
- a node will be considered storage node if we PX version is < 3.1.0 and nodepools are not empty after Node is not in Initializing state
- a node will be considered storage node if we PX version is < 3.1.0 and nodepools are empty after Node is not in Initializing state

**Which issue(s) this PR fixes (optional)**
Closes # PWX-37266

**Testing Done:**

- Fresh install and upgrade PX
- labeling node with px/service= stop and start
- Install with Security enabled/disabled