### PR TITLE
PWX-36928: telemetry SSL-cert validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ export DOCKER_HUB_REPO=<eg. mybuildx>
 make container deploy
 ```
 
+

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -2,6 +2,9 @@ package component
 
 import (
 	cryptoTls "crypto/tls"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
@@ -127,6 +130,10 @@ const (
 
 var (
 	certStoreTypeRegx = regexp.MustCompile(`certStoreType: .*`)
+	// oid_pseudonym is x.500 attribute type Pseudonym
+	oid_pseudonym = asn1.ObjectIdentifier([]int{2, 5, 4, 65})
+	// errInvalidTelemetryCert returned when telemetry certificate is invalid
+	errInvalidTelemetryCert = fmt.Errorf("invalid telemetry certificate")
 )
 
 type telemetry struct {
@@ -833,6 +840,18 @@ func (t *telemetry) createDeploymentTelemetryRegistration(
 	deployment.Spec.Template.ObjectMeta = k8sutil.AddManagedByOperatorLabel(deployment.Spec.Template.ObjectMeta)
 	pxutil.ApplyStorageClusterSettingsToPodSpec(cluster, &deployment.Spec.Template.Spec)
 
+	// have a valid cluster UUID?  lets validate the Telemetry SSL cert
+	if cuuid := cluster.Status.ClusterUID; cuuid != "" {
+		if certBytes, err := t.getTelemetrySSLCert(deployment.Namespace); err != nil {
+			logrus.WithError(err).Errorf("failed to get telemetry SSL cert")
+		} else if err2 := t.validateTelemetrySSLCert(certBytes, cuuid); err2 == errInvalidTelemetryCert {
+			logrus.Warn("refreshing telemetry SSL cert")
+			t.refreshTelemetrySSLCert(deployment)
+		} else if err2 != nil {
+			logrus.WithError(err2).Errorf("failed to validate telemetry SSL cert")
+		}
+	}
+
 	existingDeployment := &appsv1.Deployment{}
 	if err := k8sutil.GetDeployment(t.k8sClient, deployment.Name, deployment.Namespace, existingDeployment); err != nil {
 		return err
@@ -1002,6 +1021,79 @@ func (t *telemetry) createDeploymentTelemetryCollectorV2(
 
 	t.isCollectorDeploymentCreated = true
 	return nil
+}
+
+// getTelemetrySSLCert returns the telemetry SSL cert
+func (t *telemetry) getTelemetrySSLCert(namespace string) ([]byte, error) {
+	var sec v1.Secret
+	logrus.Debugf("Inspecting secret %s/%s for SSL cert", namespace, pxutil.TelemetryCertName)
+	err := k8sutil.GetSecret(t.k8sClient, pxutil.TelemetryCertName, namespace, &sec)
+	if err != nil {
+		return nil, err
+	}
+	return sec.Data["cert"], nil
+}
+
+// validateTelemetrySSLCert validates the telemetry SSL certificate.
+// - note: cert's Psaudonym needs to match the cluster UUID
+func (t *telemetry) validateTelemetrySSLCert(certBytes []byte, cuuid string) error {
+	if len(certBytes) <= 0 || cuuid == "" {
+		return nil
+	}
+
+	block, _ := pem.Decode(certBytes)
+	if block == nil {
+		return fmt.Errorf("failed to decode SSL certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return err
+	} else if cert == nil {
+		return fmt.Errorf("failed to parse SSL certificate")
+	}
+
+	// find Pseudonym in Subject names
+	pseudonym := ""
+	for _, v := range cert.Subject.Names {
+		if v.Type.Equal(oid_pseudonym) {
+			var ok bool
+			// quick sanity check!
+			if pseudonym, ok = v.Value.(string); !ok {
+				return fmt.Errorf("SSL cert Pseudonym is not a string")
+			}
+			break
+		}
+	}
+	if pseudonym == "" {
+		logrus.Errorf("SSL cert Pseudonym not found")
+		return errInvalidTelemetryCert
+	}
+
+	if pseudonym != cuuid {
+		logrus.Errorf("SSL cert Pseudonym %s does not match cluster UUID %s",
+			pseudonym, cuuid)
+		return errInvalidTelemetryCert
+	}
+	logrus.Debugf("SSL cert Pseudonym %s matches cluster UUID", pseudonym)
+	return nil
+}
+
+// refreshTelemetrySSLCert deletes the telemetry SSL cert secret and telemetry-registration PODs
+func (t *telemetry) refreshTelemetrySSLCert(dep *appsv1.Deployment) {
+	if dep == nil {
+		return
+	}
+	logrus.Warnf("refreshTelemetrySSLCert - deleting telemetry SSL cert secret %s/%s", dep.Namespace, pxutil.TelemetryCertName)
+	err := k8sutil.DeleteSecret(t.k8sClient, pxutil.TelemetryCertName, dep.Namespace, dep.OwnerReferences...)
+	if err != nil {
+		logrus.WithError(err).Warnf("failed to delete secret %s/%s", dep.Namespace, pxutil.TelemetryCertName)
+	}
+
+	logrus.Warnf("refreshTelemetrySSLCert - deleting POD labeled role=%s", DeploymentNameTelemetryRegistration)
+	err = k8sutil.DeletePodsByLabel(t.k8sClient, map[string]string{"role": DeploymentNameTelemetryRegistration}, dep.Namespace)
+	if err != nil {
+		logrus.WithError(err).Warnf("failed to delete px-telemetry-registration POD")
+	}
 }
 
 func getArcusTelemetryLocation(cluster *corev1.StorageCluster) string {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -16226,6 +16226,96 @@ func TestTelemetrySecretDeletion(t *testing.T) {
 	require.Empty(t, secret.OwnerReferences)
 }
 
+func TestTelemetrySecretRefresh(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	recorder := record.NewFakeRecorder(10)
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), recorder)
+	require.NoError(t, err)
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/oci-monitor:3.2.0",
+			Monitoring: &corev1.MonitoringSpec{
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: true,
+				},
+			},
+			DeleteStrategy: &corev1.StorageClusterDeleteStrategy{
+				Type: corev1.UninstallAndWipeStorageClusterStrategyType,
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			ClusterUID: "test-clusteruid",
+		},
+	}
+
+	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	require.NotEmpty(t, ownerRef)
+
+	err = k8sClient.Create(
+		context.TODO(),
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            testutil.TelemetryCertName,
+				Namespace:       cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Data: map[string][]byte{
+				"cert": []byte(`-----BEGIN CERTIFICATE-----
+MIIFEzCCA3ugAwIBAgIDASXwMA0GCSqGSIb3DQEBCwUAMFkxCzAJBgNVBAYTAlVT
+MRkwFwYDVQQKDBBQdXJlIFN0b3JhZ2UgSW5jMQ4wDAYDVQQLDAVQdXJlMTEfMB0G
+A1UEAwwWUHVyZTEgU3Vib3JkaW5hdGUgQ0EgNDAeFw0yNDA1MTQwNjExNDBaFw0y
+NTA1MTQwNjExNDBaMIHoMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5p
+YTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUHVyZVN0b3JhZ2Ux
+EzARBgNVBAsTClB1cmUgSW5mcmExEDAOBgNVBAMTB3Vua25vd24xLTArBgNVBAUT
+JDMxY2RmNzc0LTk0YTktNDE4MS04MGNkLTIxNWJkZDRmZWI1MzEtMCsGA1UEQRYk
+Yzc1ZTJjYmYtMTc2NS00MDY4LTkxM2QtNzYxODNlNjhmOGNjMREwDwYDVQQEFghw
+b3J0d29yeDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAONBSa5q3wyl
+6qVWZO7KCWZASUDPkFv8y31vtKAoS1jhAe4mDtDWyDxXrBMK9ngdKMpWfrBaoZZQ
+Z7FtOGsaVzansSXZAReYiZj1OFZKZkEEhhulNxHPOV3zKJKQxNOrdGfi0i8ZhlDG
+9YbYIJDeeiJE44UaYn/K+Vs/m+x5K95dFqtXdvIuhL00dVT1DR56pcskprAJ8R+i
+ILTYKkkwn+noeajESpIzdUHdtDbWF/+kw5j+e+CUWxtsKw1xfTz7fj+6Vufemrhw
+MV/DP5fbjS1RBHBhCN3LDFmwPSPJAniDECOYRsiR5eFkIHd42wQOu/EceFMfwjzA
+mtOSQzvQdC0CAwEAAaOB0zCB0DAMBgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFA5o
+8M8qUnCkQY/IRLW9P0hXo2+HMFsGCCsGAQUFBwEBBE8wTTBLBggrBgEFBQcwAYY/
+aHR0cDovL3N1Yi1jYS0wNC5zZWMuY2xvdWQtc3VwcG9ydC5wdXJlc3RvcmFnZS5j
+b206ODA4MC9jYS9vY3NwMA4GA1UdDwEB/wQEAwIEsDATBgNVHSUEDDAKBggrBgEF
+BQcDAjAdBgNVHQ4EFgQUvcvcmGzxsDP2oLRIl72EsV0P12IwDQYJKoZIhvcNAQEL
+BQADggGBAJRfBb4D1ojq8vj006xKpp/eLMyAxMRMuYwzrooDa+U4kdvPlk0ibA3i
+zChg117eRV19mjzTHaVPovwlzfhCqZFYyRR+c0iOFu/DUBBOamMZLx2rcZsnA9XC
+QN/9TIyDnXyup9dG6WAu1z5RW6VPifek1DUjdngj9TiyJQOchwLWD/iBG86Ap2gJ
++zt/G4Nwq5VZOp6qX7zfuW+hY9t8FVAz0X9+ohQHgN2eCxvdajgly4+TpVxybubQ
+tooUqkPNRKZ5P0IT9Do0E1z9ZlAQqGTC5abC9RNwAXf/KpIFpardKC/p5BwOZI2P
+aqDgX/Bcx/XoiRHBtDv450/GnAdgD+1yxFCjVkt3vnJybSgdbYV5f2+Owowc3aUw
+agq/IJO6rOF10LX7cDqVKfoQqbpU80v4Uk1Ls6FntKkzUj6njnpoPWdoFqxJmoDG
+zvz7BX4rQqGCD6ElMHyQM7rdq77/ywgSiRJlFf7eQsWNKTpHueulgqnqdW55pNaW
+JhBhJjN84g==
+-----END CERTIFICATE-----`),
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	require.Len(t, recorder.Events, 0)
+
+	// male sure invalid secret got deleted
+	secret := v1.Secret{}
+	err = testutil.Get(k8sClient, &secret, testutil.TelemetryCertName, cluster.Namespace)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
 func TestTelemetryCCMGoRestartPhonehome(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
@@ -2025,6 +2026,27 @@ func DeleteSecret(
 	return k8sClient.Update(context.TODO(), secret)
 }
 
+// GetSecret gets secret
+func GetSecret(
+	k8sClient client.Client,
+	name string,
+	namespace string,
+	secret *v1.Secret,
+) error {
+	err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+		secret,
+	)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 // GetCRDFromFile parses a CRD definition filename from crdBaseDir and returns the parsed object
 func GetCRDFromFile(
 	filename string,
@@ -2310,4 +2332,34 @@ func GetDefaultKubeSchedulerImage(k8sVersion *version.Version) string {
 		return prefix + "1.21.4"
 	}
 	return prefix + k8sVersion.String()
+}
+
+// DeletePodsByLabel deletes pods by label, from a given namespace
+func DeletePodsByLabel(
+	k8sClient client.Client,
+	mylabels map[string]string,
+	namespace string,
+) error {
+	podList := &v1.PodList{}
+	err := k8sClient.List(
+		context.TODO(),
+		podList,
+		&client.ListOptions{
+			Namespace:     namespace,
+			LabelSelector: labels.SelectorFromSet(mylabels),
+		},
+	)
+	if err != nil {
+		return err
+	} else if len(podList.Items) <= 0 {
+		return nil
+	}
+
+	for _, pod := range podList.Items {
+		logrus.Debugf("Deleting pod %s/%s", pod.Namespace, pod.Name)
+		if err := k8sClient.Delete(context.TODO(), &pod); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -765,13 +765,13 @@ func reconstructSpecURL(cluster *corev1.StorageCluster) string {
 
 func validateTelemetrySecret(cluster *corev1.StorageCluster, timeout, interval time.Duration, force bool) error {
 	t := func() (interface{}, bool, error) {
-		secret, err := coreops.Instance().GetSecret("pure-telemetry-certs", cluster.Namespace)
+		secret, err := coreops.Instance().GetSecret(TelemetryCertName, cluster.Namespace)
 		if err != nil {
 			if errors.IsNotFound(err) && !force {
 				// Skip secret existence validation
 				return nil, false, nil
 			}
-			return nil, true, fmt.Errorf("failed to get secret pure-telemetry-certs: %v", err)
+			return nil, true, fmt.Errorf("failed to get secret %s: %v", TelemetryCertName, err)
 		}
 		logrus.Debugf("Found secret %s", secret.Name)
 
@@ -1490,13 +1490,13 @@ func ValidateUninstallStorageCluster(
 
 	// Verify telemetry secret is deleted on UninstallAndWipe when telemetry is enabled
 	if cluster.Spec.DeleteStrategy != nil && cluster.Spec.DeleteStrategy.Type == corev1.UninstallAndWipeStorageClusterStrategyType {
-		secret, err := coreops.Instance().GetSecret("pure-telemetry-certs", cluster.Namespace)
+		secret, err := coreops.Instance().GetSecret(TelemetryCertName, cluster.Namespace)
 		if err != nil && !errors.IsNotFound(err) {
-			return fmt.Errorf("failed to get secret pure-telemetry-certs: %v", err)
+			return fmt.Errorf("failed to get secret %s: %v", TelemetryCertName, err)
 		} else if err == nil {
 			// Secret found, only do the validation when telemetry is enabled, since if it's disabled, there's a chance secret owner is not set yet
 			if cluster.Spec.Monitoring != nil && cluster.Spec.Monitoring.Telemetry != nil && cluster.Spec.Monitoring.Telemetry.Enabled {
-				return fmt.Errorf("telemetry secret pure-telemetry-certs was found when shouldn't have been")
+				return fmt.Errorf("telemetry secret %s was found when shouldn't have been", TelemetryCertName)
 			}
 			// Delete stale telemetry secret
 			if err := coreops.Instance().DeleteSecret(secret.Name, cluster.Namespace); err != nil {


### PR DESCRIPTION
* adding code to validate (and refresh) Pure1 Telemetry's SSL certificate

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

ISSUE:
* customer did not properly recycle the px-cluster, so the SSL certificate in Telemetry's secret was pointing to a STALE ClusterUUID

FIX:
* as a fix, operator is now explicitly checking the Telemetry's SSL certificate
* if certificate is invalid, it'll remove the Telemetry's secret, and restart the telemetry-registration POD

**Which issue(s) this PR fixes** (optional)
Closes # PWX-36928

**Special notes for your reviewer**:

Adding dedicated Unit-test

Also, manually changed Telemetry's secret with a dummy SSL certificate -- and the PODs are restarting:

```
# kubectl get pods -o wide

NAME                                             READY   STATUS        RESTARTS   AGE     IP            NODE   NOMINATED NODE   READINESS GATES
...
portworx-operator-6bd847f88f-n8ssm               1/1     Running       0          45s     10.244.2.22   foo2   <none>           <none>
...
px-telemetry-phonehome-fxcqb                     2/2     Running       0          5d15h   10.244.1.15   foo3   <none>           <none>
px-telemetry-registration-69ccd685f7-bgb8c       2/2     Running       0          24s     10.13.1.64    foo4   <none>           <none>
px-telemetry-registration-69ccd685f7-hmgp7       2/2     Terminating   0          7d14h   10.13.1.59    foo2   <none>           <none>
```

Logs:
```
time="21-05-2024 20:11:45" level=info msg="Using ccm-go version: 1.2.2" file="util.go:1282"
time="21-05-2024 20:11:45" level=debug msg="Inspecting secret portworx/pure-telemetry-certs for SSL cert" file="telemetry.go:1024"
time="21-05-2024 20:11:45" level=error msg="SSL cert Pseudonym not found" file="telemetry.go:1063"
time="21-05-2024 20:11:45" level=warning msg="refreshing telemetry SSL cert" file="telemetry.go:843"
time="21-05-2024 20:11:45" level=warning msg="refreshTelemetrySSLCert - deleting telemetry SSL cert secret portworx/pure-telemetry-certs" file="telemetry.go:1081"
time="21-05-2024 20:11:45" level=info msg="Deleting portworx/pure-telemetry-certs Secret" file="k8s.go:2021"
time="21-05-2024 20:11:45" level=warning msg="refreshTelemetrySSLCert - deleting POD labeled role=px-telemetry-registration" file="telemetry.go:1087"
time="21-05-2024 20:11:45" level=debug msg="Deleting pod portworx/px-telemetry-registration-69ccd685f7-hmgp7" file="k8s.go:2359"
```