### PR TITLE
PTX-23958: Check custom secure port in k3s for pvcController in tests

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -3155,7 +3155,7 @@ func validatePvcControllerPorts(cluster *corev1.StorageCluster, pvcControllerDep
 						for _, containerCommand := range container.Command {
 							if strings.Contains(containerCommand, "--secure-port") {
 								if len(pvcSecurePort) == 0 {
-									if isAKS(cluster) {
+									if isAKS(cluster) || IsK3sCluster() {
 										if strings.Split(containerCommand, "=")[1] != AksPVCControllerSecurePort {
 											return nil, true, fmt.Errorf("failed to validate secure-port, secure-port is missing in the PVC Controler pod %s", pod.Name)
 										}

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -116,8 +116,8 @@ const (
 	// PxOperatorMasterVersion is a tag for PX Operator master version
 	PxOperatorMasterVersion = "99.9.9"
 
-	// AksPVCControllerSecurePort is the PVC controller secure port.
-	AksPVCControllerSecurePort = "10261"
+	// CustomPVCControllerSecurePort is the PVC controller secure port.
+	CustomPVCControllerSecurePort = "10261"
 
 	pxAnnotationPrefix = "portworx.io"
 
@@ -3156,7 +3156,7 @@ func validatePvcControllerPorts(cluster *corev1.StorageCluster, pvcControllerDep
 							if strings.Contains(containerCommand, "--secure-port") {
 								if len(pvcSecurePort) == 0 {
 									if isAKS(cluster) || IsK3sCluster() {
-										if strings.Split(containerCommand, "=")[1] != AksPVCControllerSecurePort {
+										if strings.Split(containerCommand, "=")[1] != CustomPVCControllerSecurePort {
 											return nil, true, fmt.Errorf("failed to validate secure-port, secure-port is missing in the PVC Controler pod %s", pod.Name)
 										}
 									} else {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This is a fix for the integration tests where a custom secure port is checked for pvc controller as well for k3s clusters

**Which issue(s) this PR fixes** (optional)
Closes # PTX-23958

