### PR TITLE
PWX-37366: Add function to check if k3s deployment or rke2

### DIFF
--- a/drivers/storage/portworx/component/pvccontroller.go
+++ b/drivers/storage/portworx/component/pvccontroller.go
@@ -331,14 +331,14 @@ func (c *pvcController) createDeployment(
 		command = append(command, "--address=0.0.0.0")
 		if port, ok := cluster.Annotations[pxutil.AnnotationPVCControllerPort]; ok && port != "" {
 			command = append(command, "--port="+port)
-		} else if pxutil.IsAKS(cluster) || c.isK3sDeployment() {
+		} else if pxutil.IsAKS(cluster) || c.isK3sOrRke2Deployment() {
 			command = append(command, "--port="+CustomPVCControllerInsecurePort)
 		}
 	}
 
 	if securePort, ok := cluster.Annotations[pxutil.AnnotationPVCControllerSecurePort]; ok && securePort != "" {
 		command = append(command, "--secure-port="+securePort)
-	} else if pxutil.IsAKS(cluster) || c.isK3sDeployment() {
+	} else if pxutil.IsAKS(cluster) || c.isK3sOrRke2Deployment() {
 		command = append(command, "--secure-port="+CustomPVCControllerSecurePort)
 	}
 
@@ -420,7 +420,7 @@ func (c *pvcController) getPVCControllerDeploymentSpec(
 	if c.k8sVersion.GreaterThanOrEqual(k8sutil.K8sVer1_22) {
 		if port, ok := cluster.Annotations[pxutil.AnnotationPVCControllerSecurePort]; ok && port != "" {
 			healthCheckPort = port
-		} else if pxutil.IsAKS(cluster) || c.isK3sDeployment() {
+		} else if pxutil.IsAKS(cluster) || c.isK3sOrRke2Deployment() {
 			healthCheckPort = CustomPVCControllerSecurePort
 		} else {
 			healthCheckPort = defaultPVCControllerSecurePort
@@ -428,7 +428,7 @@ func (c *pvcController) getPVCControllerDeploymentSpec(
 		healthCheckScheme = v1.URISchemeHTTPS
 	} else if port, ok := cluster.Annotations[pxutil.AnnotationPVCControllerPort]; ok && port != "" {
 		healthCheckPort = port
-	} else if pxutil.IsAKS(cluster) || c.isK3sDeployment() {
+	} else if pxutil.IsAKS(cluster) || c.isK3sOrRke2Deployment() {
 		healthCheckPort = CustomPVCControllerInsecurePort
 	}
 
@@ -551,7 +551,7 @@ func (c *pvcController) getPVCControllerDeploymentSpec(
 	return deployment
 }
 
-func (c *pvcController) isK3sDeployment() bool {
+func (c *pvcController) isK3sOrRke2Deployment() bool {
 
 	if c.isK3s != nil {
 		return *c.isK3s
@@ -562,7 +562,7 @@ func (c *pvcController) isK3sDeployment() bool {
 		return false
 	}
 	if len(ext) > 0 {
-		ok := pxutil.IsK3sClusterExt(ext)
+		ok := pxutil.IsK3sOrRke2ClusterExt(ext)
 		c.isK3s = boolPtr(ok)
 		return *c.isK3s
 	}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -2097,6 +2097,49 @@ func TestPVCControllerInstallForK3s(t *testing.T) {
 	verifyPVCControllerDeploymentObject(t, cluster, k8sClient, pvcControllerDeployment)
 }
 
+func TestPVCControllerInstallForRke2(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+
+	k8sClient := testutil.FakeK8sClient()
+
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.18.0+rke2r1",
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-system",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "true",
+			},
+		},
+	}
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	verifyPVCControllerInstall(t, cluster, k8sClient, "pvcControllerClusterRole.yaml")
+
+	specFileName := "pvcControllerDeployment.yaml"
+	pvcControllerDeployment := testutil.GetExpectedDeployment(t, specFileName)
+	command := pvcControllerDeployment.Spec.Template.Spec.Containers[0].Command
+	command = append(command, "--port="+component.CustomPVCControllerInsecurePort)
+	command = append(command, "--secure-port="+component.CustomPVCControllerSecurePort)
+	pvcControllerDeployment.Spec.Template.Spec.Containers[0].Command = command
+	pvcControllerDeployment.Spec.Template.Spec.Containers[0].Image = "gcr.io/google_containers/kube-controller-manager-amd64:v1.18.0"
+	pvcControllerDeployment.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.HTTPGet.Port = intstr.Parse(component.CustomPVCControllerInsecurePort)
+
+	verifyPVCControllerDeploymentObject(t, cluster, k8sClient, pvcControllerDeployment)
+}
+
 func TestPVCControllerWhenPVCControllerDisabledExplicitly(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1950,7 +1950,7 @@ func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 
 func isK3sClusterExt(ext string) bool {
 	if len(ext) > 0 {
-		return pxutil.IsK3sClusterExt(ext) || strings.HasPrefix(ext[1:], "rke2")
+		return pxutil.IsK3sClusterExt(ext)
 	}
 	return false
 }

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -1950,7 +1950,7 @@ func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 
 func isK3sOrRke2ClusterExt(ext string) bool {
 	if len(ext) > 0 {
-		return pxutil.IsK3sClusterExt(ext)
+		return pxutil.IsK3sOrRke2ClusterExt(ext)
 	}
 	return false
 }

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -123,7 +123,7 @@ func newTemplate(
 		return nil, err
 	}
 
-	t.isK3s = isK3sClusterExt(ext)
+	t.isK3s = isK3sOrRke2ClusterExt(ext)
 	t.runOnMaster = t.isK3s || pxutil.RunOnMaster(cluster)
 	t.pxVersion = pxutil.GetPortworxVersion(cluster)
 	deprecatedCSIDriverName := pxutil.UseDeprecatedCSIDriverName(cluster)
@@ -1948,7 +1948,7 @@ func getCommonVolumeList(pxVersion *version.Version) []volumeInfo {
 	return list
 }
 
-func isK3sClusterExt(ext string) bool {
+func isK3sOrRke2ClusterExt(ext string) bool {
 	if len(ext) > 0 {
 		return pxutil.IsK3sClusterExt(ext)
 	}

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1915,5 +1915,5 @@ func isVersionSupported(current, target string) bool {
 }
 
 func IsK3sClusterExt(ext string) bool {
-	return strings.HasPrefix(ext[1:], "k3s")
+	return strings.HasPrefix(ext[1:], "k3s") || strings.HasPrefix(ext[1:], "rke2")
 }

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1914,7 +1914,7 @@ func isVersionSupported(current, target string) bool {
 	return currentVersion.Core().GreaterThanOrEqual(targetVersion)
 }
 
-func IsK3sClusterExt(ext string) bool {
+func IsK3sOrRke2ClusterExt(ext string) bool {
 	return strings.HasPrefix(ext[1:], "k3s") || strings.HasPrefix(ext[1:], "rke2")
 }
 

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -1810,7 +1810,7 @@ func GetExpectedPxNodeList(cluster *corev1.StorageCluster) ([]v1.Node, error) {
 			NodeAffinity: cluster.Spec.Placement.NodeAffinity.DeepCopy(),
 		}
 	} else {
-		if IsK3sCluster() || IsPxDeployedOnMaster(cluster) {
+		if IsK3sOrRke2Cluster() || IsPxDeployedOnMaster(cluster) {
 			runOnMaster = true
 		}
 
@@ -1889,8 +1889,8 @@ func GetFullVersion() (*version.Version, string, error) {
 	return ver, "", err
 }
 
-// IsK3sCluster returns true or false, based on this kubernetes cluster is k3s or not
-func IsK3sCluster() bool {
+// IsK3sOrRke2Cluster returns true or false, based on this kubernetes cluster is k3s or rke2 or not
+func IsK3sOrRke2Cluster() bool {
 	// Get k8s version ext
 	_, ext, _ := GetFullVersion()
 
@@ -3155,7 +3155,7 @@ func validatePvcControllerPorts(cluster *corev1.StorageCluster, pvcControllerDep
 						for _, containerCommand := range container.Command {
 							if strings.Contains(containerCommand, "--secure-port") {
 								if len(pvcSecurePort) == 0 {
-									if isAKS(cluster) || IsK3sCluster() {
+									if isAKS(cluster) || IsK3sOrRke2Cluster() {
 										if strings.Split(containerCommand, "=")[1] != CustomPVCControllerSecurePort {
 											return nil, true, fmt.Errorf("failed to validate secure-port, secure-port is missing in the PVC Controler pod %s", pod.Name)
 										}

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -116,8 +116,8 @@ const (
 	// PxOperatorMasterVersion is a tag for PX Operator master version
 	PxOperatorMasterVersion = "99.9.9"
 
-	// AksPVCControllerSecurePort is the PVC controller secure port.
-	AksPVCControllerSecurePort = "10261"
+	// CustomPVCControllerSecurePort is the PVC controller secure port.
+	CustomPVCControllerSecurePort = "10261"
 
 	pxAnnotationPrefix = "portworx.io"
 
@@ -3155,8 +3155,8 @@ func validatePvcControllerPorts(cluster *corev1.StorageCluster, pvcControllerDep
 						for _, containerCommand := range container.Command {
 							if strings.Contains(containerCommand, "--secure-port") {
 								if len(pvcSecurePort) == 0 {
-									if isAKS(cluster) {
-										if strings.Split(containerCommand, "=")[1] != AksPVCControllerSecurePort {
+									if isAKS(cluster) || IsK3sCluster() {
+										if strings.Split(containerCommand, "=")[1] != CustomPVCControllerSecurePort {
 											return nil, true, fmt.Errorf("failed to validate secure-port, secure-port is missing in the PVC Controler pod %s", pod.Name)
 										}
 									} else {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Similar to [#1510](https://github.com/libopenstorage/operator/pull/1510) , same issue is seen in rke2 cluster. Solution is to check if cluster is k3s or rke2 and add a custom pvccontroller port

**Which issue(s) this PR fixes** (optional)
Closes # PWX-37366


