### PR TITLE
StorageCluster schema changes to support parallel portworx upgrades

### DIFF
--- a/deploy/crds/core_v1_storagecluster_crd.yaml
+++ b/deploy/crds/core_v1_storagecluster_crd.yaml
@@ -176,6 +176,16 @@ spec:
                           their place. Once the new pods are available, it then proceeds onto other
                           StorageCluster pods, thus ensuring that at least 70% of original number of
                           StorageCluster pods are available at all times during the update.
+                      disruption:
+                        type: object
+                        description: >-
+                          The default behavior is non-disruptive upgrades. This setting disables the default
+                          non-disruptive upgrades and reverts to the previous behavior of upgrading nodes in
+                          parallel without worrying about disruption.
+                        properties:
+                          allow:
+                            type: boolean
+                            description: Flag indicates whether updates are non-disruptive or disruptive.
               deleteStrategy:
                 type: object
                 description: Delete strategy to uninstall and wipe the storage cluster.

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -313,11 +313,11 @@ type RollingUpdateStorageCluster struct {
 	// The default behavior is non-disruptive upgrades. This setting disables the default
 	// non-disruptive upgrades and reverts to the previous behavior of upgrading nodes in
 	// parallel without worrying about disruption.
-	Disruption DisruptionSpec `json:"disruption,omitempty"`
+	Disruption Disruption `json:"disruption,omitempty"`
 }
 
-// DisruptionSpec contains disruption details
-type DisruptionSpec struct {
+// Disruption contains configuration for disruption
+type Disruption struct {
 	// Flag indicates whether updates are non-disruptive or disruptive.
 	Allow *bool `json:"allow,omitempty"`
 }

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -309,6 +309,17 @@ type RollingUpdateStorageCluster struct {
 	// Defaults to 0 (pod will be considered available as soon as it is ready)
 	// +optional
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty"`
+
+	// The default behavior is non-disruptive upgrades. This setting disables the default
+	// non-disruptive upgrades and reverts to the previous behavior of upgrading nodes in
+	// parallel without worrying about disruption.
+	Disruption DisruptionSpec `json:"disruption,omitempty"`
+}
+
+// DisruptionSpec contains disruption details
+type DisruptionSpec struct {
+	// Flag indicates whether updates are non-disruptive or disruptive.
+	Allow *bool `json:"allow,omitempty"`
 }
 
 // StorageClusterDeleteStrategyType is enum for storage cluster delete strategies


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR will add a new field to control the PX upgrade behavior. The default behavior would be to have a non-disruptive upgrade. But users should be able to disable that and go back to the old behavior of upgrading nodes in parallel without worrying about the disruption. 

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-36509
