### PR TITLE
[cherry-pick] PWX-37573: tighten the checks for avoiding unnecessary VM live migrat…

### DIFF
--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -163,7 +163,7 @@ func (c *Controller) rollingUpdate(cluster *corev1.StorageCluster, hash string, 
 	}
 
 	// check if we should live-migrate VMs before updating the storage node
-	virtLauncherPodsByNode := map[string][]v1.Pod{}
+	virtLauncherPodsByNode := map[string][]*operatorutil.VMPodEviction{}
 	if len(oldPodsToDelete) > 0 && !forceContinueUpgrade(cluster) && evictVMsDuringUpdate(cluster) {
 		vmPodsPresent, err := c.kubevirt.ClusterHasVMPods()
 		if err != nil {

--- a/pkg/mock/kubevirtmanager.mock.go
+++ b/pkg/mock/kubevirtmanager.mock.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/core/v1"
+	util "github.com/libopenstorage/operator/pkg/util"
 )
 
 // MockKubevirtManager is a mock of KubevirtManager interface.
@@ -50,10 +50,10 @@ func (mr *MockKubevirtManagerMockRecorder) ClusterHasVMPods() *gomock.Call {
 }
 
 // GetVMPodsToEvictByNode mocks base method.
-func (m *MockKubevirtManager) GetVMPodsToEvictByNode(arg0 map[string]bool) (map[string][]v1.Pod, error) {
+func (m *MockKubevirtManager) GetVMPodsToEvictByNode(arg0 map[string]bool) (map[string][]*util.VMPodEviction, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetVMPodsToEvictByNode", arg0)
-	ret0, _ := ret[0].(map[string][]v1.Pod)
+	ret0, _ := ret[0].(map[string][]*util.VMPodEviction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -65,7 +65,7 @@ func (mr *MockKubevirtManagerMockRecorder) GetVMPodsToEvictByNode(arg0 interface
 }
 
 // StartEvictingVMPods mocks base method.
-func (m *MockKubevirtManager) StartEvictingVMPods(arg0 []v1.Pod, arg1 string, arg2 func(string)) {
+func (m *MockKubevirtManager) StartEvictingVMPods(arg0 []*util.VMPodEviction, arg1 string, arg2 func(string)) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "StartEvictingVMPods", arg0, arg1, arg2)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -89,6 +89,15 @@ const (
 	ValidMinAvailable = "ValidMinAvailable"
 )
 
+// VMPodEviction has info about the virt-launcher pod that needs to be evicted before upgrading PX on a node
+type VMPodEviction struct {
+	// PodToEvict is the virt-launcher pod that needs to be evicted
+	PodToEvict v1.Pod
+	// LiveMigrationInProgress is true if in-progress live-migration exists for this VM. In this case, the eviction
+	// should be skipped until the next reconcile cycle
+	LiveMigrationInProgress bool
+}
+
 var (
 	// commonDockerRegistries is a map of commonly used Docker registries
 	commonDockerRegistries = map[string]bool{


### PR DESCRIPTION
…ion (#1563)

**What this PR does / why we need it**:

If the live-migration is in progress for a VM that we want to evict, do not create another live migration for that VM in the same Reconcile() cycle.

Just before starting a live-migration, check the VMI one more time to verify that the VMI is pointing to the same node as the pod being evicted.

These two extra checks reduce the window in which PX and operator may try to live-migrate the same VM out of the same node. Also, it handles any other unexpected live-migrations that might start.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-37573

**Special notes for your reviewer**:

