### PR TITLE
PWX-36817_PWX-32899_op-24.1.1: Fixing .svc.cluster.local DNS domain

### DIFF
--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -332,18 +332,18 @@ func updateDataIfNginxConfigMap(cm *v1.ConfigMap, storageNs string) {
     http {
       server {
         listen 8080;
-          server_name px-plugin-proxy.` + storageNs + `.svc.cluster.local;
+          server_name px-plugin-proxy.` + storageNs + `;
         location / {
-          proxy_pass http://portworx-api.` + storageNs + `.svc.cluster.local:9021;
+          proxy_pass http://portworx-api.` + storageNs + `:9021;
         }
       }
       server {
         listen 8443 ssl;
-        server_name px-plugin-proxy.` + storageNs + `.svc.cluster.local;
+        server_name px-plugin-proxy.` + storageNs + `;
         ssl_certificate /etc/nginx/certs/tls.crt;
         ssl_certificate_key /etc/nginx/certs/tls.key;
         location / {
-          proxy_pass http://portworx-api.` + storageNs + `.svc.cluster.local:9021;
+          proxy_pass http://portworx-api.` + storageNs + `:9021;
         }
       }
     }`,


### PR DESCRIPTION
* note, fixing the remaining use of `.svc.cluster.local` DNS domain in the GUI plugin
* note: the tests are still creating mock host-entries with `.svc.cluster.local` DNS domain in the `/etc/hosts` files -- but this should be OK

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The PX deployment should not assume the K8s/OCP cluster is using the default DNS-domain `.svc.cluster.local`

FIX:
* the K8s deployment already fixes the `/etc/resolv.conf` file for all the PODs, such that the host-resolution _without_ the domain works OK
  - i.e. both `host px-plugin-proxy.portworx.svc.cluster.local` and `host px-plugin-proxy.portworx` should resolve into IP without problems

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-36817/PWX-32899   (op-24.1.0 branch)

**Special notes for your reviewer**:

Manual test:

* changed `portworx-operator` deployment to `replicas=0`  (note, turns px-operator POD)
* edit `oc edit cm px-plugin-proxy-conf` config for NginX to remove the `.svc.cluster.local`  (same as this PR!!)
* restarted the POD:

```
oc delete pod -Al name=px-plugin-proxy
pod "px-plugin-proxy-545b555f5-hhrln" deleted
```

* find POD's hostname and process ID:

```
$ oc get pod -Al name=px-plugin-proxy -o wide
...
portworx    px-plugin-proxy-545b555f5-rwncr   1/1     Running   0          28s   10.129.2.178   ocp-zox-01-vk6hn-worker-6xbv9   <none>           <none>

$ oc get nodes -o wide | grep ocp-zox-01-vk6hn-worker-6xbv9
ocp-zox-01-vk6hn-worker-6xbv9   Ready    worker                 46h   v1.25.16+054f0ba   10.13.112.101   10.13.112.101   Red Hat Enterprise Linux CoreOS 412.86.202405210920-0 (Ootpa)   4.18.0-372.105.1.el8_6.x86_64   cri-o://1.25.5-19.2.rhaos4.12.gitba93e0a.el8

$ ssh core@10.13.112.101
$ sudo bash -l
# ps -ef --forest
...
root     3816624       1  0 18:56 ?        00:00:00 /usr/bin/conmon -b /run/containers/storage/overlay-containers/69534a436aa0a8c6d1243e25d10ec9c08c1af054eea7fb4bca7727262e9d9097/userdata -c 69534a436aa0a8c6d1243e25d10ec9c08c1af054eea7fb4bca7727262e9d9097 --exit-dir /var/run/crio/exits -l /var/log/pods/portworx_px-plugin-proxy-545b555f5-rwncr_70c217d3-2f22-4a34-b922-198654af60c5/nginx/0.log --log-level info -n k8s_nginx_px-plugin-proxy-545b555f5-rwncr_portworx_70c217d3-2f22-4a34-b922-198654af60c5_0 -P /run/containers/storage/overlay-containers/69534a436aa0a8c6d1243e25d10ec9c08c1af054eea7fb4bca7727262e9d9097/userdata/conmon-pidfile -p /run/containers/storage/overlay-containers/69534a436aa0a8c6d1243e25d10ec9c08c1af054eea7fb4bca7727262e9d9097/userdata/pidfile --persist-dir /var/lib/containers/storage/overlay-containers/69534a436aa0a8c6d1243e25d10ec9c08c1af054eea7fb4bca7727262e9d9097/userdata -r /usr/bin/runc --runtime-arg --root=/run/runc --socket-dir-path /var/run/crio --syslog -u 69534a436aa0a8c6d1243e25d10ec9c08c1af054eea7fb4bca7727262e9d9097 -s
1000670+ 3816637 3816624  0 18:56 ?        00:00:00  \_ nginx: master process nginx -g daemon off;
1000670+ 3816675 3816637  0 18:56 ?        00:00:00      \_ nginx: worker process
```

* access POD's file-system via `/proc` and check the PODs `nginx.conf` is correct:

```
# cd /proc/3816675/root/etc/nginx/
# ls -al
total 0
drwxrwsrwx. 4 root 1000670000  91 Jun 14 18:56 .
drwxr-xr-x. 1 root root        31 Jun 14 18:56 ..
drwxr-sr-x. 2 root 1000670000  24 Jun 14 18:56 ..2024_06_14_18_56_27.1893323355
drwxrwsrwt. 3 root 1000670000 120 Jun 14 18:56 certs
lrwxrwxrwx. 1 root 1000670000  32 Jun 14 18:56 ..data -> ..2024_06_14_18_56_27.1893323355
lrwxrwxrwx. 1 root 1000670000  17 Jun 14 18:56 nginx.conf -> ..data/nginx.conf

# cat nginx.conf
pid /tmp/nginx.pid;
    events {
      worker_connections 1024;
    }
    http {
      server {
        listen 8080;
          server_name px-plugin-proxy.portworx;
        location / {
          proxy_pass http://portworx-api.portworx:9021;
        }
      }
      server {
        listen 8443 ssl;
        server_name px-plugin-proxy.portworx;
        ssl_certificate /etc/nginx/certs/tls.crt;
        ssl_certificate_key /etc/nginx/certs/tls.key;
        location / {
          proxy_pass http://portworx-api.portworx:9021;
        }
      }
    }
```
* note, this proves that `pod/px-plugin-proxy-545b555f5-rwncr` is running with the correct `/etc/nginx/nginx.conf` file  (same config as PR!)

Finally - we check the OCP GUI, and confirmed the OCP GUI (still) rendered correctly