### PR TITLE
PWX-36817_PWX-32899_r2_master: Fixing .svc.cluster.local DNS domain (#1574)

### DIFF
--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -332,18 +332,18 @@ func updateDataIfNginxConfigMap(cm *v1.ConfigMap, storageNs string) {
     http {
       server {
         listen 8080;
-          server_name px-plugin-proxy.` + storageNs + `.svc.cluster.local;
+          server_name px-plugin-proxy.` + storageNs + `;
         location / {
-          proxy_pass http://portworx-api.` + storageNs + `.svc.cluster.local:9021;
+          proxy_pass http://portworx-api.` + storageNs + `:9021;
         }
       }
       server {
         listen 8443 ssl;
-        server_name px-plugin-proxy.` + storageNs + `.svc.cluster.local;
+        server_name px-plugin-proxy.` + storageNs + `;
         ssl_certificate /etc/nginx/certs/tls.crt;
         ssl_certificate_key /etc/nginx/certs/tls.key;
         location / {
-          proxy_pass http://portworx-api.` + storageNs + `.svc.cluster.local:9021;
+          proxy_pass http://portworx-api.` + storageNs + `:9021;
         }
       }
     }`,


### PR DESCRIPTION
* note, fixing the remaining use of .svc.cluster.local DNS domain in the GUI plugin
* note: the tests are still creating mock host-entries with .svc.cluster.local DNS domain in the `/etc/hosts` files -- but this should be OK

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1574 into `master` branch

**Which issue(s) this PR fixes** (optional)
Closes #   PWX-36817/PWX-32899 for master -branch

**Special notes for your reviewer**:

Please refer to https://github.com/libopenstorage/operator/pull/1574 for tests info