### PR TITLE
PWX-37681 : Use service account for prometheus endpoint authentication for OCP 4.16

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -191,7 +191,7 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 		ocp416plus, err := pxutil.IsSupportedOCPVersion(c.k8sClient, pxutil.Openshift_4_16_version)
 
 		if err != nil {
-			logrus.Errorf("error during checking OCP version %w ", err)
+			logrus.Errorf("error during checking OCP version %v ", err)
 		} else {
 			if ocp416plus {
 				// on OCP 4.16 and above, create service account and cluster role binding for OCP Prometheus by default
@@ -207,7 +207,7 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 			if err := c.createSecret(cluster.Namespace, ownerRef, ocp416plus); err != nil {
 				// log the error and proceed for deployment creation
 				// if secret is created in next reconcilation loop successfully, deployment will be updated with volume mounts
-				logrus.Errorf("error during creating secret %w ", err)
+				logrus.Errorf("error during creating secret %v ", err)
 			}
 		}
 	}

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -191,7 +191,7 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 		ocp416plus, err := pxutil.IsSupportedOCPVersion(c.k8sClient, pxutil.Openshift_4_16_version)
 
 		if err != nil {
-			logrus.Errorf("Error during checking OCP version %v ", err)
+			logrus.Errorf("error during checking OCP version %w ", err)
 		} else {
 			if ocp416plus {
 				// on OCP 4.16 and above, create service account and cluster role binding for OCP Prometheus by default
@@ -207,7 +207,7 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 			if err := c.createSecret(cluster.Namespace, ownerRef, ocp416plus); err != nil {
 				// log the error and proceed for deployment creation
 				// if secret is created in next reconcilation loop successfully, deployment will be updated with volume mounts
-				logrus.Errorf("Error during creating secret %v ", err)
+				logrus.Errorf("error during creating secret %w ", err)
 			}
 		}
 	}
@@ -361,7 +361,7 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 	if ocp416Plus {
 		err := k8sutil.GetSecret(c.k8sClient, AutopilotSecretName, clusterNamespace, secret)
 		if err != nil {
-			return fmt.Errorf("Error during getting secret %v ", err)
+			return fmt.Errorf("error during getting secret %w ", err)
 		}
 
 		if secret.Data != nil {
@@ -370,7 +370,7 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 				// if secret type is service account token, check if token is expired
 				refreshNeeded, err := isTokenRefreshRequired(secret)
 				if err != nil {
-					return fmt.Errorf("Error during checking token refresh %v ", err)
+					return fmt.Errorf("error during checking token refresh %w ", err)
 				}
 				if refreshNeeded {
 					// refresh the token if it is expired
@@ -409,7 +409,7 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 
 		token, err := generateAPSaToken(clusterNamespace, defaultAutoPilotSaTokenExpirationSeconds)
 		if err != nil {
-			return fmt.Errorf("Error during generating token %v ", err)
+			return fmt.Errorf("error during generating token %v ", err)
 		}
 		secret.Data = make(map[string][]byte)
 		secret.Data["token"] = token

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -415,6 +415,7 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 			if err != nil {
 				return fmt.Errorf("Error during generating token %v ", err)
 			}
+			secret.Data = make(map[string][]byte)
 			secret.Data["token"] = token
 		}
 

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -208,7 +208,7 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 			if err := c.createSecret(cluster.Namespace, ownerRef, ocp416plus); err != nil {
 				// log the error and proceed for deployment creation
 				// if secret is created in next reconcilation loop successfully, deployment will be updated with volume mounts
-				logrus.Errorf("error during creating secret %v ", err)
+				logrus.Errorf("error during creating secret : %v ", err)
 			}
 		}
 	}
@@ -369,7 +369,7 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 			// if secret exists, check if token is expired
 			refreshNeeded, err := isTokenRefreshRequired(secret)
 			if err != nil {
-				return fmt.Errorf("error during checking token refresh %w ", err)
+				return fmt.Errorf("error during checking token refresh: %w ", err)
 			}
 			if refreshNeeded {
 				// refresh the token if it is expired

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -192,7 +192,7 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 		ocp416plus, err := pxutil.IsSupportedOCPVersion(c.k8sClient, pxutil.Openshift_4_16_version)
 
 		if err != nil {
-			logrus.Errorf("error during checking OCP version %v ", err)
+			logrus.Errorf("error during checking OCP version: %v ", err)
 		} else {
 			if ocp416plus {
 				// on OCP 4.16 and above, create service account and cluster role binding for OCP Prometheus by default

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -55,6 +55,12 @@ const (
 	OCPThanosRulerSecretPrefix = "thanos-ruler-token"
 	// Autopilot Secret name for prometheus-user-workload-token
 	AutopilotSecretName = "autopilot-prometheus-auth"
+	// AutopilotPrometheusServiceAccountName name of the prometheus service account for Openshift
+	AutopilotPrometheusServiceAccountName = "autopilot-prometheus"
+	// AutopilotClusterRoleBindingName name of the cluster role binding for Openshift
+	AutopilotPrometheusClusterRoleBindingName = "autopilot-promethues-binding"
+	// OpenshiftClusterRoleName name of the cluster role for Openshift, this role is already present in Openshift
+	OpenshiftClusterRoleName = "cluster-monitoring-view"
 )
 
 var (
@@ -116,7 +122,7 @@ var (
 					SecretName: AutopilotSecretName,
 					Items: []v1.KeyToPath{
 						{
-							Key:  "cacert",
+							Key:  "ca.crt",
 							Path: "ca-certificates.crt",
 						},
 					},
@@ -131,6 +137,7 @@ type autopilot struct {
 	k8sClient               client.Client
 	k8sVersion              version.Version
 	isUserWorkloadSupported *bool
+	isSecretCreated         bool
 }
 
 func (c *autopilot) Name() string {
@@ -174,6 +181,18 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 		return err
 	}
 	if c.isOCPUserWorkloadSupported() {
+		ok, err := pxutil.IsSupportedOCPVersion(c.k8sClient, pxutil.Openshift_4_16_version)
+		if err == nil && ok {
+			// on OCP 4.16 and above, create service account and cluster role binding for OCP Prometheus by default
+			// autopilot requires to access Prometheus metrics
+			if err := c.createServiceAccountForOCP(cluster.Namespace, ownerRef); err != nil {
+				return err
+			}
+			if err := c.createClusterRoleBindingForOCP(cluster.Namespace, ownerRef); err != nil {
+				return err
+			}
+		}
+
 		if err := c.createSecret(cluster.Namespace, ownerRef); err != nil {
 			// log the error and proceed for deployment creation
 			// if secret is created in next reconcilation loop successfully, deployment will be updated with volume mounts
@@ -207,6 +226,12 @@ func (c *autopilot) Delete(cluster *corev1.StorageCluster) error {
 		if err := k8sutil.DeleteSecret(c.k8sClient, AutopilotSecretName, cluster.Namespace, *ownerRef); err != nil {
 			return err
 		}
+		if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, AutopilotClusterRoleBindingName); err != nil {
+			return err
+		}
+		if err := k8sutil.DeleteServiceAccount(c.k8sClient, AutopilotPrometheusServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
+			return err
+		}
 	}
 
 	c.MarkDeleted()
@@ -216,6 +241,7 @@ func (c *autopilot) Delete(cluster *corev1.StorageCluster) error {
 func (c *autopilot) MarkDeleted() {
 	c.isCreated = false
 	c.isUserWorkloadSupported = nil
+	c.isSecretCreated = false
 }
 
 func (c *autopilot) createConfigMap(
@@ -265,26 +291,109 @@ func (c *autopilot) createConfigMap(
 	return err
 }
 
+// createServiceAccountForOCP creates service account for OCP Prometheus
+// autopilot to access Prometheus metrics
+// This is required for OCP 4.16 and above
+func (c *autopilot) createServiceAccountForOCP(namespace string, ownerRef *metav1.OwnerReference) error {
+	return k8sutil.CreateOrUpdateServiceAccount(
+		c.k8sClient,
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            AutopilotPrometheusServiceAccountName,
+				Namespace:       namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+		},
+		ownerRef,
+	)
+}
+
+// createClusterRoleBindingForOCP creates cluster role binding for OCP Prometheus
+// autopilot to access Prometheus metrics requires cluster-monitoring-view role
+// This is required for OCP 4.16 and above
+func (c *autopilot) createClusterRoleBindingForOCP(namespace string, ownerRef *metav1.OwnerReference) error {
+	return k8sutil.CreateOrUpdateClusterRoleBinding(
+		c.k8sClient,
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: AutopilotPrometheusClusterRoleBindingName,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     OpenshiftClusterRoleName,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      AutopilotPrometheusServiceAccountName,
+					Namespace: namespace,
+				},
+			},
+		},
+	)
+}
+
 func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.OwnerReference) error {
 
-	token, cert, err := c.getPrometheusTokenAndCert()
+	ocp_416, err := pxutil.IsSupportedOCPVersion(c.k8sClient, pxutil.Openshift_4_16_version)
 	if err != nil {
 		return err
 	}
 
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            AutopilotSecretName,
+			Namespace:       clusterNamespace,
+			OwnerReferences: []metav1.OwnerReference{*ownerRef},
+		},
+	}
+
+	if ocp_416 {
+		// OCP 4.16 and above, secret is created by default if autopilot is enabled
+		// if secret is already created, return
+		if c.isCreated {
+			return nil
+		}
+
+		// check if secret already exists, this is first time creation
+		// or secret is created in last reconcilation loop
+		err := k8sutil.GetSecret(c.k8sClient, secret.Name, secret.Namespace, secret)
+		if err != nil {
+			return err
+		}
+
+		// if secret already exists, return
+		// once secret is created, it should not be updated
+		// if secret is deleted, it will be created if operator is restarted
+		if secret.Data != nil {
+			c.isSecretCreated = true
+			return nil
+		}
+
+		// create secret with service account token
+		secret.Type = v1.SecretTypeServiceAccountToken
+		secret.Annotations = map[string]string{
+			"kubernetes.io/service-account.name": AutopilotPrometheusServiceAccountName,
+		}
+	} else {
+		// OCP 4.15 and below, secret is created if user workload monitoring is enabled
+		// and openshift's prometheus secret is found
+		token, cert, err := c.getPrometheusTokenAndCert()
+		if err != nil {
+			return err
+		}
+
+		// token and ca.crt are updated in every reconcilation loop
+		// to check if it was refreshed
+		secret.Data = make(map[string][]byte)
+		secret.Data["token"] = []byte(token)
+		secret.Data["ca.crt"] = []byte(cert) // change to ca.crt to match the key in the generated in secret by kubernetes
+	}
+
 	return k8sutil.CreateOrUpdateSecret(
 		c.k8sClient,
-		&v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            AutopilotSecretName,
-				Namespace:       clusterNamespace,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-			Data: map[string][]byte{
-				"token":  []byte(token),
-				"cacert": []byte(cert),
-			},
-		},
+		secret,
 		ownerRef,
 	)
 }

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -378,13 +378,6 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 				if err != nil {
 					return fmt.Errorf("failed to check token in secret %s/%s: %w", clusterNamespace, AutopilotSecretName, err)
 				}
-				// delete autopilot deployment to sync with new token
-				logrus.Info("deleting autopilot pod to sync with new token")
-				err = k8sutil.DeletePodsByLabel(c.k8sClient, map[string]string{"name": "autopilot"}, clusterNamespace)
-				if err != nil {
-					return fmt.Errorf("error during deleting autopilot pod  %w ", err)
-				}
-				logrus.Infof("token refreshed successfully for secret %s/%s", clusterNamespace, AutopilotSecretName)
 			}
 		} else {
 			// if secret is not created, create the secret

--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -448,7 +448,7 @@ func (c *prometheus) createOperatorDeployment(
 		cluster,
 		cluster.Status.DesiredImages.PrometheusOperator,
 	)
-
+	
 	deployment := getPrometheusOperatorDeploymentSpec(cluster, ownerRef, imageName)
 	modified := existingImageName != imageName ||
 		util.HasPullSecretChanged(cluster, existingDeployment.Spec.Template.Spec.ImagePullSecrets) ||

--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -448,7 +448,7 @@ func (c *prometheus) createOperatorDeployment(
 		cluster,
 		cluster.Status.DesiredImages.PrometheusOperator,
 	)
-	
+
 	deployment := getPrometheusOperatorDeploymentSpec(cluster, ownerRef, imageName)
 	modified := existingImageName != imageName ||
 		util.HasPullSecretChanged(cluster, existingDeployment.Spec.Template.Spec.ImagePullSecrets) ||

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -4847,11 +4847,15 @@ func TestAutopilotInstallAndUninstallOnOpenshift415(t *testing.T) {
 func setUpMockCoreOps(mockCtrl *gomock.Controller, clientset *fakek8sclient.Clientset) *mockcore.MockOps {
 	mockCoreOps := mockcore.NewMockOps(mockCtrl)
 	coreops.SetInstance(mockCoreOps)
+	defaultTokenExpirationSeconds := int64(12 * 60 * 60)
 
 	simpleClientset := coreops.New(clientset)
 	mockCoreOps.EXPECT().
 		CreateToken(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&authv1.TokenRequest{
+			Spec: authv1.TokenRequestSpec{
+				ExpirationSeconds: &defaultTokenExpirationSeconds,
+			},
 			Status: authv1.TokenRequestStatus{
 				Token: "xxxx",
 			},

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -4938,7 +4938,7 @@ func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
 	// on OCP 4.16+ , autopilot-prometheus service account will be used for authentication
 	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: component.OpenshiftClusterRoleName,
+			Name: component.OpenshiftClusterViewRoleName,
 		},
 		Subjects: []rbacv1.Subject{
 			{

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -5031,9 +5031,9 @@ func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
 	require.Equal(t, cluster.Name, expectedSA.OwnerReferences[0].Name)
 
 	// Autopilot Prometheus Cluster role binding
-	expectedPrometheusCRB := testutil.GetExpectedClusterRoleBinding(t, "autopilotClusterRoleBinding.yaml")
+	expectedPrometheusCRB := testutil.GetExpectedClusterRoleBinding(t, "autopilotPrometheusClusterRoleBinding.yaml")
 	actualClusterRoleCRB := &rbacv1.ClusterRoleBinding{}
-	err = testutil.Get(k8sClient, actualClusterRoleCRB, component.AutopilotClusterRoleBindingName, "")
+	err = testutil.Get(k8sClient, actualClusterRoleCRB, component.AutopilotPrometheusClusterRoleBindingName, "")
 	require.NoError(t, err)
 	require.Equal(t, expectedPrometheusCRB.Name, actualClusterRoleCRB.Name)
 	require.Empty(t, actualCRB.OwnerReferences)

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -4886,7 +4886,6 @@ func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
 		},
 	}
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish() // Ensure the mock controller is finished
 	setUpMockCoreOps(mockCtrl, versionClient)
 
 	reregisterComponents()
@@ -5046,7 +5045,6 @@ func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
 	actualSecret := &v1.Secret{}
 	err = testutil.Get(k8sClient, actualSecret, component.AutopilotSecretName, cluster.Namespace)
 	require.NoError(t, err)
-
 	require.Equal(t, expectedSecret.Type, actualSecret.Type)
 	require.Equal(t, expectedSecret.Annotations, actualSecret.Annotations)
 
@@ -5055,7 +5053,6 @@ func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
 	autopilotDeployment := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
-
 	require.Equal(t, expectedDeployment.Spec.Template.Spec.Volumes, autopilotDeployment.Spec.Template.Spec.Volumes)
 	require.Equal(t, expectedDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts)
 

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -4838,6 +4838,199 @@ func TestAutopilotInstallAndUninstallOnOpenshift415(t *testing.T) {
 
 }
 
+// test Autopilot install and Uninstall on ocp cluster 4.16
+func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
+
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: component.ClusterOperatorVersion,
+			APIResources: []metav1.APIResource{
+				{
+					Kind: component.ClusterOperatorKind,
+				},
+			},
+		},
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+
+	reregisterComponents()
+	operator := &ocpconfig.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: component.OpenshiftAPIServer,
+		},
+		Status: ocpconfig.ClusterOperatorStatus{
+			RelatedObjects: []ocpconfig.ObjectReference{
+				{Name: component.OpenshiftAPIServer},
+			},
+			Versions: []ocpconfig.OperandVersion{
+				{
+					Name:    component.OpenshiftAPIServer,
+					Version: "4.16",
+				},
+			},
+		},
+	}
+	k8sClient := testutil.FakeK8sClient()
+	err := k8sClient.Create(context.TODO(), operator)
+	require.NoError(t, err)
+
+	driver := portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	stcSpec := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "true",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Monitoring: &corev1.MonitoringSpec{Telemetry: &corev1.TelemetrySpec{}},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: true,
+				Image:   "portworx/autopilot:1.1.1",
+				Providers: []corev1.DataProviderSpec{
+					{
+						Name: "default",
+						Type: "prometheus",
+						Params: map[string]string{
+							"url": "http://prometheus:9090",
+						},
+					},
+					{
+						Name: "second",
+						Type: "datadog",
+						Params: map[string]string{
+							"url":  "http://datadog:9090",
+							"auth": "foobar",
+						},
+					},
+				},
+				Args: map[string]string{
+					"min_poll_interval": "4",
+					"log-level":         "info",
+				},
+			},
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					SelfSigned: &corev1.SelfSignedSpec{
+						Issuer:        stringPtr(defaultSelfSignedIssuer),
+						TokenLifetime: stringPtr(defaultTokenLifetime),
+						SharedSecret:  stringPtr(pxutil.SecurityPXSharedSecretSecretName),
+					},
+				},
+			},
+		},
+	}
+
+	cluster := stcSpec.DeepCopy()
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// on OCP 4.16+ , autopilot-prometheus service account will be used for authentication
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: component.OpenshiftClusterRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     "example-user",
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "view",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	err = k8sClient.Create(context.TODO(), clusterRoleBinding)
+	require.NoError(t, err)
+
+	// Autopilot ConfigMap
+	expectedConfigMap := testutil.GetExpectedConfigMap(t, "autopilotConfigMap.yaml")
+	autopilotConfigMap := &v1.ConfigMap{}
+	err = testutil.Get(k8sClient, autopilotConfigMap, component.AutopilotConfigMapName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedConfigMap.Name, autopilotConfigMap.Name)
+	require.Equal(t, expectedConfigMap.Namespace, autopilotConfigMap.Namespace)
+	require.Len(t, autopilotConfigMap.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, autopilotConfigMap.OwnerReferences[0].Name)
+	require.Equal(t, expectedConfigMap.Data, autopilotConfigMap.Data)
+
+	// Autopilot ServiceAccount
+	sa := &v1.ServiceAccount{}
+	err = testutil.Get(k8sClient, sa, component.AutopilotServiceAccountName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, component.AutopilotServiceAccountName, sa.Name)
+	require.Equal(t, cluster.Namespace, sa.Namespace)
+	require.Len(t, sa.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, sa.OwnerReferences[0].Name)
+
+	// Autopilot ClusterRoleBinding
+	expectedCRB := testutil.GetExpectedClusterRoleBinding(t, "autopilotClusterRoleBinding.yaml")
+	actualCRB := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, actualCRB, component.AutopilotClusterRoleBindingName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedCRB.Name, actualCRB.Name)
+	require.Empty(t, actualCRB.OwnerReferences)
+	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
+	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
+
+	// Autopilot Prometheus Service Account
+	expectedSA := &v1.ServiceAccount{}
+	err = testutil.Get(k8sClient, expectedSA, component.AutopilotPrometheusServiceAccountName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, component.AutopilotPrometheusServiceAccountName, expectedSA.Name)
+	require.Equal(t, cluster.Namespace, expectedSA.Namespace)
+	require.Len(t, expectedSA.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, expectedSA.OwnerReferences[0].Name)
+
+	// Autopilot Prometheus Cluster role binding
+	expectedPrometheusCRB := testutil.GetExpectedClusterRoleBinding(t, "autopilotClusterRoleBinding.yaml")
+	actualClusterRoleCRB := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, actualClusterRoleCRB, component.AutopilotClusterRoleBindingName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedPrometheusCRB.Name, actualClusterRoleCRB.Name)
+	require.Empty(t, actualCRB.OwnerReferences)
+	require.ElementsMatch(t, expectedPrometheusCRB.Subjects, actualClusterRoleCRB.Subjects)
+	require.Equal(t, expectedPrometheusCRB.RoleRef, actualClusterRoleCRB.RoleRef)
+
+	// Autopilot Secret
+	expectedSecret := testutil.GetExpectedSecret(t, "autopilot-auth-token-secret_4_16.yaml")
+	actualSecret := &v1.Secret{}
+	err = testutil.Get(k8sClient, actualSecret, component.AutopilotSecretName, cluster.Namespace)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedSecret.Type, actualSecret.Type)
+	require.Equal(t, expectedSecret.Annotations, actualSecret.Annotations)
+
+	// Autopilot Deployment
+	expectedDeployment := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_14.yaml")
+	autopilotDeployment := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+
+	require.Equal(t, expectedDeployment.Spec.Template.Spec.Volumes, autopilotDeployment.Spec.Template.Spec.Volumes)
+	require.Equal(t, expectedDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts)
+
+	autopilotComponent, _ := component.Get(component.AutopilotComponentName)
+	err = autopilotComponent.Delete(cluster)
+	autopilotComponent.MarkDeleted()
+	require.NoError(t, err)
+
+}
+
 func TestSecurityInstall(t *testing.T) {
 	k8sClient := testutil.FakeK8sClient()
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))

--- a/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
+++ b/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
@@ -6,4 +6,6 @@ kind: Secret
 metadata:
   name: autopilot-prometheus-auth
   namespace: kube-test
-type: Opaque
+  annotations:
+    kubernetes.io/service-account.name: autopilot-prometheus
+type: kubernetes.io/service-account-token

--- a/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
+++ b/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
@@ -6,6 +6,3 @@ kind: Secret
 metadata:
   name: autopilot-prometheus-auth
   namespace: kube-test
-  annotations:
-    kubernetes.io/service-account.name: autopilot-prometheus
-type: kubernetes.io/service-account-token

--- a/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_14.yaml
+++ b/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_14.yaml
@@ -125,7 +125,7 @@ spec:
           secret:
             defaultMode: 420
             items:
-              - key: cacert
+              - key: ca.crt
                 path: ca-certificates.crt
             secretName: autopilot-prometheus-auth
         - name: config-volume

--- a/drivers/storage/portworx/testspec/autopilotPrometheusClusterRoleBinding.yaml
+++ b/drivers/storage/portworx/testspec/autopilotPrometheusClusterRoleBinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: autopilot-prometheus
-    namespace: portworx
+    namespace: kube-test

--- a/drivers/storage/portworx/testspec/autopilotPrometheusClusterRoleBinding.yaml
+++ b/drivers/storage/portworx/testspec/autopilotPrometheusClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: autopilot-promethues-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: autopilot-prometheus
+    namespace: portworx

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -264,6 +264,7 @@ const (
 	OpenshiftAPIServer                  = "openshift-apiserver"
 	OpenshiftPrometheusSupportedVersion = "4.12"
 	Openshift_4_15_Version              = "4.15"
+	Openshift_4_16_version              = "4.16"
 	// OpenshiftMonitoringRouteName name of OCP user-workload route
 	OpenshiftMonitoringRouteName = "thanos-querier"
 	// OpenshiftMonitoringRouteName namespace of OCP user-workload route

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ replace (
 	github.com/coreos/prometheus-operator => github.com/prometheus-operator/prometheus-operator v0.46.0
 	github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v5.1.1-0.20190919185747-9394ee8dd536+incompatible
 	github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240221210452-7757fdc2b8ff
-	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240529170916-515f6d54c338
+	github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240613172635-81b5b390baf4
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring => github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.46.0
 	golang.org/x/tools => golang.org/x/tools v0.1.11
 	google.golang.org/grpc => google.golang.org/grpc v1.29.1

--- a/go.sum
+++ b/go.sum
@@ -4086,6 +4086,8 @@ github.com/portworx/px-object-controller v0.0.0-20220804234424-40d3b8a84987/go.m
 github.com/portworx/pxc v0.33.0/go.mod h1:Tl7hf4K2CDr0XtxzM08sr9H/KsMhscjf9ydb+MnT0U4=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20240529170916-515f6d54c338 h1:OQrP+tPFU9bzK6ZzjPOFE9ZBSQmAwWKx+RhjGYZPT1s=
 github.com/portworx/sched-ops v1.20.4-rc1.0.20240529170916-515f6d54c338/go.mod h1:KOe618gr1FAzVmLNe9LFHss19df3MBZ0qom6Ct7RpyM=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240613172635-81b5b390baf4 h1:+pKJx5jqqxqFrtbOQaGg8Fwl0LrbX71ejZHlc9NZG3I=
+github.com/portworx/sched-ops v1.20.4-rc1.0.20240613172635-81b5b390baf4/go.mod h1:KOe618gr1FAzVmLNe9LFHss19df3MBZ0qom6Ct7RpyM=
 github.com/portworx/talisman v0.0.0-20210302012732-8af4564777f7/go.mod h1:e8a6uFpSbOlRpZQlW9aXYogC+GWAo065G0RL9hDkD4Q=
 github.com/portworx/torpedo v0.20.4-rc1.0.20210325154352-eb81b0cdd145/go.mod h1:CkLAs/ojTzSu3SPyeDxc3qhsbRU78H5Xz1qJlj1Ap1U=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=

--- a/pkg/mock/mockcore/core.ops.mock.go
+++ b/pkg/mock/mockcore/core.ops.mock.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	core "github.com/portworx/sched-ops/k8s/core"
+	authv1 "k8s.io/api/authentication/v1"
 	v1 "k8s.io/api/certificates/v1"
 	v10 "k8s.io/api/core/v1"
 	v11 "k8s.io/api/networking/v1"
@@ -296,6 +297,21 @@ func (m *MockOps) CreateServiceAccount(arg0 *v10.ServiceAccount) (*v10.ServiceAc
 func (mr *MockOpsMockRecorder) CreateServiceAccount(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceAccount", reflect.TypeOf((*MockOps)(nil).CreateServiceAccount), arg0)
+}
+
+// CreateToken mocks base method.
+func (m *MockOps) CreateToken(name, namespace string, tokenRequest *authv1.TokenRequest) (*authv1.TokenRequest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateToken", name, namespace, tokenRequest)
+	ret0, _ := ret[0].(*authv1.TokenRequest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateToken indicates an expected call of CreateToken.
+func (mr *MockOpsMockRecorder) CreateToken(name, namespace, tokenRequest interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateToken", reflect.TypeOf((*MockOps)(nil).CreateToken), name, namespace, tokenRequest)
 }
 
 // DeleteCertificateSigningRequests mocks base method.

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1992,6 +1992,31 @@ func CreateOrUpdateSecret(
 	return nil
 }
 
+// GetSecret get a secret from k8s
+func GetSecret(
+	k8sClient client.Client,
+	name string,
+	namsespace string,
+	secret *v1.Secret,
+) error {
+	err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      name,
+			Namespace: namsespace,
+		},
+		secret,
+	)
+
+	if errors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // CreateOrAppendToSecret creates a secret if not present, else appends data to it
 func CreateOrAppendToSecret(
 	k8sClient client.Client,

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -1993,31 +1993,6 @@ func CreateOrUpdateSecret(
 	return nil
 }
 
-// GetSecret get a secret from k8s
-func GetSecret(
-	k8sClient client.Client,
-	name string,
-	namsespace string,
-	secret *v1.Secret,
-) error {
-	err := k8sClient.Get(
-		context.TODO(),
-		types.NamespacedName{
-			Name:      name,
-			Namespace: namsespace,
-		},
-		secret,
-	)
-
-	if errors.IsNotFound(err) {
-		return nil
-	} else if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // CreateOrAppendToSecret creates a secret if not present, else appends data to it
 func CreateOrAppendToSecret(
 	k8sClient client.Client,

--- a/vendor/github.com/portworx/sched-ops/k8s/core/serviceaccounts.go
+++ b/vendor/github.com/portworx/sched-ops/k8s/core/serviceaccounts.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,6 +20,8 @@ type ServiceAccountOps interface {
 	DeleteServiceAccount(accountName, namespace string) error
 	// ListServiceAccount in given namespace
 	ListServiceAccount(namespace string, opts metav1.ListOptions) (*corev1.ServiceAccountList, error)
+	// CreateToken creates a token associated with a serviceaccount through a tokenRequest
+	CreateToken(name, namespace string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error)
 }
 
 // CreateServiceAccount creates the given service account
@@ -66,4 +69,13 @@ func (c *Client) DeleteServiceAccount(accountName, namespace string) error {
 	return c.kubernetes.CoreV1().ServiceAccounts(namespace).Delete(context.TODO(), accountName, metav1.DeleteOptions{
 		PropagationPolicy: &deleteForegroundPolicy,
 	})
+}
+
+// CreateToken creates the server's representation of the tokenRequest associated with a service account
+func (c *Client) CreateToken(name, namespace string, tokenRequest *authenticationv1.TokenRequest) (*authenticationv1.TokenRequest, error) {
+	if err := c.initClient(); err != nil {
+		return nil, err
+	}
+
+	return c.kubernetes.CoreV1().ServiceAccounts(namespace).CreateToken(context.TODO(), name, tokenRequest, metav1.CreateOptions{})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -304,7 +304,7 @@ github.com/portworx/kvdb/etcd/common
 github.com/portworx/kvdb/etcd/v2
 github.com/portworx/kvdb/etcd/v3
 github.com/portworx/kvdb/mem
-# github.com/portworx/sched-ops v1.20.4-rc1.0.20240529170916-515f6d54c338 => github.com/portworx/sched-ops v1.20.4-rc1.0.20240529170916-515f6d54c338
+# github.com/portworx/sched-ops v1.20.4-rc1.0.20240529170916-515f6d54c338 => github.com/portworx/sched-ops v1.20.4-rc1.0.20240613172635-81b5b390baf4
 ## explicit; go 1.19
 github.com/portworx/sched-ops/k8s/apiextensions
 github.com/portworx/sched-ops/k8s/apps
@@ -1044,7 +1044,7 @@ sigs.k8s.io/yaml/goyaml.v2
 # github.com/coreos/prometheus-operator => github.com/prometheus-operator/prometheus-operator v0.46.0
 # github.com/kubernetes-incubator/external-storage => github.com/libopenstorage/external-storage v5.1.1-0.20190919185747-9394ee8dd536+incompatible
 # github.com/libopenstorage/openstorage => github.com/libopenstorage/openstorage v1.0.1-0.20240221210452-7757fdc2b8ff
-# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240529170916-515f6d54c338
+# github.com/portworx/sched-ops => github.com/portworx/sched-ops v1.20.4-rc1.0.20240613172635-81b5b390baf4
 # github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring => github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.46.0
 # golang.org/x/tools => golang.org/x/tools v0.1.11
 # google.golang.org/grpc => google.golang.org/grpc v1.29.1


### PR DESCRIPTION
**What this PR does / why we need it**:
On OCP 4.16, the thanos-ruler-token secret, which was used to fetch ca.crt and token for prometheus endpoint authentication is removed and the authentication is current user's authentication token is used for the same.
From operator 24.1.1 and OCP 4.16, operator will not use Openshift's secret, rather do following to authenticater Openshift prometheus endopoint.
1. Create **autopilot-prometheus** service account
2.  Create **autopilot-promethues-binding** cluster role binding to created service account with **cluster-monitoring-view** cluster role.
3.  In **autopilot-prometheus-auth** secret, which is already created today, add following to use the secret's ca.crt and token with above permissions.
```
metadata:  
  annotations:
      kubernetes.io/service-account.name: autopilot-prometheus
 type: kubernetes.io/service-account-token
```
4. The token will expire every 30 days
5. Till token expiry time is reached half way, the token is refreshed and autopilot pod is killed to restart new pod with updated token

- The above mentioned steps are done only for OCP 4.16+ versions.
- For 4.15 and lesser version, no change will be there 


**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-37681

**Testing done**:
- Tested on OCP 4.16.0-rc.4 build, autopilot is successfully able to register to prometheus endpoint
