### PR TITLE
PWX-37760: Update component images when autoUpdateComponents is set

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -688,7 +688,7 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			prometheusVersionChanged := p.hasPrometheusVersionChanged(toUpdate)
 			grafanaVersionChanged := p.hasGrafanaVersionChanged(toUpdate)
 			if toUpdate.Spec.Monitoring.Prometheus.Enabled &&
-				(toUpdate.Status.DesiredImages.PrometheusOperator == "" || pxVersionChanged || prometheusVersionChanged) {
+				(toUpdate.Status.DesiredImages.PrometheusOperator == "" || pxVersionChanged || prometheusVersionChanged || autoUpdateComponents(toUpdate)) {
 				toUpdate.Status.DesiredImages.Prometheus = release.Components.Prometheus
 				toUpdate.Status.DesiredImages.PrometheusOperator = release.Components.PrometheusOperator
 				toUpdate.Status.DesiredImages.PrometheusConfigMapReload = release.Components.PrometheusConfigMapReload
@@ -696,12 +696,12 @@ func (p *portworx) SetDefaultsOnStorageCluster(toUpdate *corev1.StorageCluster) 
 			}
 			if toUpdate.Spec.Monitoring.Prometheus.AlertManager != nil &&
 				toUpdate.Spec.Monitoring.Prometheus.AlertManager.Enabled &&
-				(toUpdate.Status.DesiredImages.AlertManager == "" || pxVersionChanged || prometheusVersionChanged) {
+				(toUpdate.Status.DesiredImages.AlertManager == "" || pxVersionChanged || prometheusVersionChanged || autoUpdateComponents(toUpdate)) {
 				toUpdate.Status.DesiredImages.AlertManager = release.Components.AlertManager
 			}
 			if toUpdate.Spec.Monitoring.Grafana != nil &&
 				toUpdate.Spec.Monitoring.Grafana.Enabled &&
-				(toUpdate.Status.DesiredImages.Grafana == "" || pxVersionChanged || grafanaVersionChanged) {
+				(toUpdate.Status.DesiredImages.Grafana == "" || pxVersionChanged || grafanaVersionChanged || autoUpdateComponents(toUpdate)) {
 				toUpdate.Status.DesiredImages.Grafana = release.Components.Grafana
 			}
 		}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: For components like prometheus, alert manager and grafana they do not update desiredImages in the stc when autoUpdateComponents is set to Once or Always. This change will ensure that the component images get updated

**Which issue(s) this PR fixes** (optional)
Closes # PWX-37760, PWX-37545

**Special notes for your reviewer**: Similar issue was found for dynamic Plugin images and the [fix](https://github.com/libopenstorage/operator/pull/1499) was similar to this PR 

