### PR TITLE
PWX-37852: add APPLIANCE_ID env to px-telemetry-registration deployment

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -817,6 +817,11 @@ func (t *telemetry) createDeploymentTelemetryRegistration(
 		container := &deployment.Spec.Template.Spec.Containers[i]
 		if container.Name == containerNameTelemetryRegistration {
 			container.Image = telemetryImage
+			// add APPLIANCE_ID env var
+			container.Env = append(container.Env, v1.EnvVar{
+				Name:  configParameterApplianceID,
+				Value: cluster.Status.ClusterUID,
+			})
 		} else if container.Name == containerNameTelemetryProxy {
 			container.Image = proxyImage
 		}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -15180,7 +15180,7 @@ func TestTelemetryContainerOrchestratorEnable(t *testing.T) {
 	deployment := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 1)
+	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
 
 	// Compatible PX & Incompatible Telemetry Images
 	cluster.Spec.Image = "portworx/image:3.2.0"
@@ -15197,7 +15197,7 @@ func TestTelemetryContainerOrchestratorEnable(t *testing.T) {
 	// Validate deployments
 	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 1)
+	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
 
 	// Incompatible PX & compatible Telemetry Images
 	cluster.Spec.Image = "portworx/image:3.0.0"
@@ -15214,7 +15214,7 @@ func TestTelemetryContainerOrchestratorEnable(t *testing.T) {
 	// Validate deployments
 	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 1)
+	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
 
 	// Compatible PX & Telemetry Images
 	cluster.Spec.Image = "portworx/image:3.2.0"
@@ -15232,9 +15232,13 @@ func TestTelemetryContainerOrchestratorEnable(t *testing.T) {
 	// Validate deployments
 	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
-	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[1].Name, "REFRESH_TOKEN")
-	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[1].Value, "")
+	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 3)
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[0].Name, "CONFIG")
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[0].Value, "config/config_properties_px.yaml")
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[1].Name, "APPLIANCE_ID")
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[1].Value, "test-clusteruid")
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[2].Name, "REFRESH_TOKEN")
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[2].Value, "")
 
 	// Port shift on OCP
 	cluster.Annotations[pxutil.AnnotationIsOpenshift] = "true"

--- a/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
@@ -48,6 +48,8 @@ spec:
       - env:
         - name: CONFIG
           value: config/config_properties_px.yaml
+        - name: APPLIANCE_ID
+          value: test-clusteruid
         image: docker.io/portworx/px-telemetry:4.3.2
         imagePullPolicy: Always
         name: registration


### PR DESCRIPTION
* operator to supply the `env APPLIANCE_ID = <PX_ClusterUUID>` to px-telemetry-registration deployment

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The PR adds explicit `env APPLIANCE_ID = <PX_ClusterUUID>` to px-telemetry-registration deployment

* without this env-var, we are triggering some auto-discovery code in Telemetry-PODs --
  1. which is "extra work" that is not necessary,
  2. it does not always work correctly  (fails when recovering client SSL certs), and also
  3. DX team wants to remove this auto-discovery code  (long term)

**Which issue(s) this PR fixes** (optional)
Closes # PWX-37852

**Special notes for your reviewer**:

Manual test --

```
# kubectl edit pod px-telemetry-registration-7dcd89fb89-pq9l2

apiVersion: v1
kind: Pod
spec:
  containers:
  - env:
    - name: CONFIG
      value: config/config_properties_px.yaml
    - name: APPLIANCE_ID
      value: 934d3323-0c25-431e-beb9-676bda79d7b6
    image: docker.io/purestorage/ccm-go:1.0.25
    imagePullPolicy: Always
    name: registration
...
```
* note, the `934d3323-0c25-431e-beb9-676bda79d7b6` is our PX ClusterUUID

**Test 1**: startup
* the PODs start correctly, without any issues

**Test 2**: Refresh client SSL cert
1. `kubectl delete secret/pure-telemetry-certs`
2. On https://skyline.purestorage.com/app/dashboard/portworx/934d3323-0c25-431e-beb9-676bda79d7b6 click `Edit` for `Arcus Keybox status` -- and click on `[Reset]` button ("Reset the Arcus Keybox status to allow a new registration")
3. delete tele-registration POD bia `kubectl get pod -Al 'role=px-telemetry-registration'`

RESULT: The POD re-registered correctly to Telemetry/Arcus backend, and re-genrated the client SSL cert (we got new `secret/pure-telemetry-certs`)