### PR TITLE
PWX-37852_24.1.1: add APPLIANCE_ID env to px-telemetry-registration deployment (#1588)

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -839,6 +839,11 @@ func (t *telemetry) createDeploymentTelemetryRegistration(
 		container := &deployment.Spec.Template.Spec.Containers[i]
 		if container.Name == containerNameTelemetryRegistration {
 			container.Image = telemetryImage
+			// add APPLIANCE_ID env var
+			container.Env = append(container.Env, v1.EnvVar{
+				Name:  configParameterApplianceID,
+				Value: cluster.Status.ClusterUID,
+			})
 		} else if container.Name == containerNameTelemetryProxy {
 			container.Image = proxyImage
 		}

--- a/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
@@ -40,6 +40,8 @@ spec:
       - env:
         - name: CONFIG
           value: config/config_properties_px.yaml
+        - name: APPLIANCE_ID
+          value: test-clusteruid
         image: docker.io/portworx/px-telemetry:4.3.2
         imagePullPolicy: Always
         name: registration


### PR DESCRIPTION
* operator to supply the `env APPLIANCE_ID = <PX_ClusterUUID>` to px-telemetry-registration deployment

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1588 into `release-24.1.1` branch

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

