### PR TITLE
PWX-37844 : Restarting portworx pods when vsphere secret is changed

### DIFF
--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -624,6 +624,15 @@ func (c *Controller) groupStorageClusterPods(
 			}
 		}
 	}
+	fmt.Println("TRY2 INSIDE groupStorageClusterPods", len(newPods), len(oldPods), c.numSecretsUpdated)
+	if c.numSecretsUpdated != nil {
+		fmt.Println("TRY2 conditions are: ", len(oldPods) == 0, len(c.numSecretsUpdated) == len(newPods), len(c.numSecretsUpdated))
+	}
+	if c.numSecretsUpdated != nil && len(oldPods) == 0 && len(c.numSecretsUpdated) == len(newPods) {
+		fmt.Println("TRY2 making it nil")
+		c.numSecretsUpdated = nil
+		fmt.Println("TRY2 after making it nil", c.numSecretsUpdated)
+	}
 	return newPods, oldPods
 }
 
@@ -829,6 +838,15 @@ func (c *Controller) syncStoragePod(
 	// are compared below with corresponding history revision.
 	if updated := c.Driver.IsPodUpdated(cluster, pod); !updated {
 		return false
+	}
+
+	fmt.Println("TRY2 before checking isSecretsUpdated", c.numSecretsUpdated, node.Name, c.numSecretsUpdated != nil)
+	if c.numSecretsUpdated != nil {
+		fmt.Println("TRY2 isSecretsUpdated is true, returning false", c.numSecretsUpdated[node.Name], node.Name)
+		if _, ok := c.numSecretsUpdated[node.Name]; !ok {
+			//c.numSecretsUpdated[pod.Spec.NodeName] = true
+			return false
+		}
 	}
 
 	var oldNodeLabels map[string]string

--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -624,14 +624,10 @@ func (c *Controller) groupStorageClusterPods(
 			}
 		}
 	}
-	fmt.Println("TRY2 INSIDE groupStorageClusterPods", len(newPods), len(oldPods), c.numSecretsUpdated)
-	if c.numSecretsUpdated != nil {
-		fmt.Println("TRY2 conditions are: ", len(oldPods) == 0, len(c.numSecretsUpdated) == len(newPods), len(c.numSecretsUpdated))
-	}
-	if c.numSecretsUpdated != nil && len(oldPods) == 0 && len(c.numSecretsUpdated) == len(newPods) {
-		fmt.Println("TRY2 making it nil")
-		c.numSecretsUpdated = nil
-		fmt.Println("TRY2 after making it nil", c.numSecretsUpdated)
+
+	// If secrets was updated and all px pods have completed update then reset the nodesUpdatedMap to nil
+	if c.nodesUpdatedMap != nil && len(oldPods) == 0 && len(c.nodesUpdatedMap) == len(newPods) {
+		c.nodesUpdatedMap = nil
 	}
 	return newPods, oldPods
 }
@@ -840,11 +836,9 @@ func (c *Controller) syncStoragePod(
 		return false
 	}
 
-	fmt.Println("TRY2 before checking isSecretsUpdated", c.numSecretsUpdated, node.Name, c.numSecretsUpdated != nil)
-	if c.numSecretsUpdated != nil {
-		fmt.Println("TRY2 isSecretsUpdated is true, returning false", c.numSecretsUpdated[node.Name], node.Name)
-		if _, ok := c.numSecretsUpdated[node.Name]; !ok {
-			//c.numSecretsUpdated[pod.Spec.NodeName] = true
+	// If secret has changed and pod not updated, then pod should be updated
+	if c.nodesUpdatedMap != nil {
+		if _, ok := c.nodesUpdatedMap[node.Name]; !ok {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Currently when wrong vsphere secret values are used, px fails to come up. But if the secret is updated, px still fails to come up as the old env variables are still mounted on the container. Solution is to restart all px pods when secret is changed. In the PR, operator keeps comparing the resource versions of the vsphere secret and when it changes, triggers the restart of px pods. 

**Which issue(s) this PR fixes** (optional)
Closes # PWX-37844

**Special notes for your reviewer**: Everytime operator restarts, the older resource version becomes nil and the operator might assume the resource version has changed. To tackle this, the value of secret is first fetched when the operator is initialised. However there is an edge case where operator is restarting and secret gets updated then. Since operator takes 1second to restart this is a very rare occurance. 

