### PR TITLE
PWX-36928_24.1.1: telmetry SSL-cert validation (#1553)

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -15706,6 +15706,96 @@ func TestTelemetrySecretDeletion(t *testing.T) {
 	require.Empty(t, secret.OwnerReferences)
 }
 
+func TestTelemetrySecretRefresh(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	recorder := record.NewFakeRecorder(10)
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), recorder)
+	require.NoError(t, err)
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/oci-monitor:3.2.0",
+			Monitoring: &corev1.MonitoringSpec{
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: true,
+				},
+			},
+			DeleteStrategy: &corev1.StorageClusterDeleteStrategy{
+				Type: corev1.UninstallAndWipeStorageClusterStrategyType,
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			ClusterUID: "test-clusteruid",
+		},
+	}
+
+	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	require.NotEmpty(t, ownerRef)
+
+	err = k8sClient.Create(
+		context.TODO(),
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            component.TelemetryCertName,
+				Namespace:       cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Data: map[string][]byte{
+				"cert": []byte(`-----BEGIN CERTIFICATE-----
+MIIFEzCCA3ugAwIBAgIDASXwMA0GCSqGSIb3DQEBCwUAMFkxCzAJBgNVBAYTAlVT
+MRkwFwYDVQQKDBBQdXJlIFN0b3JhZ2UgSW5jMQ4wDAYDVQQLDAVQdXJlMTEfMB0G
+A1UEAwwWUHVyZTEgU3Vib3JkaW5hdGUgQ0EgNDAeFw0yNDA1MTQwNjExNDBaFw0y
+NTA1MTQwNjExNDBaMIHoMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5p
+YTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUHVyZVN0b3JhZ2Ux
+EzARBgNVBAsTClB1cmUgSW5mcmExEDAOBgNVBAMTB3Vua25vd24xLTArBgNVBAUT
+JDMxY2RmNzc0LTk0YTktNDE4MS04MGNkLTIxNWJkZDRmZWI1MzEtMCsGA1UEQRYk
+Yzc1ZTJjYmYtMTc2NS00MDY4LTkxM2QtNzYxODNlNjhmOGNjMREwDwYDVQQEFghw
+b3J0d29yeDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAONBSa5q3wyl
+6qVWZO7KCWZASUDPkFv8y31vtKAoS1jhAe4mDtDWyDxXrBMK9ngdKMpWfrBaoZZQ
+Z7FtOGsaVzansSXZAReYiZj1OFZKZkEEhhulNxHPOV3zKJKQxNOrdGfi0i8ZhlDG
+9YbYIJDeeiJE44UaYn/K+Vs/m+x5K95dFqtXdvIuhL00dVT1DR56pcskprAJ8R+i
+ILTYKkkwn+noeajESpIzdUHdtDbWF/+kw5j+e+CUWxtsKw1xfTz7fj+6Vufemrhw
+MV/DP5fbjS1RBHBhCN3LDFmwPSPJAniDECOYRsiR5eFkIHd42wQOu/EceFMfwjzA
+mtOSQzvQdC0CAwEAAaOB0zCB0DAMBgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFA5o
+8M8qUnCkQY/IRLW9P0hXo2+HMFsGCCsGAQUFBwEBBE8wTTBLBggrBgEFBQcwAYY/
+aHR0cDovL3N1Yi1jYS0wNC5zZWMuY2xvdWQtc3VwcG9ydC5wdXJlc3RvcmFnZS5j
+b206ODA4MC9jYS9vY3NwMA4GA1UdDwEB/wQEAwIEsDATBgNVHSUEDDAKBggrBgEF
+BQcDAjAdBgNVHQ4EFgQUvcvcmGzxsDP2oLRIl72EsV0P12IwDQYJKoZIhvcNAQEL
+BQADggGBAJRfBb4D1ojq8vj006xKpp/eLMyAxMRMuYwzrooDa+U4kdvPlk0ibA3i
+zChg117eRV19mjzTHaVPovwlzfhCqZFYyRR+c0iOFu/DUBBOamMZLx2rcZsnA9XC
+QN/9TIyDnXyup9dG6WAu1z5RW6VPifek1DUjdngj9TiyJQOchwLWD/iBG86Ap2gJ
++zt/G4Nwq5VZOp6qX7zfuW+hY9t8FVAz0X9+ohQHgN2eCxvdajgly4+TpVxybubQ
+tooUqkPNRKZ5P0IT9Do0E1z9ZlAQqGTC5abC9RNwAXf/KpIFpardKC/p5BwOZI2P
+aqDgX/Bcx/XoiRHBtDv450/GnAdgD+1yxFCjVkt3vnJybSgdbYV5f2+Owowc3aUw
+agq/IJO6rOF10LX7cDqVKfoQqbpU80v4Uk1Ls6FntKkzUj6njnpoPWdoFqxJmoDG
+zvz7BX4rQqGCD6ElMHyQM7rdq77/ywgSiRJlFf7eQsWNKTpHueulgqnqdW55pNaW
+JhBhJjN84g==
+-----END CERTIFICATE-----`),
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	require.Len(t, recorder.Events, 0)
+
+	// male sure invalid secret got deleted
+	secret := v1.Secret{}
+	err = testutil.Get(k8sClient, &secret, component.TelemetryCertName, cluster.Namespace)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
 func TestTelemetryCCMGoRestartPhonehome(t *testing.T) {
 	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
 	reregisterComponents()

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
@@ -2076,6 +2077,27 @@ func DeleteSecret(
 	return k8sClient.Update(context.TODO(), secret)
 }
 
+// GetSecret gets secret
+func GetSecret(
+	k8sClient client.Client,
+	name string,
+	namespace string,
+	secret *v1.Secret,
+) error {
+	err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+		secret,
+	)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 // GetCRDFromFile parses a CRD definition filename from crdBaseDir and returns the parsed object
 func GetCRDFromFile(
 	filename string,
@@ -2361,4 +2383,34 @@ func GetDefaultKubeSchedulerImage(k8sVersion *version.Version) string {
 		return prefix + "1.21.4"
 	}
 	return prefix + k8sVersion.String()
+}
+
+// DeletePodsByLabel deletes pods by label, from a given namespace
+func DeletePodsByLabel(
+	k8sClient client.Client,
+	mylabels map[string]string,
+	namespace string,
+) error {
+	podList := &v1.PodList{}
+	err := k8sClient.List(
+		context.TODO(),
+		podList,
+		&client.ListOptions{
+			Namespace:     namespace,
+			LabelSelector: labels.SelectorFromSet(mylabels),
+		},
+	)
+	if err != nil {
+		return err
+	} else if len(podList.Items) <= 0 {
+		return nil
+	}
+
+	for _, pod := range podList.Items {
+		logrus.Debugf("Deleting pod %s/%s", pod.Namespace, pod.Name)
+		if err := k8sClient.Delete(context.TODO(), &pod); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
* adding code to validate (and refresh) Pure1 Telemetry's SSL certificate

Manually fixed Conflicts:
	drivers/storage/portworx/component/telemetry.go
	pkg/util/test/util.go

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

This is a cherry-pick of https://github.com/libopenstorage/operator/pull/1553 into `release-24.1.1` branch

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-36928  (for 24.1.1)

**Special notes for your reviewer**:

