### PR TITLE
PWX-37982 Use the expiration time returned by k8s api server for px sa token

### DIFF
--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -65,9 +65,13 @@ func setUpMockCoreOps(mockCtrl *gomock.Controller, clientset *fakek8sclient.Clie
 	coreops.SetInstance(mockCoreOps)
 
 	simpleClientset := coreops.New(clientset)
+	defaultTokenExpirationSeconds := int64(12 * 60 * 60)
 	mockCoreOps.EXPECT().
 		CreateToken(gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(&authv1.TokenRequest{
+			Spec: authv1.TokenRequestSpec{
+				ExpirationSeconds: &defaultTokenExpirationSeconds,
+			},
 			Status: authv1.TokenRequestStatus{
 				Token: "xxxx",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
There's a global `maxExpirationSeconds` which can be smaller than the token expiration time we set. If this is the case, k8s will silently set the returned token expiration time to the `maxExpirationSeconds`, which will expire earlier than we expected, brining px not having a valid token to talk to k8s.


