### PR TITLE
PWX-38004 : Update ca.crt in autopilot secret when upgrading from OCP from 4.15 to 4.16

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -365,38 +365,22 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 			return fmt.Errorf("error during getting secret %w ", err)
 		}
 
-		if secret.Data != nil {
-			// if secret exists, check if token is expired
-			refreshNeeded, err := isTokenRefreshRequired(secret)
-			if err != nil {
-				return fmt.Errorf("error during checking token refresh: %w ", err)
-			}
-			if refreshNeeded {
-				// refresh the token if it is expired
-				logrus.Infof("refreshing token for secret %s/%s", clusterNamespace, AutopilotSecretName)
-				err := c.refreshTokenSecret(secret, clusterNamespace, ownerRef)
-				if err != nil {
-					return fmt.Errorf("failed to check token in secret %s/%s: %w", clusterNamespace, AutopilotSecretName, err)
-				}
-			}
-		} else {
-			// if secret is not created, create the secret
-			// generate token and root ca.crt
-			token, err := generateAPSaToken(clusterNamespace, defaultAutoPilotSaTokenExpirationSeconds)
-			if err != nil {
-				return fmt.Errorf("error during generating token %v ", err)
-			}
-
-			rootCaCrt, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
-			if err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("error reading k8s cluster certificate located inside the pod at /var/run/secrets/kubernetes.io/serviceaccount/ca.crt: %w", err)
-			}
-
-			secret.Data = make(map[string][]byte)
-			secret.Data[core.ServiceAccountTokenKey] = []byte(token.Status.Token)
-			secret.Data[core.ServiceAccountRootCAKey] = rootCaCrt
-			secret.Data[AutopilotSaTokenRefreshTimeKey] = []byte(time.Now().UTC().Add(time.Duration(*token.Spec.ExpirationSeconds/2) * time.Second).Format(time.RFC3339))
+		// check if secret requires update
+		// if update is required, create the token if not present
+		// or refresh the token if it is expired
+		updateRequired, err := isSecretUpdateRequired(secret)
+		if err != nil {
+			return fmt.Errorf("error during checking token refresh: %w ", err)
 		}
+
+		if updateRequired {
+			logrus.Infof("refreshing token for secret %s/%s", clusterNamespace, AutopilotSecretName)
+			err := c.updateSecretTokenAndCert(secret, clusterNamespace, ownerRef)
+			if err != nil {
+				return fmt.Errorf("failed to check token in secret %s/%s: %w", clusterNamespace, AutopilotSecretName, err)
+			}
+		}
+		return nil
 	} else {
 		// OCP 4.15 and below, secret is created if user workload monitoring is enabled
 		// and openshift's prometheus secret is found
@@ -410,13 +394,12 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 		secret.Data = make(map[string][]byte)
 		secret.Data[core.ServiceAccountTokenKey] = []byte(token)
 		secret.Data[core.ServiceAccountRootCAKey] = []byte(cert) // change to ca.crt to match the key in the generated in secret by kubernetes
+		return k8sutil.CreateOrUpdateSecret(
+			c.k8sClient,
+			secret,
+			ownerRef,
+		)
 	}
-
-	return k8sutil.CreateOrUpdateSecret(
-		c.k8sClient,
-		secret,
-		ownerRef,
-	)
 }
 
 func (c *autopilot) createServiceAccount(
@@ -937,22 +920,41 @@ func (c *autopilot) isOCPUserWorkloadSupported() bool {
 	return *c.isUserWorkloadSupported
 }
 
-func (c *autopilot) refreshTokenSecret(secret *v1.Secret, clusterNamespace string, ownerRef *metav1.OwnerReference) error {
+// updateSecretTokenAndCert updates the secret with new token, token refresh timestamp and ca.crt
+func (c *autopilot) updateSecretTokenAndCert(secret *v1.Secret, clusterNamespace string, ownerRef *metav1.OwnerReference) error {
 
-	// update the token when it is half way to expiration
+	// update the token when it is half the way to expiration
 	newToken, err := generateAPSaToken(clusterNamespace, defaultAutoPilotSaTokenExpirationSeconds)
 	if err != nil {
 		return err
 	}
 
-	// update the secret with new token
-	secret.Data[core.ServiceAccountTokenKey] = []byte(newToken.Status.Token)
-	secret.Data[AutopilotSaTokenRefreshTimeKey] = []byte(time.Now().UTC().Add(time.Duration(*newToken.Spec.ExpirationSeconds/2) * time.Second).Format(time.RFC3339))
-	err = k8sutil.CreateOrUpdateSecret(c.k8sClient, secret, ownerRef)
+	// get the root ca.crt from the secret mounted inside the pod
+	// this is required while upgrading from OCP 4.15 to 4.16
+	// since the ca.crt is changed in 4.16 and not managed by openshift
+	rootCaCrt, err := getCertForSecret()
 	if err != nil {
 		return err
 	}
-	return nil
+
+	// update the secret with new token and secret
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	secret.Data[core.ServiceAccountTokenKey] = []byte(newToken.Status.Token)
+	secret.Data[core.ServiceAccountRootCAKey] = rootCaCrt
+	// set the token refresh time to half the way of token expiration
+	secret.Data[AutopilotSaTokenRefreshTimeKey] = []byte(time.Now().UTC().Add(time.Duration(*newToken.Spec.ExpirationSeconds/2) * time.Second).Format(time.RFC3339))
+	return k8sutil.CreateOrUpdateSecret(c.k8sClient, secret, ownerRef)
+}
+
+// get the root ca.crt from the secret mounted inside the pod
+func getCertForSecret() ([]byte, error) {
+	rootCaCrt, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("error reading k8s cluster certificate located inside the pod at /var/run/secrets/kubernetes.io/serviceaccount/ca.crt: %w", err)
+	}
+	return rootCaCrt, nil
 }
 
 func generateAPSaToken(clusterNamespace string, expirationSeconds int64) (*authv1.TokenRequest, error) {
@@ -968,8 +970,12 @@ func generateAPSaToken(clusterNamespace string, expirationSeconds int64) (*authv
 	return tokenResp, nil
 }
 
-func isTokenRefreshRequired(secret *v1.Secret) (bool, error) {
-	if len(secret.Data) == 0 || len(secret.Data[v1.ServiceAccountTokenKey]) == 0 {
+// isSecretUpdateRequired returns true if secret is not present
+// isSecretUpdateRequired returns true if token expiry is not set
+// isSecretUpdateRequired returns true if token is expired
+// isSecretUpdateRequired returns false if token is not expired
+func isSecretUpdateRequired(secret *v1.Secret) (bool, error) {
+	if secret.Data == nil || len(secret.Data[AutopilotSaTokenRefreshTimeKey]) == 0 {
 		return true, nil
 	}
 	expirationTime, err := time.Parse(time.RFC3339, string(secret.Data[AutopilotSaTokenRefreshTimeKey]))

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -4857,7 +4857,7 @@ func setUpMockCoreOps(mockCtrl *gomock.Controller, clientset *fakek8sclient.Clie
 				ExpirationSeconds: &defaultTokenExpirationSeconds,
 			},
 			Status: authv1.TokenRequestStatus{
-				Token: "xxxx",
+				Token: "dG9rZW4tdmFsdWU=",
 			},
 		}, nil).
 		AnyTimes()
@@ -5064,6 +5064,185 @@ func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
 	err = autopilotComponent.Delete(cluster)
 	autopilotComponent.MarkDeleted()
 	require.NoError(t, err)
+
+}
+
+// test OCP upgrade from 4.15 to 4.16
+func TestAutopilotUpgradeFrom415To416(t *testing.T) {
+
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: component.ClusterOperatorVersion,
+			APIResources: []metav1.APIResource{
+				{
+					Kind: component.ClusterOperatorKind,
+				},
+			},
+		},
+	}
+	coreops.SetInstance(coreops.New(versionClient))
+
+	reregisterComponents()
+	operator := &ocpconfig.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: component.OpenshiftAPIServer,
+		},
+		Status: ocpconfig.ClusterOperatorStatus{
+			RelatedObjects: []ocpconfig.ObjectReference{
+				{Name: component.OpenshiftAPIServer},
+			},
+			Versions: []ocpconfig.OperandVersion{
+				{
+					Name:    component.OpenshiftAPIServer,
+					Version: "4.15",
+				},
+			},
+		},
+	}
+	k8sClient := testutil.FakeK8sClient()
+	err := k8sClient.Create(context.TODO(), operator)
+	require.NoError(t, err)
+
+	driver := portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	stcSpec := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "true",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Monitoring: &corev1.MonitoringSpec{Telemetry: &corev1.TelemetrySpec{}},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: true,
+				Image:   "portworx/autopilot:1.1.1",
+				Providers: []corev1.DataProviderSpec{
+					{
+						Name: "default",
+						Type: "prometheus",
+						Params: map[string]string{
+							"url": "http://prometheus:9090",
+						},
+					},
+					{
+						Name: "second",
+						Type: "datadog",
+						Params: map[string]string{
+							"url":  "http://datadog:9090",
+							"auth": "foobar",
+						},
+					},
+				},
+				Args: map[string]string{
+					"min_poll_interval": "4",
+					"log-level":         "info",
+				},
+			},
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					SelfSigned: &corev1.SelfSignedSpec{
+						Issuer:        stringPtr(defaultSelfSignedIssuer),
+						TokenLifetime: stringPtr(defaultTokenLifetime),
+						SharedSecret:  stringPtr(pxutil.SecurityPXSharedSecretSecretName),
+					},
+				},
+			},
+		},
+	}
+
+	cluster := stcSpec.DeepCopy()
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	// on OCP 4.15 , thanos-ruler-token secret is used for certificate and token
+	// this secret is created by openshift
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "thanos-ruler-token-abcd",
+			Namespace: "openshift-user-workload-monitoring",
+		},
+		Data: map[string][]byte{
+			"token":  []byte("dG9rZW4tdmFsdWU="),
+			"ca.crt": []byte("Y2VydGlmaWNhdGUtdmFsdWU="),
+		},
+	}
+
+	err = k8sClient.Create(context.TODO(), secret)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Autopilot Secret on 4.15
+	expectedSecret415 := testutil.GetExpectedSecret(t, "autopilot-auth-token-secret.yaml")
+	actualSecret415 := &v1.Secret{}
+	err = testutil.Get(k8sClient, actualSecret415, component.AutopilotSecretName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedSecret415.Data, actualSecret415.Data)
+	// on OCP 4.15, token refresh time is not set
+	require.Empty(t, expectedSecret415.Data[component.AutopilotSaTokenRefreshTimeKey])
+
+	// Autopilot Deployment on 4.15
+	expectedDeployment415 := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_14.yaml")
+	autopilotDeployment415 := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment415, component.AutopilotDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedDeployment415.Spec.Template.Spec.Volumes, autopilotDeployment415.Spec.Template.Spec.Volumes)
+	require.Equal(t, expectedDeployment415.Spec.Template.Spec.Containers[0].VolumeMounts, autopilotDeployment415.Spec.Template.Spec.Containers[0].VolumeMounts)
+
+	mockCtrl := gomock.NewController(t)
+	setUpMockCoreOps(mockCtrl, versionClient)
+
+	// upgrade cluster to OCP 4.16
+	operator.Status.Versions[0].Version = "4.16"
+	err = k8sClient.Update(context.Background(), operator)
+	require.NoError(t, err)
+
+	// reconcile storagecluster
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// Autopilot Prometheus Service Account on OCP 4.16
+	expectedSA := &v1.ServiceAccount{}
+	err = testutil.Get(k8sClient, expectedSA, component.AutopilotPrometheusServiceAccountName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, component.AutopilotPrometheusServiceAccountName, expectedSA.Name)
+	require.Equal(t, cluster.Namespace, expectedSA.Namespace)
+	require.Len(t, expectedSA.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, expectedSA.OwnerReferences[0].Name)
+
+	// Autopilot Prometheus Cluster role binding on OCP 4.16
+	expectedPrometheusCRB := testutil.GetExpectedClusterRoleBinding(t, "autopilotPrometheusClusterRoleBinding.yaml")
+	actualClusterRoleCRB := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, actualClusterRoleCRB, component.AutopilotPrometheusClusterRoleBindingName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedPrometheusCRB.Name, actualClusterRoleCRB.Name)
+	require.ElementsMatch(t, expectedPrometheusCRB.Subjects, actualClusterRoleCRB.Subjects)
+	require.Equal(t, expectedPrometheusCRB.RoleRef, actualClusterRoleCRB.RoleRef)
+
+	// Autopilot Secret on OCP 4.16
+	expectedSecret416 := testutil.GetExpectedSecret(t, "autopilot-auth-token-secret_4_16.yaml")
+	actualSecret416 := &v1.Secret{}
+	err = testutil.Get(k8sClient, actualSecret416, component.AutopilotSecretName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedSecret416.Data["token"], actualSecret416.Data["token"])
+	// on OCP 4.16, token refresh time is set
+	require.NotEmpty(t, expectedSecret416.Data[component.AutopilotSaTokenRefreshTimeKey])
+
+	// Autopilot Deployment on OCP 4.16
+	expectedDeployment416 := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_14.yaml")
+	autopilotDeployment416 := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment416, component.AutopilotDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedDeployment416.Spec.Template.Spec.Volumes, autopilotDeployment416.Spec.Template.Spec.Volumes)
+	require.Equal(t, expectedDeployment416.Spec.Template.Spec.Containers[0].VolumeMounts, autopilotDeployment416.Spec.Template.Spec.Containers[0].VolumeMounts)
 
 }
 

--- a/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
+++ b/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   ca.crt: WTJWeWRHbG1hV05oZEdVdGRtRnNkV1U9
   token: ZEc5clpXNHRkbUZzZFdVPQ==
+  autopilotSaTokenRefreshTime: MjAyMC0wNy0xNlQxNzoxNzoxN1o=
 kind: Secret
 metadata:
   name: autopilot-prometheus-auth


### PR DESCRIPTION
**What this PR does / why we need it**:
Issue :
Issue with the code was that ca.crt would not get updated during upgrade case of OCP cluster, since secret was already available. The change in the code updates ca.crt everytime token is refreshed. This handles case when pod certidicate is also updated on runtime. The new code flow is like following during every reconcilation loop : 
1. Fetch the secret
2. check if secret requires update, if secret is not present, present but expiry is not set or expiry is set but token is expired, we will create/update the secret.
3. If step 2 says update is required, certificare is fetched from path /var/run/secrets/kubernetes.io/serviceaccount/ca.crt within the pod, and updated in the secret.

This handles fresh install and upgrade case as well.

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-38004

**Special notes for your reviewer**:
- Verified on OCP 4.15 and OCP 4.16
- Added UTs for OCP upgrade case.
