### PR TITLE
[cherry-pick] PWX-36251 | Delete renamed px-attachdriveset-lock configmap on deletion of storage cluster 

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -3726,7 +3726,21 @@ func TestGarbageCollection(t *testing.T) {
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
+				Name:      "px-attachdriveset-lock",
+				Namespace: cluster.Namespace,
+			},
+			Data: map[string]string{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "px-attach-driveset-lock",
+				Namespace: "kube-system",
+			},
+			Data: map[string]string{},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "px-attachdriveset-lock",
 				Namespace: "kube-system",
 			},
 			Data: map[string]string{},

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -937,7 +937,10 @@ func (c *Controller) gcNeeded(obj client.Object) bool {
 	}
 
 	if obj.GetObjectKind().GroupVersionKind().Kind == "ConfigMap" {
-		if obj.GetName() == "px-attach-driveset-lock" ||
+		// px-attachdriveset-lock configmap name has changed in porx to px-attach-driveset-lock
+		// and changes are merged to PX 2.13.2 onwards and 3.0.0 onwards. Since operator has to support till n-2 px versions,
+		// operator needs to have support for clean up of both px-attachdriveset-lock as well as px-attach-driveset-lock
+		if obj.GetName() == "px-attach-driveset-lock" || obj.GetName() == "px-attachdriveset-lock" ||
 			strings.HasPrefix(obj.GetName(), "px-bringup-queue-lock") {
 			return true
 		}


### PR DESCRIPTION

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
cherry pick PR for https://github.com/libopenstorage/operator/pull/1590
**Which issue(s) this PR fixes** (optional)
Closes #https://purestorage.atlassian.net/browse/PWX-36251

**Special notes for your reviewer**:

