### PR TITLE
Fix PX ServiceAccount token audience

### DIFF
--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -616,7 +616,6 @@ func (c *portworxBasic) refreshTokenSecret(secret *v1.Secret, cluster *corev1.St
 func generatePxSaToken(cluster *corev1.StorageCluster, expirationSeconds int64) (*authv1.TokenRequest, error) {
 	tokenRequest := &authv1.TokenRequest{
 		Spec: authv1.TokenRequestSpec{
-			Audiences:         []string{"https://kubernetes.default.svc.cluster.local"}, // the k8s api server service
 			ExpirationSeconds: &expirationSeconds,
 		},
 	}

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -616,7 +616,7 @@ func (c *portworxBasic) refreshTokenSecret(secret *v1.Secret, cluster *corev1.St
 func generatePxSaToken(cluster *corev1.StorageCluster, expirationSeconds int64) (*authv1.TokenRequest, error) {
 	tokenRequest := &authv1.TokenRequest{
 		Spec: authv1.TokenRequestSpec{
-			Audiences:         []string{"px"},
+			Audiences:         []string{"https://kubernetes.default.svc.cluster.local"}, // the k8s api server service
 			ExpirationSeconds: &expirationSeconds,
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The target audience of the token is the k8s api server as we are using the token to talk to api server.

With a wrong audience px is not able to start with 
`level=error msg="Could not init boot manager" file="terminate.go:85" component=porx/pkg/util/logs error="Failed to initialize k8s bootstrap: failed to create configmap px-bootstrap-teststc: Unauthorized"` 
and the token validation would return
```
status:
  error: '[invalid bearer token, token audiences ["px"] is invalid for the target
    audiences ["https://kubernetes.default.svc.cluster.local"]]'
  user: {}
```