### PR TITLE
PWX-38035 : Remove ca.crt mount volume from autopilot pod

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -814,12 +814,13 @@ func (c *autopilot) getDesiredVolumesAndMounts(
 	if c.isOCPUserWorkloadSupported() && c.isAutopilotSecretCreated(cluster.Namespace) {
 		for _, v := range openshiftDeploymentVolume {
 			// skip adding ca-cert-volume if OCP 4.16 and above
-			// autopilot pod will use kuberntes crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+			// autopilot pod will use kubernetes crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 			// to access prometheus metrics
-			if v.Name != "ca-cert-volume" || !ocp416plus {
-				vCopy := v.DeepCopy()
-				volumeSpecs = append(volumeSpecs, *vCopy)
+			if v.Name == "ca-cert-volume" && ocp416plus {
+				continue
 			}
+			vCopy := v.DeepCopy()
+			volumeSpecs = append(volumeSpecs, *vCopy)
 		}
 	}
 

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -5053,7 +5053,7 @@ func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
 	require.Equal(t, expectedSecret.Annotations, actualSecret.Annotations)
 
 	// Autopilot Deployment
-	expectedDeployment := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_14.yaml")
+	expectedDeployment := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_16.yaml")
 	autopilotDeployment := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
@@ -5237,7 +5237,7 @@ func TestAutopilotUpgradeFrom415To416(t *testing.T) {
 	require.NotEmpty(t, expectedSecret416.Data[component.AutopilotSaTokenRefreshTimeKey])
 
 	// Autopilot Deployment on OCP 4.16
-	expectedDeployment416 := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_14.yaml")
+	expectedDeployment416 := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_16.yaml")
 	autopilotDeployment416 := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment416, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)

--- a/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_16.yaml
+++ b/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_16.yaml
@@ -1,0 +1,138 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    tier: control-plane
+  name: autopilot
+  namespace: kube-test
+  ownerReferences:
+    - apiVersion: core.libopenstorage.org/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: StorageCluster
+      name: px-cluster
+spec:
+  selector:
+    matchLabels:
+      name: autopilot
+      tier: control-plane
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: autopilot
+        tier: control-plane
+        operator.libopenstorage.org/managed-by: portworx
+    spec:
+      containers:
+        - command:
+            - /autopilot
+            - --config=/etc/config/config.yaml
+            - --log-level=info
+          imagePullPolicy: Always
+          image: docker.io/portworx/autopilot:1.1.1
+          resources:
+            requests:
+              cpu: 100m
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+          name: autopilot
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: token-volume
+              mountPath: /var/local/secrets
+              readOnly: true
+            - name: varcores
+              mountPath: /var/cores
+          env:
+            - name: PX_NAMESPACE
+              value: kube-test
+            - name: PX_SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: apps-secret
+                  name: px-system-secrets
+      hostPID: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: px/enabled
+                    operator: NotIn
+                    values:
+                      - "false"
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+              - matchExpressions:
+                  - key: px/enabled
+                    operator: NotIn
+                    values:
+                      - "false"
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+                  - key: node-role.kubernetes.io/worker
+                    operator: Exists
+              - matchExpressions:
+                  - key: px/enabled
+                    operator: NotIn
+                    values:
+                      - "false"
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                  - key: node-role.kubernetes.io/worker
+                    operator: Exists
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                      - autopilot
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: autopilot
+      volumes:
+        - name: config-volume
+          configMap:
+            name: autopilot-config
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+        - name: token-volume
+          secret:
+            defaultMode: 420
+            items:
+              - key: token
+                path: token
+            secretName: autopilot-prometheus-auth
+        - hostPath:
+            path: /var/cores
+            type: ""
+          name: varcores


### PR DESCRIPTION
**What this PR does / why we need it**: 
This PR is required in addition to autopilot changes done here https://github.com/pure-px/autopilot/pull/262
Since autopilot will read ca.crt from /var/run/secrets/kubernetes.io/serviceaccount/ca.crt within the autopilot pod instead of /etc/ssl/px-custom/ that operator mounts, operator no longer is required to mount the certificate to authenticate prometheus URL.

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-38035

**Special notes for your reviewer**:
- This is specifically for OCP 4.16
- For OCP 4.15 and below, there will be no change
-  E2E testing with Autopilot + operator on OCP 4.16 and OCP 4.15
