### PR TITLE
PWX-38083 Fix metadata device spec format when FACD pod name doesn't exist

### DIFF
--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -410,6 +410,7 @@ func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
 		if pxutil.IsVsphere(u.cluster) {
 			cmetaData = DefCmetaVsphere
 		} else if pxutil.IsPure(u.cluster) {
+			cmetaData = DefCmetaFACD
 			var podNameOption string
 		specsItr:
 			for _, spec := range *u.cluster.Spec.CloudStorage.DeviceSpecs {
@@ -422,7 +423,9 @@ func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
 					}
 				}
 			}
-			cmetaData = fmt.Sprintf("%s,%s", DefCmetaFACD, podNameOption)
+			if len(podNameOption) > 0 {
+				cmetaData = fmt.Sprintf("%s,%s", cmetaData, podNameOption)
+			}
 		}
 		u.cluster.Spec.CloudStorage.SystemMdDeviceSpec = &cmetaData
 	}

--- a/drivers/storage/portworx/preflight_test.go
+++ b/drivers/storage/portworx/preflight_test.go
@@ -13,6 +13,7 @@ import (
 func TestDmthinFacdDefCmeta(t *testing.T) {
 	fakeRecorder := record.NewFakeRecorder(10)
 
+	// with pod name
 	u := &preFlightPortworx{
 		cluster: &corev1.StorageCluster{
 			Spec: corev1.StorageClusterSpec{
@@ -47,4 +48,40 @@ func TestDmthinFacdDefCmeta(t *testing.T) {
 	err := u.ProcessPreFlightResults(fakeRecorder, storageNodes)
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("%s,%s", DefCmetaFACD, "pod=testpod"), *u.cluster.Spec.CloudStorage.SystemMdDeviceSpec)
+
+	// without pod name
+	u = &preFlightPortworx{
+		cluster: &corev1.StorageCluster{
+			Spec: corev1.StorageClusterSpec{
+				CommonConfig: corev1.CommonConfig{
+					Env: []v1.EnvVar{
+						{
+							Name:  "PURE_FLASHARRAY_SAN_TYPE",
+							Value: "PURE_FLASHARRAY_SAN_TYPE",
+						},
+					},
+				},
+				CloudStorage: &corev1.CloudStorageSpec{
+					CloudStorageCommon: corev1.CloudStorageCommon{
+						DeviceSpecs: &[]string{"size=49"},
+					},
+				},
+			},
+		},
+		hardFail: true,
+	}
+	storageNodes = []*corev1.StorageNode{
+		{
+			Status: corev1.NodeStatus{
+				Checks: []corev1.CheckResult{
+					{
+						Type: "status",
+					},
+				},
+			},
+		},
+	}
+	err = u.ProcessPreFlightResults(fakeRecorder, storageNodes)
+	require.Nil(t, err)
+	require.Equal(t, DefCmetaFACD, *u.cluster.Spec.CloudStorage.SystemMdDeviceSpec)
 }


### PR DESCRIPTION
When FACD pod name is not specified, for example, FACD with dmthin without multitenancy, the auto-added metadata device spec should not have extra comma at the end.

https://purestorage.atlassian.net/browse/PWX-38083