### PR TITLE
PWX-31632: Add telemetry secret expiry check

### DIFF
--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -1095,10 +1095,9 @@ func (t *telemetry) validateTelemetrySSLCertPseudonym(cert *x509.Certificate, cu
 }
 
 func (t *telemetry) validateTelemetrySSLCertExpiry(cert *x509.Certificate) error {
-	recycleDate := time.Now().Add(time.Hour * 12) // delete the cert and re-register if we are within a small grace period of certificate expiry
-	warningDate := time.Now().AddDate(0, 0, 60)   // start emitting warnings if we are within 60 days of certificate expiry
-	if recycleDate.After(cert.NotAfter) {
-		logrus.Errorf("SSL cert is set to expire on %s, which is soon enough to refresh telemetry", cert.NotAfter.String())
+	warningDate := time.Now().AddDate(0, 0, 30) // start emitting warnings if we are within 30 days of certificate expiry
+	if time.Now().After(cert.NotAfter) {
+		logrus.Errorf("SSL cert expired on %s", cert.NotAfter.String())
 		return errInvalidTelemetryCert
 	} else if warningDate.After(cert.NotAfter) {
 		logrus.Warnf("SSL cert is set to expire on %s", cert.NotAfter.String())

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -1095,15 +1095,16 @@ func (t *telemetry) checkTelemetrySSLCertPseudonym(cert *x509.Certificate, cuuid
 }
 
 func (t *telemetry) checkTelemetrySSLCertExpiry(cert *x509.Certificate) error {
+	currDate := time.Now()
 	warningDate := time.Now().AddDate(0, 0, 60)     // start emitting warnings if we are within 60 days of certificate expiry
 	errorBufferDays := time.Now().AddDate(0, 0, 30) // start emitting errors if we are within 30 days of certificate expiry
-	if cert.NotAfter.Before(time.Now()) {
+	if currDate.After(cert.NotAfter) {
 		logrus.Errorf("SSL cert has already expired. NotAfter:%s", cert.NotAfter)
 		return errInvalidTelemetryCert
-	} else if cert.NotAfter.Before(errorBufferDays) {
+	} else if errorBufferDays.After(cert.NotAfter) {
 		logrus.Errorf("SSL cert is set to expire on %s", cert.NotAfter.String())
 		return nil
-	} else if cert.NotAfter.Before(warningDate) {
+	} else if warningDate.After(cert.NotAfter) {
 		logrus.Warnf("SSL cert is set to expire on %s", cert.NotAfter)
 		return nil
 	}

--- a/drivers/storage/portworx/deployment_test.go
+++ b/drivers/storage/portworx/deployment_test.go
@@ -3291,7 +3291,7 @@ func TestPodWithTelemetryUpgrade(t *testing.T) {
 	driver := portworx{}
 	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
 	require.NoError(t, err)
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 
@@ -3351,7 +3351,7 @@ func TestPodWithTelemetryCCMVolume(t *testing.T) {
 	driver := portworx{}
 	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(100))
 	require.NoError(t, err)
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 

--- a/drivers/storage/portworx/portworx_test.go
+++ b/drivers/storage/portworx/portworx_test.go
@@ -1769,7 +1769,7 @@ func TestSetDefaultsOnStorageCluster(t *testing.T) {
 		},
 	}
 
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 	err = driver.SetDefaultsOnStorageCluster(cluster)
 	require.NoError(t, err)
 
@@ -1948,7 +1948,7 @@ func TestSetDefaultsOnStorageClusterOnEKS(t *testing.T) {
 			Namespace: "kube-test",
 		},
 	}
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 
 	// TestCase: default cloud provider
 	err = preflight.InitPreflightChecker(k8sClient)
@@ -2051,7 +2051,7 @@ func TestStorageClusterPlacementDefaults(t *testing.T) {
 			Namespace: "kube-test",
 		},
 	}
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 
 	// TestCase: placement spec below k8s 1.24
 	expectedPlacement := &corev1.PlacementSpec{
@@ -3023,7 +3023,7 @@ func TestStorageClusterDefaultsForCSI(t *testing.T) {
 			Image: "px/image:2.9.0.1",
 		},
 	}
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 
 	// Simulate DesiredImages.CSISnapshotController being empty for old operator version w/o this image
 	err = driver.SetDefaultsOnStorageCluster(cluster)
@@ -3354,7 +3354,7 @@ func TestStorageClusterDefaultsForAlertManager(t *testing.T) {
 			Image: "px/image:2.8.0",
 		},
 	}
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 
 	// Don't enable alert manager if monitoring spec is nil
 	err = driver.SetDefaultsOnStorageCluster(cluster)
@@ -3454,7 +3454,7 @@ func TestStorageClusterDefaultsForGrafana(t *testing.T) {
 			Image: "px/image:2.8.0",
 		},
 	}
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 
 	// Don't enable grafana by default
 	err = driver.SetDefaultsOnStorageCluster(cluster)
@@ -4253,7 +4253,7 @@ func TestSetDefaultsOnStorageClusterForOpenshift(t *testing.T) {
 			},
 		},
 	}
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 
 	expectedPlacement := &corev1.PlacementSpec{
 		NodeAffinity: &v1.NodeAffinity{
@@ -10876,7 +10876,7 @@ func TestStorageClusterDefaultsForTelemetry(t *testing.T) {
 			},
 		},
 	}
-	createTelemetrySecret(t, k8sClient, cluster.Namespace)
+	createTelemetrySecret(t, k8sClient, cluster.Namespace, nil)
 
 	// Disable telemetry for px version < 2.8.0
 	err = driver.SetDefaultsOnStorageCluster(cluster)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Extending our `validateTelemetrySSLCert` func to check the expiry of the certificate too. Created two helper methods, one for doing the `pseudonym` check (this logic was already there) and one for doing the expiry check.

If the current time of the pod is within 12 hours of the expiry time of the certificate, we will return an error that results in `refreshTelemetrySSLCert` being called

If the current time of the pod is within 60 days of the expiry time, we will log a warning in the operators logs.

**Which issue(s) this PR fixes** (optional)
Closes PWX-31632

**Special notes for your reviewer**:
<I'm still investigating how to run tests>
