### PR TITLE
PWX-36510: No disruption of volumes for portworx upgrades

### DIFF
--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -101,6 +101,10 @@ func (c *disruptionBudget) Reconcile(cluster *corev1.StorageCluster) error {
 	if err != nil {
 		return fmt.Errorf("failed to enumerate nodes: %v", err)
 	}
+	if len(nodeEnumerateResponse.Nodes) == 0 {
+		logrus.Warnf("Cannot create/update storage PodDisruptionBudget as there are no storage nodes")
+		return nil
+	}
 
 	if pxutil.ClusterSupportsParallelUpgrade(nodeEnumerateResponse.Nodes) {
 		// Get the list of k8s nodes that are part of the current cluster

--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -102,7 +102,7 @@ func (c *disruptionBudget) Reconcile(cluster *corev1.StorageCluster) error {
 		return fmt.Errorf("failed to enumerate nodes: %v", err)
 	}
 
-	if pxutil.ClusterSupportsParallelUpgrade(nodeEnumerateResponse) {
+	if pxutil.ClusterSupportsParallelUpgrade(nodeEnumerateResponse.Nodes) {
 		// Get the list of k8s nodes that are part of the current cluster
 		k8sNodeList := &v1.NodeList{}
 		err = c.k8sClient.List(context.TODO(), k8sNodeList)

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -805,6 +805,30 @@ func (p *portworx) GetKVDBMembers(cluster *corev1.StorageCluster) (map[string]bo
 	return kvdbMap, nil
 }
 
+func (p *portworx) GetNodesSelectedForUpgrade(cluster *corev1.StorageCluster, nodesToBeUpgraded []string, unavailableNodes []string) ([]string, error) {
+	var err error
+	p.sdkConn, err = pxutil.GetPortworxConn(p.sdkConn, p.k8sClient, cluster.Namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Portworx connection: %v", err)
+	}
+	nodeClient := storageapi.NewOpenStorageNodeClient(p.sdkConn)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup context with token: %v", err)
+	}
+	nodeFilterResponse, err := nodeClient.FilterNonOverlappingNodes(
+		ctx,
+		&storageapi.SdkFilterNonOverlappingNodesRequest{
+			InputNodes: nodesToBeUpgraded,
+			DownNodes:  unavailableNodes,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get non overlapping nodes: %v", err)
+	}
+	return nodeFilterResponse.NodeIds, nil
+}
+
 func (p *portworx) DeleteStorage(
 	cluster *corev1.StorageCluster,
 ) (*corev1.ClusterCondition, error) {

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1587,9 +1587,9 @@ func NodesToDeletePDB(k8sClient client.Client, nodeEnumerateResponse *api.SdkNod
 
 }
 
-func ClusterSupportsParallelUpgrade(nodeEnumerateResponse *api.SdkNodeEnumerateWithFiltersResponse) bool {
+func ClusterSupportsParallelUpgrade(nodes []*api.StorageNode) bool {
 
-	for _, node := range nodeEnumerateResponse.Nodes {
+	for _, node := range nodes {
 		if node.Status == api.Status_STATUS_DECOMMISSION {
 			continue
 		}

--- a/drivers/storage/storage.go
+++ b/drivers/storage/storage.go
@@ -78,6 +78,9 @@ type ClusterPluginInterface interface {
 	GetStorageNodes(cluster *corev1.StorageCluster) ([]*storageapi.StorageNode, error)
 	// GetKVDBMembers returns a map of Nodes with kvdb and if its healthy or not
 	GetKVDBMembers(cluster *corev1.StorageCluster) (map[string]bool, error)
+	// GetNodesSelectedForUpgrade returns a list of pods that can be upgraded without losing volume quorum
+	// The function calls filterNonOverlappingNodes API for portworx versions greater than or equal to  3.1.2
+	GetNodesSelectedForUpgrade(cluster *corev1.StorageCluster, nodesToBeUpgraded []string, unavailableNodes []string) ([]string, error)
 }
 
 var (

--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -277,7 +277,7 @@ type RollingUpdateStorageCluster struct {
 	// The default behavior is non-disruptive upgrades. This setting disables the default
 	// non-disruptive upgrades and reverts to the previous behavior of upgrading nodes in
 	// parallel without worrying about disruption.
-	Disruption Disruption `json:"disruption,omitempty"`
+	Disruption *Disruption `json:"disruption,omitempty"`
 }
 
 // Disruption contains configuration for disruption

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -6585,14 +6585,23 @@ func TestUpdateStorageClusterStorageSpec(t *testing.T) {
 		nodeInfoMap:       maps.MakeSyncMap[string, *k8s.NodeInfo](),
 		kubevirt:          testutil.NoopKubevirtManager(mockCtrl),
 	}
-
+	storageNodeList := []*storageapi.StorageNode{
+		{
+			Id:                "node1",
+			SchedulerNodeName: "k8s-node",
+			NodeLabels: map[string]string{
+				"PX Version": "3.0.0",
+			},
+			Status: storageapi.Status_STATUS_OK,
+		},
+	}
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().SetDefaultsOnStorageCluster(gomock.Any()).AnyTimes()
 	driver.EXPECT().GetSelectorLabels().Return(nil).AnyTimes()
 	driver.EXPECT().String().Return(driverName).AnyTimes()
 	driver.EXPECT().PreInstall(gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().UpdateDriver(gomock.Any()).Return(nil).AnyTimes()
-	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(nil, nil).AnyTimes()
+	driver.EXPECT().GetStorageNodes(gomock.Any()).Return(storageNodeList, nil).AnyTimes()
 	driver.EXPECT().GetStoragePodSpec(gomock.Any(), gomock.Any()).Return(v1.PodSpec{}, nil).AnyTimes()
 	driver.EXPECT().UpdateStorageClusterStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	driver.EXPECT().IsPodUpdated(gomock.Any(), gomock.Any()).Return(true).AnyTimes()

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -35,7 +35,6 @@ import (
 	apiextensionsops "github.com/portworx/sched-ops/k8s/apiextensions"
 	operatorops "github.com/portworx/sched-ops/k8s/operator"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -117,7 +116,6 @@ type Controller struct {
 	isStorkSchedDeploymentCreated bool
 	ctrl                          controller.Controller
 	kubevirt                      KubevirtManager
-	sdkConn                       *grpc.ClientConn
 	// Node to NodeInfo map
 	nodeInfoMap maps.SyncMap[string, *k8s.NodeInfo]
 }
@@ -236,16 +234,13 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 	err := c.client.Get(context.TODO(), request.NamespacedName, cluster)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			fmt.Println("HERE1")
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected.
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		fmt.Println("HERE2")
 		return reconcile.Result{}, err
 	}
-	fmt.Println("HERE3")
 	if err := c.validate(cluster); err != nil {
 		k8s.WarningEvent(c.recorder, cluster, util.FailedValidationReason, err.Error())
 		if updateErr := util.UpdateLiveStorageClusterLifecycle(c.client, cluster, corev1.ClusterStateDegraded); updateErr != nil {
@@ -810,7 +805,6 @@ func (c *Controller) syncStorageCluster(
 
 	// TODO: Don't process a storage cluster until all its previous creations and
 	// deletions have been processed.
-	fmt.Println("BEFORE MANAGE")
 	err = c.manage(cluster, hash, nodeList)
 	if err != nil {
 		return fmt.Errorf("manage failed: %s", err)

--- a/pkg/mock/storagedriver.mock.go
+++ b/pkg/mock/storagedriver.mock.go
@@ -85,6 +85,21 @@ func (mr *MockDriverMockRecorder) GetKVDBPodSpec(arg0, arg1 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKVDBPodSpec", reflect.TypeOf((*MockDriver)(nil).GetKVDBPodSpec), arg0, arg1)
 }
 
+// GetNodesSelectedForUpgrade mocks base method.
+func (m *MockDriver) GetNodesSelectedForUpgrade(arg0 *v1.StorageCluster, arg1, arg2 []string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNodesSelectedForUpgrade", arg0, arg1, arg2)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNodesSelectedForUpgrade indicates an expected call of GetNodesSelectedForUpgrade.
+func (mr *MockDriverMockRecorder) GetNodesSelectedForUpgrade(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodesSelectedForUpgrade", reflect.TypeOf((*MockDriver)(nil).GetNodesSelectedForUpgrade), arg0, arg1, arg2)
+}
+
 // GetSelectorLabels mocks base method.
 func (m *MockDriver) GetSelectorLabels() map[string]string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: This PR uses the `FilterNonOverlappingNodes` API for portworx versions greater than or equal px versions 3.1.2 to perform portworx upgrades without disrupting the volume quorum. Currently we randomly choose `maxUnavailable` nodes and upgrade them together. With this change we will first filter nodes such that volumes are not disrupted and pick `maxUnavailable` from that list to upgrade together.  
Note that by default this feature is enabled but will be useful only when maxUnavailable value is set in the rolling update strategy. To disable the feature, user will have to add the flag - 
`rollingUpdate:
    disruption:
        allow: true`


**Which issue(s) this PR fixes** (optional)
Closes # PWX-36510

