### PR TITLE
PWX-37884 Refactor px serviceaccount token integration test

### DIFF
--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -496,6 +496,9 @@ func BasicInstallWithPxSaTokenRefresh(tc *types.TestCase) func(*testing.T) {
 		require.NoError(t, err)
 		recreatedToken := string(pxSaSecret.Data[core.ServiceAccountTokenKey])
 		require.NotEqual(t, refreshedToken, recreatedToken, "the token did not get refreshed")
+
+		// Delete and validate the deletion
+		ci_utils.UninstallAndValidateStorageCluster(cluster, t)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Move token verification, that the token inside px runc container is the same as in the created secret, to storage cluster verification.

Verify that the token is refreshed stays in the integration test.