### PR TITLE
Skip px sa token refresh integration test if version prior to 24.2

### DIFF
--- a/test/integration_test/basic_test.go
+++ b/test/integration_test/basic_test.go
@@ -162,6 +162,13 @@ var testStorageClusterBasicCases = []types.TestCase{
 				},
 			},
 		}),
+		ShouldSkip: func(tc *types.TestCase) bool {
+			skip := ci_utils.PxOperatorVersion.LessThan(ci_utils.PxOperatorVer24_2_0)
+			if skip {
+				logrus.Info("Skipping BasicInstallWithPxSaTokenRefresh, because PX Operator version is less than 24.2.0")
+			}
+			return skip
+		},
 		TestFunc: BasicInstallWithPxSaTokenRefresh,
 	},
 	{


### PR DESCRIPTION
Skip PX ServiceAccount token refresh integration test if operator version prior to 24.2.0