### PR TITLE
PWX-38387: Disabling smart and parallel upgrade by default

### DIFF
--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -412,8 +412,12 @@ func (c *disruptionBudget) updateMinAvailableForNodePDB(cluster *corev1.StorageC
 	// Calculate the minimum number of nodes that should be available
 	quorumValue := int(math.Floor(float64(storageNodesCount)/2) + 1)
 	calculatedMinAvailable := quorumValue
+
+	// TODO: Once the feature has been tested well enough, change behavior to enable feature by default
+	// For now, setting default behavior to disable non-disruptive upgrades
+
 	// When non disruptive upgrades is disabled
-	if cluster.Annotations != nil && cluster.Annotations[pxutil.AnnotationsDisableNonDisruptiveUpgrade] == "true" {
+	if cluster.Annotations == nil || cluster.Annotations[pxutil.AnnotationsDisableNonDisruptiveUpgrade] == "" || cluster.Annotations[pxutil.AnnotationsDisableNonDisruptiveUpgrade] == "true" {
 		if cluster.Annotations[pxutil.AnnotationStoragePodDisruptionBudget] == "" {
 			calculatedMinAvailable = storageNodesCount - 1
 		} else if userProvidedMinValue < quorumValue || userProvidedMinValue >= storageNodesCount {

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -1679,7 +1679,7 @@ func GetNodesToUpgrade(cluster *corev1.StorageCluster,
 		}
 	}
 
-	if cluster.Annotations != nil && cluster.Annotations[AnnotationsDisableNonDisruptiveUpgrade] == "true" {
+	if cluster.Annotations == nil || cluster.Annotations[AnnotationsDisableNonDisruptiveUpgrade] == "" || cluster.Annotations[AnnotationsDisableNonDisruptiveUpgrade] == "true" {
 		return canBeUpgradedNodes, cordonedPxNodesMap, nodesDown, nil
 	}
 

--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -9928,6 +9928,10 @@ func TestDoesTelemetryMatch(t *testing.T) {
 	for _, tc := range cases {
 		driverName := "mock-driver"
 		cluster := createStorageCluster()
+		allowDisruption := false
+		cluster.Spec.UpdateStrategy.RollingUpdate.Disruption = &corev1.Disruption{
+			Allow: &allowDisruption,
+		}
 		// use monitoring spec from TC
 		cluster.Spec.Monitoring = tc.old.Monitoring
 		cluster.Spec.Image = "portworx:2.10.1"

--- a/pkg/controller/storagecluster/storagecluster.go
+++ b/pkg/controller/storagecluster/storagecluster.go
@@ -1646,6 +1646,12 @@ func (c *Controller) setStorageClusterDefaults(cluster *corev1.StorageCluster) e
 			maxUnavailable := intstr.FromInt(defaultMaxUnavailablePods)
 			updateStrategy.RollingUpdate.MaxUnavailable = &maxUnavailable
 		}
+		// Temporarily disabling smart and parallel upgrades by setting value of disruption to true
+		if updateStrategy.RollingUpdate.Disruption == nil {
+			disruption := true
+			updateStrategy.RollingUpdate.Disruption = &corev1.Disruption{}
+			updateStrategy.RollingUpdate.Disruption.Allow = &disruption
+		}
 	}
 
 	if toUpdate.Spec.RevisionHistoryLimit == nil {

--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -129,7 +129,9 @@ func (c *Controller) rollingUpdate(cluster *corev1.StorageCluster, hash string, 
 		}
 	}
 	// Non disruptive upgrade of nodes only if update strategy is rolling and if allow disruption is false
-	if cluster.Spec.UpdateStrategy.RollingUpdate == nil || cluster.Spec.UpdateStrategy.RollingUpdate.Disruption == nil || !*cluster.Spec.UpdateStrategy.RollingUpdate.Disruption.Allow {
+	// TODO: Enable the feature by default once the feature has been tested well enough
+	// For the time being, the feature will be disabled by default and user can enable by setting Disruption to false
+	if cluster.Spec.UpdateStrategy.RollingUpdate != nil && cluster.Spec.UpdateStrategy.RollingUpdate.Disruption != nil && !*cluster.Spec.UpdateStrategy.RollingUpdate.Disruption.Allow {
 		oldAvailablePods, err = c.parallelUpgradeNodesList(cluster, oldAvailablePods, unavailableNodes, storageNodeList)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: We will disable the non disruptive upgrades for kubernetes and portworx by default until more testing is done
1. **Portworx upgrades:**
By default `disruptions` field of RollingUpdate will be set to true. To enable the feature, user needs to set the value to false

2.  **Kubernetes Upgrades:**
By default no annotation will be added, and will be considered as the feature is disabled. The user can also add annotation `"portworx.io/disable-non-disruptive-upgrade":true` to disable the feature. To enable it, the user will need to add the annotation with the value false 
