### PR TITLE
PWX-38103 Ignore unhealthy nodes if a healthy one is found

### DIFF
--- a/pkg/controller/storagecluster/controller_test.go
+++ b/pkg/controller/storagecluster/controller_test.go
@@ -4449,7 +4449,12 @@ func TestUpdateStorageClusterBasedOnStorageNodeStatuses(t *testing.T) {
 	var storageNodes []*storageapi.StorageNode
 	storageNodes = append(storageNodes, createStorageNode("k8s-node-0", true))
 	storageNodes = append(storageNodes, createStorageNode("k8s-node-1", true))
+	// Create duplicate storage nodes with unhealthy statuses and one with healthy status.
+	// We need to verify that the one with healthy status is considered when calculating
+	// what nodes to upgrade next.
+	storageNodes = append(storageNodes, createStorageNode("k8s-node-2", false))
 	storageNodes = append(storageNodes, createStorageNode("k8s-node-2", true))
+	storageNodes = append(storageNodes, createStorageNode("k8s-node-2", false))
 	storageNodes = append(storageNodes, createStorageNode("not-k8s-node", false))
 
 	driver.EXPECT().Validate(gomock.Any()).Return(nil).AnyTimes()
@@ -4508,7 +4513,7 @@ func TestUpdateStorageClusterBasedOnStorageNodeStatuses(t *testing.T) {
 	require.Empty(t, podControl.DeletePodName)
 
 	// TestCase: Mark the unhealthy storage node to healthy, the update should begin.
-	storageNodes[3].Status = storageapi.Status_STATUS_OK
+	storageNodes[5].Status = storageapi.Status_STATUS_OK
 	result, err = controller.Reconcile(context.TODO(), request)
 	require.NoError(t, err)
 	require.Empty(t, result)


### PR DESCRIPTION
for the same k8s node. If one healthy node is found then there is a PX node which is healthy on that k8s node. The unhealthy ones are present because they were previously running on that k8s node before. Such nodes will either find a new k8s node or will get auto-decommissioned in case of a storageless nodes.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-38103

**Special notes for your reviewer**:
- UTs added
- Manually tested with a local mode vsphere setup where storageless nodes become new storageless nodes on restart.
