### PR TITLE
PWX-38471: Merge dmthin operator changes to release-24.2.0 branch 

### DIFF
--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -824,6 +824,8 @@ func (t *template) getCloudProvider() string {
 	} else if pxutil.IsPKS(t.cluster) {
 		// PKS runs on non-vsphere too but we haven't seen any customers doing so.
 		return cloudops.Vsphere
+	} else if pxutil.IsPure(t.cluster) {
+		return cloudops.Pure
 	}
 
 	return ""

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -315,6 +315,15 @@ func (p *portworx) preflightShouldRun(toUpdate *corev1.StorageCluster) bool {
 		return true
 	}
 
+	isSupportedOCP, err := pxutil.IsSupportedOCPVersion(p.k8sClient, pxutil.OpenshiftPxSupportedVersion)
+	if err != nil {
+		logrus.Errorf("Error checking for OpenShift version %s", err.Error())
+		return false
+	}
+	if preflight.IsVsphere() && isSupportedOCP { // Preflight runs on Vsphere and OCP 4.13+
+		return true
+	}
+
 	return false // All else disable
 }
 

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -328,13 +328,6 @@ func (p *portworx) preflightShouldRun(toUpdate *corev1.StorageCluster) bool {
 		}
 	}
 
-	pxVer312, _ := version.NewVersion("3.1.2")
-	if clusterPXver.GreaterThanOrEqual(pxVer312) { // PX version is 3.1.2 or above
-		if pxutil.IsPure(toUpdate) && isSupportedOCP { // Preflight runs on FACD and OCP 4.13+
-			return true
-		}
-	}
-
 	return false // All else disable
 }
 

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -320,8 +320,19 @@ func (p *portworx) preflightShouldRun(toUpdate *corev1.StorageCluster) bool {
 		logrus.Errorf("Error checking for OpenShift version %s", err.Error())
 		return false
 	}
-	if preflight.IsVsphere() && isSupportedOCP { // Preflight runs on Vsphere and OCP 4.13+
-		return true
+
+	pxVer31, _ := version.NewVersion("3.1")
+	if clusterPXver.GreaterThanOrEqual(pxVer31) { // PX version is 3.1.0 or above
+		if pxutil.IsVsphere(toUpdate) && isSupportedOCP { // Preflight runs on Vsphere and OCP 4.13+
+			return true
+		}
+	}
+
+	pxVer312, _ := version.NewVersion("3.1.2")
+	if clusterPXver.GreaterThanOrEqual(pxVer312) { // PX version is 3.1.2 or above
+		if pxutil.IsPure(toUpdate) && isSupportedOCP { // Preflight runs on FACD and OCP 4.13+
+			return true
+		}
 	}
 
 	return false // All else disable

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -315,19 +315,6 @@ func (p *portworx) preflightShouldRun(toUpdate *corev1.StorageCluster) bool {
 		return true
 	}
 
-	isSupportedOCP, err := pxutil.IsSupportedOCPVersion(p.k8sClient, pxutil.OpenshiftPxSupportedVersion)
-	if err != nil {
-		logrus.Errorf("Error checking for OpenShift version %s", err.Error())
-		return false
-	}
-
-	pxVer31, _ := version.NewVersion("3.1")
-	if clusterPXver.GreaterThanOrEqual(pxVer31) { // PX version is 3.1.0 or above
-		if pxutil.IsVsphere(toUpdate) && isSupportedOCP { // Preflight runs on Vsphere and OCP 4.13+
-			return true
-		}
-	}
-
 	return false // All else disable
 }
 

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -410,6 +410,7 @@ func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
 		if pxutil.IsVsphere(u.cluster) {
 			cmetaData = DefCmetaVsphere
 		} else if pxutil.IsPure(u.cluster) {
+			cmetaData = DefCmetaFACD
 			var podNameOption string
 		specsItr:
 			for _, spec := range *u.cluster.Spec.CloudStorage.DeviceSpecs {
@@ -422,7 +423,9 @@ func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
 					}
 				}
 			}
-			cmetaData = fmt.Sprintf("%s,%s", DefCmetaFACD, podNameOption)
+			if len(podNameOption) > 0 {
+				cmetaData = fmt.Sprintf("%s,%s", cmetaData, podNameOption)
+			}
 		}
 		u.cluster.Spec.CloudStorage.SystemMdDeviceSpec = &cmetaData
 	}

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -410,7 +410,19 @@ func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
 		if pxutil.IsVsphere(u.cluster) {
 			cmetaData = DefCmetaVsphere
 		} else if pxutil.IsPure(u.cluster) {
-			cmetaData = DefCmetaFACD
+			var podNameOption string
+		specsItr:
+			for _, spec := range *u.cluster.Spec.CloudStorage.DeviceSpecs {
+				options := strings.Split(spec, ",")
+				for _, option := range options {
+					keyValPair := strings.Split(option, "=")
+					if len(keyValPair) == 2 && keyValPair[0] == "pod" {
+						podNameOption = option
+						break specsItr
+					}
+				}
+			}
+			cmetaData = fmt.Sprintf("%s,%s", DefCmetaFACD, podNameOption)
 		}
 		u.cluster.Spec.CloudStorage.SystemMdDeviceSpec = &cmetaData
 	}

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -37,6 +37,8 @@ const (
 	DefCmetaAWS = "type=gp3,size=64"
 	// DefCmetaVsphere default metadata cloud device for DMthin Vsphere
 	DefCmetaVsphere    = "type=eagerzeroedthick,size=64"
+	// DefCmetaFACD default metadata cloud device for DMthin FACD
+	DefCmetaFACD    = "size=64"
 	preFlightOutputLog = "/var/cores/px-pre-flight-output.log"
 	// Fatal result string from pre-flight check
 	Fatal = "fatal"
@@ -407,6 +409,8 @@ func (u *preFlightPortworx) processPassedChecks(recorder record.EventRecorder) {
 		cmetaData := DefCmetaAWS
 		if pxutil.IsVsphere(u.cluster) {
 			cmetaData = DefCmetaVsphere
+		} else if pxutil.IsPure(u.cluster) {
+			cmetaData = DefCmetaFACD
 		}
 		u.cluster.Spec.CloudStorage.SystemMdDeviceSpec = &cmetaData
 	}

--- a/drivers/storage/portworx/preflight.go
+++ b/drivers/storage/portworx/preflight.go
@@ -36,9 +36,9 @@ const (
 	// DefCmetaData default metadata cloud device for DMthin AWS
 	DefCmetaAWS = "type=gp3,size=64"
 	// DefCmetaVsphere default metadata cloud device for DMthin Vsphere
-	DefCmetaVsphere    = "type=eagerzeroedthick,size=64"
+	DefCmetaVsphere = "type=eagerzeroedthick,size=64"
 	// DefCmetaFACD default metadata cloud device for DMthin FACD
-	DefCmetaFACD    = "size=64"
+	DefCmetaFACD       = "size=64"
 	preFlightOutputLog = "/var/cores/px-pre-flight-output.log"
 	// Fatal result string from pre-flight check
 	Fatal = "fatal"

--- a/drivers/storage/portworx/preflight_test.go
+++ b/drivers/storage/portworx/preflight_test.go
@@ -13,6 +13,7 @@ import (
 func TestDmthinFacdDefCmeta(t *testing.T) {
 	fakeRecorder := record.NewFakeRecorder(10)
 
+	// with pod name
 	u := &preFlightPortworx{
 		cluster: &corev1.StorageCluster{
 			Spec: corev1.StorageClusterSpec{
@@ -47,4 +48,40 @@ func TestDmthinFacdDefCmeta(t *testing.T) {
 	err := u.ProcessPreFlightResults(fakeRecorder, storageNodes)
 	require.Nil(t, err)
 	require.Equal(t, fmt.Sprintf("%s,%s", DefCmetaFACD, "pod=testpod"), *u.cluster.Spec.CloudStorage.SystemMdDeviceSpec)
+
+	// without pod name
+	u = &preFlightPortworx{
+		cluster: &corev1.StorageCluster{
+			Spec: corev1.StorageClusterSpec{
+				CommonConfig: corev1.CommonConfig{
+					Env: []v1.EnvVar{
+						{
+							Name:  "PURE_FLASHARRAY_SAN_TYPE",
+							Value: "PURE_FLASHARRAY_SAN_TYPE",
+						},
+					},
+				},
+				CloudStorage: &corev1.CloudStorageSpec{
+					CloudStorageCommon: corev1.CloudStorageCommon{
+						DeviceSpecs: &[]string{"size=49"},
+					},
+				},
+			},
+		},
+		hardFail: true,
+	}
+	storageNodes = []*corev1.StorageNode{
+		{
+			Status: corev1.NodeStatus{
+				Checks: []corev1.CheckResult{
+					{
+						Type: "status",
+					},
+				},
+			},
+		},
+	}
+	err = u.ProcessPreFlightResults(fakeRecorder, storageNodes)
+	require.Nil(t, err)
+	require.Equal(t, DefCmetaFACD, *u.cluster.Spec.CloudStorage.SystemMdDeviceSpec)
 }

--- a/drivers/storage/portworx/preflight_test.go
+++ b/drivers/storage/portworx/preflight_test.go
@@ -1,0 +1,50 @@
+package portworx
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "github.com/libopenstorage/operator/pkg/apis/core/v1"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+func TestDmthinFacdDefCmeta(t *testing.T) {
+	fakeRecorder := record.NewFakeRecorder(10)
+
+	u := &preFlightPortworx{
+		cluster: &corev1.StorageCluster{
+			Spec: corev1.StorageClusterSpec{
+				CommonConfig: corev1.CommonConfig{
+					Env: []v1.EnvVar{
+						{
+							Name:  "PURE_FLASHARRAY_SAN_TYPE",
+							Value: "PURE_FLASHARRAY_SAN_TYPE",
+						},
+					},
+				},
+				CloudStorage: &corev1.CloudStorageSpec{
+					CloudStorageCommon: corev1.CloudStorageCommon{
+						DeviceSpecs: &[]string{"size=49,pod=testpod"},
+					},
+				},
+			},
+		},
+		hardFail: true,
+	}
+	storageNodes := []*corev1.StorageNode{
+		{
+			Status: corev1.NodeStatus{
+				Checks: []corev1.CheckResult{
+					{
+						Type: "status",
+					},
+				},
+			},
+		},
+	}
+	err := u.ProcessPreFlightResults(fakeRecorder, storageNodes)
+	require.Nil(t, err)
+	require.Equal(t, fmt.Sprintf("%s,%s", DefCmetaFACD, "pod=testpod"), *u.cluster.Spec.CloudStorage.SystemMdDeviceSpec)
+}

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -270,7 +270,6 @@ const (
 	OpenshiftPrometheusSupportedVersion = "4.12"
 	Openshift_4_15_Version              = "4.15"
 	Openshift_4_16_version              = "4.16"
-	OpenshiftPxSupportedVersion         = "4.13"
 	// OpenshiftMonitoringRouteName name of OCP user-workload route
 	OpenshiftMonitoringRouteName = "thanos-querier"
 	// OpenshiftMonitoringRouteName namespace of OCP user-workload route

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -270,6 +270,7 @@ const (
 	OpenshiftPrometheusSupportedVersion = "4.12"
 	Openshift_4_15_Version              = "4.15"
 	Openshift_4_16_version              = "4.16"
+	OpenshiftPxSupportedVersion         = "4.13"
 	// OpenshiftMonitoringRouteName name of OCP user-workload route
 	OpenshiftMonitoringRouteName = "thanos-querier"
 	// OpenshiftMonitoringRouteName namespace of OCP user-workload route

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -413,7 +413,7 @@ func GetCloudProvider(cluster *corev1.StorageCluster) string {
 	if IsVsphere(cluster) {
 		return cloudops.Vsphere
 	} else if IsPure(cluster) {
-	    return cloudops.Pure
+		return cloudops.Pure
 	}
 	// TODO: implement conditions for other providers
 	return ""

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -399,10 +399,21 @@ func IsVsphere(cluster *corev1.StorageCluster) bool {
 	return false
 }
 
+// IsPure returns true if PURE_SAN_TYPE  is present in the spec
+func IsPure(cluster *corev1.StorageCluster) bool {
+	envValue, exists := GetClusterEnvValue(cluster, "PURE_FLASHARRAY_SAN_TYPE")
+	if exists && len(envValue) > 0 {
+		return true
+	}
+	return false
+}
+
 // GetCloudProvider returns the cloud provider string
 func GetCloudProvider(cluster *corev1.StorageCluster) string {
 	if IsVsphere(cluster) {
 		return cloudops.Vsphere
+	} else if IsPure(cluster) {
+	    return cloudops.Pure
 	}
 	// TODO: implement conditions for other providers
 	return ""
@@ -564,6 +575,14 @@ func IncludeCSISnapshotController(cluster *corev1.StorageCluster) bool {
 	return cluster.Spec.CSI != nil && cluster.Spec.CSI.InstallSnapshotController != nil && *cluster.Spec.CSI.InstallSnapshotController
 }
 
+func TrimVersionString(version string) string {
+	if idx := strings.Index(version, "-"); idx != -1 {
+		return version[:idx]
+	}
+
+	return version
+}
+
 // GetPortworxVersion returns the Portworx version based on the Spec data provided.
 // We first try to extract the image from the PX_IMAGE env variable if specified,
 // If not specified then we use Spec.Image, if the version extraction fails for any
@@ -590,6 +609,7 @@ func GetPortworxVersion(cluster *corev1.StorageCluster) *version.Version {
 	parts := strings.Split(pxImage, ":")
 	if len(parts) >= 2 {
 		pxVersionStr := parts[len(parts)-1]
+		pxVersionStr = TrimVersionString(pxVersionStr)
 		pxVersion, err = version.NewSemver(pxVersionStr)
 		if err == nil {
 			logrus.Infof("Using version extracted from image name: %s", pxVersionStr)

--- a/pkg/preflight/utils.go
+++ b/pkg/preflight/utils.go
@@ -29,6 +29,10 @@ func IsAWS() bool {
 	return Instance().ProviderName() == string(cloudops.AWS)
 }
 
+func IsVsphere() bool {
+	return Instance().ProviderName() == string(cloudops.Vsphere)
+}
+
 // RequiresCheck returns whether a preflight check is needed based on the platform
 func RequiresCheck() bool {
 	return Instance().ProviderName() == string(cloudops.AWS) ||

--- a/pkg/preflight/utils.go
+++ b/pkg/preflight/utils.go
@@ -33,10 +33,15 @@ func IsVsphere() bool {
 	return Instance().ProviderName() == string(cloudops.Vsphere)
 }
 
+func IsPure() bool {
+	return Instance().ProviderName() == string(cloudops.Pure)
+}
+
 // RequiresCheck returns whether a preflight check is needed based on the platform
 func RequiresCheck() bool {
 	return Instance().ProviderName() == string(cloudops.AWS) ||
-		Instance().ProviderName() == string(cloudops.Vsphere)
+		Instance().ProviderName() == string(cloudops.Vsphere) ||
+		Instance().ProviderName() == string(cloudops.Pure)
 }
 
 // RunningOnCloud checks whether portworx is running on cloud

--- a/pkg/preflight/utils.go
+++ b/pkg/preflight/utils.go
@@ -29,14 +29,6 @@ func IsAWS() bool {
 	return Instance().ProviderName() == string(cloudops.AWS)
 }
 
-func IsVsphere() bool {
-	return Instance().ProviderName() == string(cloudops.Vsphere)
-}
-
-func IsPure() bool {
-	return Instance().ProviderName() == string(cloudops.Pure)
-}
-
 // RequiresCheck returns whether a preflight check is needed based on the platform
 func RequiresCheck() bool {
 	return Instance().ProviderName() == string(cloudops.AWS) ||


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Merge dmthin operator changes to release-24.2.0 branch
Changes include enabling detection of pure and vsphere cloud provider and handling metadevicespec addition.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-38471

Operator regression test runs
https://jenkins.pwx.dev.purestorage.com/job/Users/job/svijaykumar/job/dev-op-basic/68/
https://jenkins.pwx.dev.purestorage.com/job/Users/job/svijaykumar/job/dev-op-basic/69/

**Special notes for your reviewer**:

dmthin ocp facd fc checklist : https://purestorage.atlassian.net/wiki/spaces/PM/pages/3160768515/Dmthin+on+OCP+with+FACD+-+Feature+Complete+Checklist

testrail milestone : https://portworx.testrail.net/index.php?/milestones/view/664
Functional test plan : https://purestorage.atlassian.net/wiki/spaces/~712020c57cf51b356b453ea13ad74fdcda0bc6/pages/3174170625/PX-storev2+OCP-FACD+Functional+Test+Plan


