### PR TITLE
Zoran's cherry picks  (#1553) (#1574) (#1588) (#1591) (#1594) (#1603) (#1604)

### DIFF
--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -336,18 +336,18 @@ func updateDataIfNginxConfigMap(cm *v1.ConfigMap, storageNs string) {
     http {
       server {
         listen 8080;
-          server_name px-plugin-proxy.` + storageNs + `.svc.cluster.local;
+          server_name px-plugin-proxy.` + storageNs + `;
         location / {
-          proxy_pass http://portworx-api.` + storageNs + `.svc.cluster.local:9021;
+          proxy_pass http://portworx-api.` + storageNs + `:9021;
         }
       }
       server {
         listen 8443 ssl;
-        server_name px-plugin-proxy.` + storageNs + `.svc.cluster.local;
+        server_name px-plugin-proxy.` + storageNs + `;
         ssl_certificate /etc/nginx/certs/tls.crt;
         ssl_certificate_key /etc/nginx/certs/tls.key;
         location / {
-          proxy_pass http://portworx-api.` + storageNs + `.svc.cluster.local:9021;
+          proxy_pass http://portworx-api.` + storageNs + `:9021;
         }
       }
     }`,

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -839,6 +839,11 @@ func (t *telemetry) createDeploymentTelemetryRegistration(
 		container := &deployment.Spec.Template.Spec.Containers[i]
 		if container.Name == containerNameTelemetryRegistration {
 			container.Image = telemetryImage
+			// add APPLIANCE_ID env var
+			container.Env = append(container.Env, v1.EnvVar{
+				Name:  configParameterApplianceID,
+				Value: cluster.Status.ClusterUID,
+			})
 		} else if container.Name == containerNameTelemetryProxy {
 			container.Image = proxyImage
 		}

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -867,13 +867,12 @@ func (t *telemetry) createDeploymentTelemetryRegistration(
 
 	// have a valid cluster UUID?  lets validate the Telemetry SSL cert
 	if cuuid := cluster.Status.ClusterUID; cuuid != "" {
-		if certBytes, err := t.getTelemetrySSLCert(deployment.Namespace); err != nil {
-			logrus.WithError(err).Errorf("failed to get telemetry SSL cert")
-		} else if err2 := t.validateTelemetrySSLCert(certBytes, cuuid); err2 == errInvalidTelemetryCert {
+		sec, err := t.validateTelemetrySSLCert(deployment.Namespace, cuuid)
+		if err == errInvalidTelemetryCert {
 			logrus.Warn("refreshing telemetry SSL cert")
-			t.refreshTelemetrySSLCert(deployment)
-		} else if err2 != nil {
-			logrus.WithError(err2).Errorf("failed to validate telemetry SSL cert")
+			t.refreshTelemetrySSLCert(sec)
+		} else if err != nil {
+			logrus.WithError(err).Errorf("failed to validate telemetry SSL cert")
 		}
 	}
 
@@ -1048,33 +1047,35 @@ func (t *telemetry) createDeploymentTelemetryCollectorV2(
 	return nil
 }
 
-// getTelemetrySSLCert returns the telemetry SSL cert
-func (t *telemetry) getTelemetrySSLCert(namespace string) ([]byte, error) {
+// validateTelemetrySSLCert validates the telemetry SSL certificate.
+// - note: cert's Psaudonym needs to match the cluster UUID
+func (t *telemetry) validateTelemetrySSLCert(namespace, cuuid string) (*v1.Secret, error) {
+	if namespace == "" || cuuid == "" {
+		return nil, fmt.Errorf("invalid namespace or cluster UUID")
+	}
+
 	var sec v1.Secret
 	logrus.Debugf("Inspecting secret %s/%s for SSL cert", namespace, pxutil.TelemetryCertName)
 	err := k8sutil.GetSecret(t.k8sClient, pxutil.TelemetryCertName, namespace, &sec)
 	if err != nil {
 		return nil, err
 	}
-	return sec.Data["cert"], nil
-}
 
-// validateTelemetrySSLCert validates the telemetry SSL certificate.
-// - note: cert's Psaudonym needs to match the cluster UUID
-func (t *telemetry) validateTelemetrySSLCert(certBytes []byte, cuuid string) error {
-	if len(certBytes) <= 0 || cuuid == "" {
-		return nil
+	certBytes := sec.Data["cert"]
+	if len(certBytes) <= 0 {
+		logrus.Warnf("SSL cert not found in secret %s/%s", namespace, pxutil.TelemetryCertName)
+		return &sec, nil
 	}
 
 	block, _ := pem.Decode(certBytes)
 	if block == nil {
-		return fmt.Errorf("failed to decode SSL certificate")
+		return &sec, fmt.Errorf("failed to decode SSL certificate")
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return err
+		return &sec, err
 	} else if cert == nil {
-		return fmt.Errorf("failed to parse SSL certificate")
+		return &sec, fmt.Errorf("failed to parse SSL certificate")
 	}
 
 	// find Pseudonym in Subject names
@@ -1084,38 +1085,43 @@ func (t *telemetry) validateTelemetrySSLCert(certBytes []byte, cuuid string) err
 			var ok bool
 			// quick sanity check!
 			if pseudonym, ok = v.Value.(string); !ok {
-				return fmt.Errorf("SSL cert Pseudonym is not a string")
+				return &sec, fmt.Errorf("SSL cert Pseudonym is not a string")
 			}
 			break
 		}
 	}
 	if pseudonym == "" {
 		logrus.Errorf("SSL cert Pseudonym not found")
-		return errInvalidTelemetryCert
+		return &sec, errInvalidTelemetryCert
 	}
 
 	if pseudonym != cuuid {
 		logrus.Errorf("SSL cert Pseudonym %s does not match cluster UUID %s",
 			pseudonym, cuuid)
-		return errInvalidTelemetryCert
+		return &sec, errInvalidTelemetryCert
 	}
-	logrus.Debugf("SSL cert Pseudonym %s matches cluster UUID", pseudonym)
-	return nil
+	logrus.Tracef("SSL cert Pseudonym %s matches cluster UUID", pseudonym)
+	return &sec, nil
 }
 
 // refreshTelemetrySSLCert deletes the telemetry SSL cert secret and telemetry-registration PODs
-func (t *telemetry) refreshTelemetrySSLCert(dep *appsv1.Deployment) {
-	if dep == nil {
+func (t *telemetry) refreshTelemetrySSLCert(sec *v1.Secret) {
+	if sec == nil {
+		return
+	} else if sec.Name != pxutil.TelemetryCertName {
+		logrus.Errorf("invalid secret name %s/%s  (expected %s)", sec.Namespace, sec.Name, pxutil.TelemetryCertName)
 		return
 	}
-	logrus.Warnf("refreshTelemetrySSLCert - deleting telemetry SSL cert secret %s/%s", dep.Namespace, pxutil.TelemetryCertName)
-	err := k8sutil.DeleteSecret(t.k8sClient, pxutil.TelemetryCertName, dep.Namespace, dep.OwnerReferences...)
+
+	logrus.Warnf("refreshTelemetrySSLCert - deleting telemetry SSL cert secret %s/%s", sec.Namespace, sec.Name)
+	err := t.k8sClient.Delete(context.TODO(), sec)
 	if err != nil {
-		logrus.WithError(err).Warnf("failed to delete secret %s/%s", dep.Namespace, pxutil.TelemetryCertName)
+		logrus.WithError(err).Errorf("failed to delete secret %s/%s", sec.Namespace, sec.Name)
+		return
 	}
 
 	logrus.Warnf("refreshTelemetrySSLCert - deleting POD labeled role=%s", DeploymentNameTelemetryRegistration)
-	err = k8sutil.DeletePodsByLabel(t.k8sClient, map[string]string{"role": DeploymentNameTelemetryRegistration}, dep.Namespace)
+	err = k8sutil.DeletePodsByLabel(t.k8sClient, map[string]string{"role": DeploymentNameTelemetryRegistration}, sec.Namespace)
 	if err != nil {
 		logrus.WithError(err).Warnf("failed to delete px-telemetry-registration POD")
 	}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -16302,6 +16302,96 @@ func TestTelemetrySecretDeletion(t *testing.T) {
 	require.Empty(t, secret.OwnerReferences)
 }
 
+func TestTelemetrySecretRefresh(t *testing.T) {
+	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	recorder := record.NewFakeRecorder(10)
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), recorder)
+	require.NoError(t, err)
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Image: "portworx/oci-monitor:3.2.0",
+			Monitoring: &corev1.MonitoringSpec{
+				Telemetry: &corev1.TelemetrySpec{
+					Enabled: true,
+				},
+			},
+			DeleteStrategy: &corev1.StorageClusterDeleteStrategy{
+				Type: corev1.UninstallAndWipeStorageClusterStrategyType,
+			},
+		},
+		Status: corev1.StorageClusterStatus{
+			ClusterUID: "test-clusteruid",
+		},
+	}
+
+	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
+	require.NotEmpty(t, ownerRef)
+
+	err = k8sClient.Create(
+		context.TODO(),
+		&v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            component.TelemetryCertName,
+				Namespace:       cluster.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+			Data: map[string][]byte{
+				"cert": []byte(`-----BEGIN CERTIFICATE-----
+MIIFEzCCA3ugAwIBAgIDASXwMA0GCSqGSIb3DQEBCwUAMFkxCzAJBgNVBAYTAlVT
+MRkwFwYDVQQKDBBQdXJlIFN0b3JhZ2UgSW5jMQ4wDAYDVQQLDAVQdXJlMTEfMB0G
+A1UEAwwWUHVyZTEgU3Vib3JkaW5hdGUgQ0EgNDAeFw0yNDA1MTQwNjExNDBaFw0y
+NTA1MTQwNjExNDBaMIHoMQswCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5p
+YTEWMBQGA1UEBxMNTW91bnRhaW4gVmlldzEUMBIGA1UEChMLUHVyZVN0b3JhZ2Ux
+EzARBgNVBAsTClB1cmUgSW5mcmExEDAOBgNVBAMTB3Vua25vd24xLTArBgNVBAUT
+JDMxY2RmNzc0LTk0YTktNDE4MS04MGNkLTIxNWJkZDRmZWI1MzEtMCsGA1UEQRYk
+Yzc1ZTJjYmYtMTc2NS00MDY4LTkxM2QtNzYxODNlNjhmOGNjMREwDwYDVQQEFghw
+b3J0d29yeDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAONBSa5q3wyl
+6qVWZO7KCWZASUDPkFv8y31vtKAoS1jhAe4mDtDWyDxXrBMK9ngdKMpWfrBaoZZQ
+Z7FtOGsaVzansSXZAReYiZj1OFZKZkEEhhulNxHPOV3zKJKQxNOrdGfi0i8ZhlDG
+9YbYIJDeeiJE44UaYn/K+Vs/m+x5K95dFqtXdvIuhL00dVT1DR56pcskprAJ8R+i
+ILTYKkkwn+noeajESpIzdUHdtDbWF/+kw5j+e+CUWxtsKw1xfTz7fj+6Vufemrhw
+MV/DP5fbjS1RBHBhCN3LDFmwPSPJAniDECOYRsiR5eFkIHd42wQOu/EceFMfwjzA
+mtOSQzvQdC0CAwEAAaOB0zCB0DAMBgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFA5o
+8M8qUnCkQY/IRLW9P0hXo2+HMFsGCCsGAQUFBwEBBE8wTTBLBggrBgEFBQcwAYY/
+aHR0cDovL3N1Yi1jYS0wNC5zZWMuY2xvdWQtc3VwcG9ydC5wdXJlc3RvcmFnZS5j
+b206ODA4MC9jYS9vY3NwMA4GA1UdDwEB/wQEAwIEsDATBgNVHSUEDDAKBggrBgEF
+BQcDAjAdBgNVHQ4EFgQUvcvcmGzxsDP2oLRIl72EsV0P12IwDQYJKoZIhvcNAQEL
+BQADggGBAJRfBb4D1ojq8vj006xKpp/eLMyAxMRMuYwzrooDa+U4kdvPlk0ibA3i
+zChg117eRV19mjzTHaVPovwlzfhCqZFYyRR+c0iOFu/DUBBOamMZLx2rcZsnA9XC
+QN/9TIyDnXyup9dG6WAu1z5RW6VPifek1DUjdngj9TiyJQOchwLWD/iBG86Ap2gJ
++zt/G4Nwq5VZOp6qX7zfuW+hY9t8FVAz0X9+ohQHgN2eCxvdajgly4+TpVxybubQ
+tooUqkPNRKZ5P0IT9Do0E1z9ZlAQqGTC5abC9RNwAXf/KpIFpardKC/p5BwOZI2P
+aqDgX/Bcx/XoiRHBtDv450/GnAdgD+1yxFCjVkt3vnJybSgdbYV5f2+Owowc3aUw
+agq/IJO6rOF10LX7cDqVKfoQqbpU80v4Uk1Ls6FntKkzUj6njnpoPWdoFqxJmoDG
+zvz7BX4rQqGCD6ElMHyQM7rdq77/ywgSiRJlFf7eQsWNKTpHueulgqnqdW55pNaW
+JhBhJjN84g==
+-----END CERTIFICATE-----`),
+			},
+		},
+		&client.CreateOptions{},
+	)
+	require.NoError(t, err)
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+	require.Len(t, recorder.Events, 0)
+
+	// male sure invalid secret got deleted
+	secret := v1.Secret{}
+	err = testutil.Get(k8sClient, &secret, component.TelemetryCertName, cluster.Namespace)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
 func TestTelemetryCCMGoRestartPhonehome(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	setUpMockCoreOps(mockCtrl, fakek8sclient.NewSimpleClientset())

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -16303,7 +16303,10 @@ func TestTelemetrySecretDeletion(t *testing.T) {
 }
 
 func TestTelemetrySecretRefresh(t *testing.T) {
-	coreops.SetInstance(coreops.New(fakek8sclient.NewSimpleClientset()))
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	setUpMockCoreOps(mockCtrl, fakek8sclient.NewSimpleClientset())
+
 	reregisterComponents()
 	k8sClient := testutil.FakeK8sClient()
 	recorder := record.NewFakeRecorder(10)

--- a/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
@@ -40,6 +40,8 @@ spec:
       - env:
         - name: CONFIG
           value: config/config_properties_px.yaml
+        - name: APPLIANCE_ID
+          value: test-clusteruid
         image: docker.io/portworx/px-telemetry:4.3.2
         imagePullPolicy: Always
         name: registration

--- a/pkg/util/k8s/k8s.go
+++ b/pkg/util/k8s/k8s.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
@@ -2077,6 +2078,27 @@ func DeleteSecret(
 	return k8sClient.Update(context.TODO(), secret)
 }
 
+// GetSecret gets secret
+func GetSecret(
+	k8sClient client.Client,
+	name string,
+	namespace string,
+	secret *v1.Secret,
+) error {
+	err := k8sClient.Get(
+		context.TODO(),
+		types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+		secret,
+	)
+	if errors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
 // GetCRDFromFile parses a CRD definition filename from crdBaseDir and returns the parsed object
 func GetCRDFromFile(
 	filename string,
@@ -2362,4 +2384,34 @@ func GetDefaultKubeSchedulerImage(k8sVersion *version.Version) string {
 		return prefix + "1.21.4"
 	}
 	return prefix + k8sVersion.String()
+}
+
+// DeletePodsByLabel deletes pods by label, from a given namespace
+func DeletePodsByLabel(
+	k8sClient client.Client,
+	mylabels map[string]string,
+	namespace string,
+) error {
+	podList := &v1.PodList{}
+	err := k8sClient.List(
+		context.TODO(),
+		podList,
+		&client.ListOptions{
+			Namespace:     namespace,
+			LabelSelector: labels.SelectorFromSet(mylabels),
+		},
+	)
+	if err != nil {
+		return err
+	} else if len(podList.Items) <= 0 {
+		return nil
+	}
+
+	for _, pod := range podList.Items {
+		logrus.Debugf("Deleting pod %s/%s", pod.Namespace, pod.Name)
+		if err := k8sClient.Delete(context.TODO(), &pod); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Cherry-picks of "missed commits" 24.1.1 -> 24.2.0 :

* PWX-38007: Telemetry cert-secret refresh fix (#1603) (#1604) - Zoran Rajic, 4 weeks ago
* PWX-36928_24.1.1: telmetry SSL-cert validation (#1553) (#1594) - Zoran Rajic, 6 weeks ago
* PWX-37852_24.1.1: add APPLIANCE_ID env to px-telemetry-registration deployment (#1588) (#1591) - Zoran Rajic, 6 weeks ago
* PWX-36817_PWX-32899_op-24.1.1: Fixing .svc.cluster.local DNS domain (#1574) - Zoran Rajic, 7 weeks ago

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

