### PR TITLE
Cherrypick commits from release 24.1.1 into 24.2.0 release branch

### DIFF
--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -3,9 +3,14 @@ package component
 import (
 	"context"
 	"fmt"
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	authv1 "k8s.io/api/authentication/v1"
+	"k8s.io/kubernetes/pkg/apis/core"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -55,6 +60,14 @@ const (
 	OCPThanosRulerSecretPrefix = "thanos-ruler-token"
 	// Autopilot Secret name for prometheus-user-workload-token
 	AutopilotSecretName = "autopilot-prometheus-auth"
+	// AutopilotPrometheusServiceAccountName name of the prometheus service account for Openshift
+	AutopilotPrometheusServiceAccountName = "autopilot-prometheus"
+	// AutopilotClusterRoleBindingName name of the cluster role binding for Openshift
+	AutopilotPrometheusClusterRoleBindingName = "autopilot-promethues-binding"
+	// OpenshiftClusterRoleName name of the cluster role for Openshift, this role is already present in Openshift
+	OpenshiftClusterViewRoleName = "cluster-monitoring-view"
+	// AutopilotSaTokenRefreshTimeKey time to refresh the service account token
+	AutopilotSaTokenRefreshTimeKey = "autopilotSaTokenRefreshTime"
 )
 
 var (
@@ -116,7 +129,7 @@ var (
 					SecretName: AutopilotSecretName,
 					Items: []v1.KeyToPath{
 						{
-							Key:  "cacert",
+							Key:  "ca.crt",
 							Path: "ca-certificates.crt",
 						},
 					},
@@ -124,6 +137,8 @@ var (
 			},
 		},
 	}
+
+	defaultAutoPilotSaTokenExpirationSeconds = int64(30 * 24 * 60 * 60)
 )
 
 type autopilot struct {
@@ -174,12 +189,30 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 		return err
 	}
 	if c.isOCPUserWorkloadSupported() {
-		if err := c.createSecret(cluster.Namespace, ownerRef); err != nil {
-			// log the error and proceed for deployment creation
-			// if secret is created in next reconcilation loop successfully, deployment will be updated with volume mounts
-			logrus.Errorf("Error during creating secret %v ", err)
+		ocp416plus, err := pxutil.IsSupportedOCPVersion(c.k8sClient, pxutil.Openshift_4_16_version)
+
+		if err != nil {
+			logrus.Errorf("error during checking OCP version: %v ", err)
+		} else {
+			if ocp416plus {
+				// on OCP 4.16 and above, create service account and cluster role binding for OCP Prometheus by default
+				// autopilot requires to access Prometheus metrics
+				if err := c.createServiceAccountForOCP(cluster.Namespace, ownerRef); err != nil {
+					return err
+				}
+				if err := c.createClusterRoleBindingForOCP(cluster.Namespace); err != nil {
+					return err
+				}
+			}
+
+			if err := c.createSecret(cluster.Namespace, ownerRef, ocp416plus); err != nil {
+				// log the error and proceed for deployment creation
+				// if secret is created in next reconcilation loop successfully, deployment will be updated with volume mounts
+				logrus.Errorf("error during creating secret : %v ", err)
+			}
 		}
 	}
+
 	if err := c.createDeployment(cluster, ownerRef); err != nil {
 		return err
 	}
@@ -200,13 +233,21 @@ func (c *autopilot) Delete(cluster *corev1.StorageCluster) error {
 	if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, AutopilotClusterRoleBindingName); err != nil {
 		return err
 	}
-	if err := k8sutil.DeleteDeployment(c.k8sClient, AutopilotDeploymentName, cluster.Namespace, *ownerRef); err != nil {
-		return err
-	}
+
 	if c.isOCPUserWorkloadSupported() {
 		if err := k8sutil.DeleteSecret(c.k8sClient, AutopilotSecretName, cluster.Namespace, *ownerRef); err != nil {
 			return err
 		}
+		if err := k8sutil.DeleteClusterRoleBinding(c.k8sClient, AutopilotPrometheusClusterRoleBindingName); err != nil {
+			return err
+		}
+		if err := k8sutil.DeleteServiceAccount(c.k8sClient, AutopilotPrometheusServiceAccountName, cluster.Namespace, *ownerRef); err != nil {
+			return err
+		}
+	}
+
+	if err := k8sutil.DeleteDeployment(c.k8sClient, AutopilotDeploymentName, cluster.Namespace, *ownerRef); err != nil {
+		return err
 	}
 
 	c.MarkDeleted()
@@ -265,26 +306,115 @@ func (c *autopilot) createConfigMap(
 	return err
 }
 
-func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.OwnerReference) error {
+// createServiceAccountForOCP creates service account for OCP Prometheus
+// autopilot to access Prometheus metrics
+// This is required for OCP 4.16 and above
+func (c *autopilot) createServiceAccountForOCP(namespace string, ownerRef *metav1.OwnerReference) error {
+	return k8sutil.CreateOrUpdateServiceAccount(
+		c.k8sClient,
+		&v1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            AutopilotPrometheusServiceAccountName,
+				Namespace:       namespace,
+				OwnerReferences: []metav1.OwnerReference{*ownerRef},
+			},
+		},
+		ownerRef,
+	)
+}
 
-	token, cert, err := c.getPrometheusTokenAndCert()
-	if err != nil {
-		return err
+// createClusterRoleBindingForOCP creates cluster role binding for OCP Prometheus
+// autopilot to access Prometheus metrics requires cluster-monitoring-view role
+// This is required for OCP 4.16 and above
+func (c *autopilot) createClusterRoleBindingForOCP(namespace string) error {
+	return k8sutil.CreateOrUpdateClusterRoleBinding(
+		c.k8sClient,
+		&rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: AutopilotPrometheusClusterRoleBindingName,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     OpenshiftClusterViewRoleName,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      "ServiceAccount",
+					Name:      AutopilotPrometheusServiceAccountName,
+					Namespace: namespace,
+				},
+			},
+		},
+	)
+}
+
+func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.OwnerReference, ocp416Plus bool) error {
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            AutopilotSecretName,
+			Namespace:       clusterNamespace,
+			OwnerReferences: []metav1.OwnerReference{*ownerRef},
+		},
+	}
+
+	if ocp416Plus {
+		err := k8sutil.GetSecret(c.k8sClient, AutopilotSecretName, clusterNamespace, secret)
+		if err != nil {
+			return fmt.Errorf("error during getting secret %w ", err)
+		}
+
+		if secret.Data != nil {
+			// if secret exists, check if token is expired
+			refreshNeeded, err := pxutil.IsTokenRefreshRequired(secret, AutopilotSaTokenRefreshTimeKey)
+			if err != nil {
+				return fmt.Errorf("error during checking token refresh: %w ", err)
+			}
+			if refreshNeeded {
+				// refresh the token if it is expired
+				logrus.Infof("refreshing token for secret %s/%s", clusterNamespace, AutopilotSecretName)
+				err := c.refreshTokenSecret(secret, clusterNamespace, ownerRef)
+				if err != nil {
+					return fmt.Errorf("failed to check token in secret %s/%s: %w", clusterNamespace, AutopilotSecretName, err)
+				}
+			}
+		} else {
+			// if secret is not created, create the secret
+			// generate token and root ca.crt
+			token, err := generateAPSaToken(clusterNamespace, defaultAutoPilotSaTokenExpirationSeconds)
+			if err != nil {
+				return fmt.Errorf("error during generating token %v ", err)
+			}
+
+			rootCaCrt, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+			if err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("error reading k8s cluster certificate located inside the pod at /var/run/secrets/kubernetes.io/serviceaccount/ca.crt: %w", err)
+			}
+
+			secret.Data = make(map[string][]byte)
+			secret.Data[core.ServiceAccountTokenKey] = []byte(token.Status.Token)
+			secret.Data[core.ServiceAccountRootCAKey] = rootCaCrt
+			secret.Data[AutopilotSaTokenRefreshTimeKey] = []byte(time.Now().UTC().Add(time.Duration(*token.Spec.ExpirationSeconds/2) * time.Second).Format(time.RFC3339))
+		}
+	} else {
+		// OCP 4.15 and below, secret is created if user workload monitoring is enabled
+		// and openshift's prometheus secret is found
+		token, cert, err := c.getPrometheusTokenAndCert()
+		if err != nil {
+			return err
+		}
+
+		// token and ca.crt are updated in every reconcilation loop
+		// to check if it was refreshed
+		secret.Data = make(map[string][]byte)
+		secret.Data[core.ServiceAccountTokenKey] = []byte(token)
+		secret.Data[core.ServiceAccountRootCAKey] = []byte(cert) // change to ca.crt to match the key in the generated in secret by kubernetes
 	}
 
 	return k8sutil.CreateOrUpdateSecret(
 		c.k8sClient,
-		&v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            AutopilotSecretName,
-				Namespace:       clusterNamespace,
-				OwnerReferences: []metav1.OwnerReference{*ownerRef},
-			},
-			Data: map[string][]byte{
-				"token":  []byte(token),
-				"cacert": []byte(cert),
-			},
-		},
+		secret,
 		ownerRef,
 	)
 }
@@ -805,6 +935,37 @@ func (c *autopilot) isOCPUserWorkloadSupported() bool {
 		c.isUserWorkloadSupported = &isSupported
 	}
 	return *c.isUserWorkloadSupported
+}
+
+func (c *autopilot) refreshTokenSecret(secret *v1.Secret, clusterNamespace string, ownerRef *metav1.OwnerReference) error {
+
+	// update the token when it is half way to expiration
+	newToken, err := generateAPSaToken(clusterNamespace, defaultAutoPilotSaTokenExpirationSeconds)
+	if err != nil {
+		return err
+	}
+
+	// update the secret with new token
+	secret.Data[core.ServiceAccountTokenKey] = []byte(newToken.Status.Token)
+	secret.Data[AutopilotSaTokenRefreshTimeKey] = []byte(time.Now().UTC().Add(time.Duration(*newToken.Spec.ExpirationSeconds/2) * time.Second).Format(time.RFC3339))
+	err = k8sutil.CreateOrUpdateSecret(c.k8sClient, secret, ownerRef)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateAPSaToken(clusterNamespace string, expirationSeconds int64) (*authv1.TokenRequest, error) {
+	tokenRequest := &authv1.TokenRequest{
+		Spec: authv1.TokenRequestSpec{
+			ExpirationSeconds: &expirationSeconds,
+		},
+	}
+	tokenResp, err := coreops.Instance().CreateToken(AutopilotPrometheusServiceAccountName, clusterNamespace, tokenRequest)
+	if err != nil {
+		return nil, fmt.Errorf("error creating token from k8s: %w", err)
+	}
+	return tokenResp, nil
 }
 
 // RegisterAutopilotComponent registers the Autopilot component

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -68,6 +68,8 @@ const (
 	OpenshiftClusterViewRoleName = "cluster-monitoring-view"
 	// AutopilotSaTokenRefreshTimeKey time to refresh the service account token
 	AutopilotSaTokenRefreshTimeKey = "autopilotSaTokenRefreshTime"
+	// CaCertPath path to ca.crt in the pod
+	CaCertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
 
 var (
@@ -365,38 +367,22 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 			return fmt.Errorf("error during getting secret %w ", err)
 		}
 
-		if secret.Data != nil {
-			// if secret exists, check if token is expired
-			refreshNeeded, err := pxutil.IsTokenRefreshRequired(secret, AutopilotSaTokenRefreshTimeKey)
-			if err != nil {
-				return fmt.Errorf("error during checking token refresh: %w ", err)
-			}
-			if refreshNeeded {
-				// refresh the token if it is expired
-				logrus.Infof("refreshing token for secret %s/%s", clusterNamespace, AutopilotSecretName)
-				err := c.refreshTokenSecret(secret, clusterNamespace, ownerRef)
-				if err != nil {
-					return fmt.Errorf("failed to check token in secret %s/%s: %w", clusterNamespace, AutopilotSecretName, err)
-				}
-			}
-		} else {
-			// if secret is not created, create the secret
-			// generate token and root ca.crt
-			token, err := generateAPSaToken(clusterNamespace, defaultAutoPilotSaTokenExpirationSeconds)
-			if err != nil {
-				return fmt.Errorf("error during generating token %v ", err)
-			}
-
-			rootCaCrt, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
-			if err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("error reading k8s cluster certificate located inside the pod at /var/run/secrets/kubernetes.io/serviceaccount/ca.crt: %w", err)
-			}
-
-			secret.Data = make(map[string][]byte)
-			secret.Data[core.ServiceAccountTokenKey] = []byte(token.Status.Token)
-			secret.Data[core.ServiceAccountRootCAKey] = rootCaCrt
-			secret.Data[AutopilotSaTokenRefreshTimeKey] = []byte(time.Now().UTC().Add(time.Duration(*token.Spec.ExpirationSeconds/2) * time.Second).Format(time.RFC3339))
+		// check if secret requires update
+		// if update is required, create the token if not present
+		// or refresh the token if it is expired
+		updateRequired, err := isSecretUpdateRequired(secret)
+		if err != nil {
+			return fmt.Errorf("error during checking token refresh: %w", err)
 		}
+
+		if updateRequired {
+			logrus.Infof("refreshing token for secret %s/%s", clusterNamespace, AutopilotSecretName)
+			err := c.updateSecretTokenAndCert(secret, clusterNamespace, ownerRef)
+			if err != nil {
+				return fmt.Errorf("failed to update secret %s/%s: %w", clusterNamespace, AutopilotSecretName, err)
+			}
+		}
+		return nil
 	} else {
 		// OCP 4.15 and below, secret is created if user workload monitoring is enabled
 		// and openshift's prometheus secret is found
@@ -410,13 +396,12 @@ func (c *autopilot) createSecret(clusterNamespace string, ownerRef *metav1.Owner
 		secret.Data = make(map[string][]byte)
 		secret.Data[core.ServiceAccountTokenKey] = []byte(token)
 		secret.Data[core.ServiceAccountRootCAKey] = []byte(cert) // change to ca.crt to match the key in the generated in secret by kubernetes
+		return k8sutil.CreateOrUpdateSecret(
+			c.k8sClient,
+			secret,
+			ownerRef,
+		)
 	}
-
-	return k8sutil.CreateOrUpdateSecret(
-		c.k8sClient,
-		secret,
-		ownerRef,
-	)
 }
 
 func (c *autopilot) createServiceAccount(
@@ -937,22 +922,41 @@ func (c *autopilot) isOCPUserWorkloadSupported() bool {
 	return *c.isUserWorkloadSupported
 }
 
-func (c *autopilot) refreshTokenSecret(secret *v1.Secret, clusterNamespace string, ownerRef *metav1.OwnerReference) error {
+// updateSecretTokenAndCert updates the secret with new token, token refresh timestamp and ca.crt
+func (c *autopilot) updateSecretTokenAndCert(secret *v1.Secret, clusterNamespace string, ownerRef *metav1.OwnerReference) error {
 
-	// update the token when it is half way to expiration
+	// update the token when it is half the way to expiration
 	newToken, err := generateAPSaToken(clusterNamespace, defaultAutoPilotSaTokenExpirationSeconds)
 	if err != nil {
 		return err
 	}
 
-	// update the secret with new token
-	secret.Data[core.ServiceAccountTokenKey] = []byte(newToken.Status.Token)
-	secret.Data[AutopilotSaTokenRefreshTimeKey] = []byte(time.Now().UTC().Add(time.Duration(*newToken.Spec.ExpirationSeconds/2) * time.Second).Format(time.RFC3339))
-	err = k8sutil.CreateOrUpdateSecret(c.k8sClient, secret, ownerRef)
+	// get the root ca.crt from the secret mounted inside the pod
+	// this is required while upgrading from OCP 4.15 to 4.16
+	// since the ca.crt is changed in 4.16 and not managed by openshift
+	rootCaCrt, err := getRootCACert()
 	if err != nil {
 		return err
 	}
-	return nil
+
+	// update the secret with new token and secret
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	secret.Data[core.ServiceAccountTokenKey] = []byte(newToken.Status.Token)
+	secret.Data[core.ServiceAccountRootCAKey] = rootCaCrt
+	// set the token refresh time to half the way of token expiration
+	secret.Data[AutopilotSaTokenRefreshTimeKey] = []byte(time.Now().UTC().Add(time.Duration(*newToken.Spec.ExpirationSeconds/2) * time.Second).Format(time.RFC3339))
+	return k8sutil.CreateOrUpdateSecret(c.k8sClient, secret, ownerRef)
+}
+
+// get the root ca.crt from the secret mounted inside the pod
+func getRootCACert() ([]byte, error) {
+	rootCaCrt, err := os.ReadFile(CaCertPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("error reading k8s cluster certificate located inside the pod at %s : %w", CaCertPath, err)
+	}
+	return rootCaCrt, nil
 }
 
 func generateAPSaToken(clusterNamespace string, expirationSeconds int64) (*authv1.TokenRequest, error) {
@@ -966,6 +970,21 @@ func generateAPSaToken(clusterNamespace string, expirationSeconds int64) (*authv
 		return nil, fmt.Errorf("error creating token from k8s: %w", err)
 	}
 	return tokenResp, nil
+}
+
+// isSecretUpdateRequired checks token expiry and returns true if token needs to be updated
+func isSecretUpdateRequired(secret *v1.Secret) (bool, error) {
+	if secret.Data == nil || len(secret.Data[AutopilotSaTokenRefreshTimeKey]) == 0 {
+		return true, nil
+	}
+	expirationTime, err := time.Parse(time.RFC3339, string(secret.Data[AutopilotSaTokenRefreshTimeKey]))
+	if err != nil {
+		return false, fmt.Errorf("error parsing expiration time: %w", err)
+	}
+	if time.Now().UTC().After(expirationTime) {
+		return true, nil
+	}
+	return false, nil
 }
 
 // RegisterAutopilotComponent registers the Autopilot component

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -6,7 +6,6 @@ import (
 	coreops "github.com/portworx/sched-ops/k8s/core"
 	authv1 "k8s.io/api/authentication/v1"
 	"k8s.io/kubernetes/pkg/apis/core"
-	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -68,8 +67,6 @@ const (
 	OpenshiftClusterViewRoleName = "cluster-monitoring-view"
 	// AutopilotSaTokenRefreshTimeKey time to refresh the service account token
 	AutopilotSaTokenRefreshTimeKey = "autopilotSaTokenRefreshTime"
-	// CaCertPath path to ca.crt in the pod
-	CaCertPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
 
 var (
@@ -190,8 +187,12 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 	if err := c.createClusterRoleBinding(cluster.Namespace); err != nil {
 		return err
 	}
+
+	ocp416plus := false
+	var err error
+
 	if c.isOCPUserWorkloadSupported() {
-		ocp416plus, err := pxutil.IsSupportedOCPVersion(c.k8sClient, pxutil.Openshift_4_16_version)
+		ocp416plus, err = pxutil.IsSupportedOCPVersion(c.k8sClient, pxutil.Openshift_4_16_version)
 
 		if err != nil {
 			logrus.Errorf("error during checking OCP version: %v ", err)
@@ -215,7 +216,7 @@ func (c *autopilot) Reconcile(cluster *corev1.StorageCluster) error {
 		}
 	}
 
-	if err := c.createDeployment(cluster, ownerRef); err != nil {
+	if err := c.createDeployment(cluster, ownerRef, ocp416plus); err != nil {
 		return err
 	}
 	return nil
@@ -533,6 +534,7 @@ func (c *autopilot) setDefaultAutopilotSecret(cluster *corev1.StorageCluster, en
 func (c *autopilot) createDeployment(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
+	ocp416plus bool,
 ) error {
 	imageName := c.getDesiredAutopilotImage(cluster)
 	if imageName == "" {
@@ -607,7 +609,7 @@ func (c *autopilot) createDeployment(
 	}
 	sort.Sort(k8sutil.EnvByName(envVars))
 
-	volumes, volumeMounts := c.getDesiredVolumesAndMounts(cluster)
+	volumes, volumeMounts := c.getDesiredVolumesAndMounts(cluster, ocp416plus)
 
 	var existingImage string
 	var existingCommand []string
@@ -805,11 +807,18 @@ func (c *autopilot) getDesiredAutopilotImage(cluster *corev1.StorageCluster) str
 
 func (c *autopilot) getDesiredVolumesAndMounts(
 	cluster *corev1.StorageCluster,
+	ocp416plus bool,
 ) ([]v1.Volume, []v1.VolumeMount) {
 	volumeSpecs := make([]corev1.VolumeSpec, 0)
 
 	if c.isOCPUserWorkloadSupported() && c.isAutopilotSecretCreated(cluster.Namespace) {
 		for _, v := range openshiftDeploymentVolume {
+			// skip adding ca-cert-volume if OCP 4.16 and above
+			// autopilot pod will use kubernetes crt /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+			// to access prometheus metrics
+			if v.Name == "ca-cert-volume" && ocp416plus {
+				continue
+			}
 			vCopy := v.DeepCopy()
 			volumeSpecs = append(volumeSpecs, *vCopy)
 		}
@@ -931,32 +940,14 @@ func (c *autopilot) updateSecretTokenAndCert(secret *v1.Secret, clusterNamespace
 		return err
 	}
 
-	// get the root ca.crt from the secret mounted inside the pod
-	// this is required while upgrading from OCP 4.15 to 4.16
-	// since the ca.crt is changed in 4.16 and not managed by openshift
-	rootCaCrt, err := getRootCACert()
-	if err != nil {
-		return err
-	}
-
 	// update the secret with new token and secret
 	if secret.Data == nil {
 		secret.Data = make(map[string][]byte)
 	}
 	secret.Data[core.ServiceAccountTokenKey] = []byte(newToken.Status.Token)
-	secret.Data[core.ServiceAccountRootCAKey] = rootCaCrt
 	// set the token refresh time to half the way of token expiration
 	secret.Data[AutopilotSaTokenRefreshTimeKey] = []byte(time.Now().UTC().Add(time.Duration(*newToken.Spec.ExpirationSeconds/2) * time.Second).Format(time.RFC3339))
 	return k8sutil.CreateOrUpdateSecret(c.k8sClient, secret, ownerRef)
-}
-
-// get the root ca.crt from the secret mounted inside the pod
-func getRootCACert() ([]byte, error) {
-	rootCaCrt, err := os.ReadFile(CaCertPath)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("error reading k8s cluster certificate located inside the pod at %s : %w", CaCertPath, err)
-	}
-	return rootCaCrt, nil
 }
 
 func generateAPSaToken(clusterNamespace string, expirationSeconds int64) (*authv1.TokenRequest, error) {

--- a/drivers/storage/portworx/component/portworx_basic.go
+++ b/drivers/storage/portworx/component/portworx_basic.go
@@ -588,7 +588,7 @@ func updateCaCrtIfNeeded(secret *v1.Secret) (bool, error) {
 }
 
 func refreshTokenIfNeeded(secret *v1.Secret, cluster *corev1.StorageCluster) (bool, error) {
-	needRefreshToken, err := isTokenRefreshRequired(secret)
+	needRefreshToken, err := pxutil.IsTokenRefreshRequired(secret, PxSaTokenRefreshTimeKey)
 	if err != nil {
 		return false, err
 	}
@@ -596,20 +596,6 @@ func refreshTokenIfNeeded(secret *v1.Secret, cluster *corev1.StorageCluster) (bo
 		if err := refreshToken(secret, cluster); err != nil {
 			return false, fmt.Errorf("failed to refresh the token secret for px container: %w", err)
 		}
-		return true, nil
-	}
-	return false, nil
-}
-
-func isTokenRefreshRequired(secret *v1.Secret) (bool, error) {
-	if len(secret.Data) == 0 || len(secret.Data[v1.ServiceAccountTokenKey]) == 0 {
-		return true, nil
-	}
-	expirationTime, err := time.Parse(time.RFC3339, string(secret.Data[PxSaTokenRefreshTimeKey]))
-	if err != nil {
-		return false, fmt.Errorf("error parsing expiration time: %w", err)
-	}
-	if time.Now().UTC().After(expirationTime) {
 		return true, nil
 	}
 	return false, nil

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -5291,7 +5291,7 @@ func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
 	require.Equal(t, expectedSecret.Annotations, actualSecret.Annotations)
 
 	// Autopilot Deployment
-	expectedDeployment := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_14.yaml")
+	expectedDeployment := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_16.yaml")
 	autopilotDeployment := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)
@@ -5475,7 +5475,7 @@ func TestAutopilotUpgradeFrom415To416(t *testing.T) {
 	require.NotEmpty(t, expectedSecret416.Data[component.AutopilotSaTokenRefreshTimeKey])
 
 	// Autopilot Deployment on OCP 4.16
-	expectedDeployment416 := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_14.yaml")
+	expectedDeployment416 := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_16.yaml")
 	autopilotDeployment416 := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, autopilotDeployment416, component.AutopilotDeploymentName, cluster.Namespace)
 	require.NoError(t, err)

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -17940,6 +17940,8 @@ func validateTokenLifetime(t *testing.T, cluster *corev1.StorageCluster, jwtClai
 	iatTime := time.Unix(int64(iatFloat64), 0)
 	expTime := time.Unix(int64(expFloat64), 0)
 	tokenLifetime := expTime.Sub(iatTime)
+	// subtract 10 minutes from tokenLifetime to adjust for the iat time creation for ntp sync
+	tokenLifetime = tokenLifetime - 10*time.Minute
 	duration, err := pxutil.ParseExtendedDuration(*cluster.Spec.Security.Auth.SelfSigned.TokenLifetime)
 	require.NoError(t, err)
 	require.Equal(t, tokenLifetime, duration)

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -5080,6 +5080,231 @@ func TestAutopilotInstallAndUninstallOnOpenshift415(t *testing.T) {
 
 }
 
+// For some reason simpleClientset doesn't work with createToken, erroring out with serviceaccounts "" not found.
+// Thus wrap the simpleClientset with MockCoreOps.
+func setUpMockCoreOps(mockCtrl *gomock.Controller, clientset *fakek8sclient.Clientset) *mockcore.MockOps {
+	mockCoreOps := mockcore.NewMockOps(mockCtrl)
+	coreops.SetInstance(mockCoreOps)
+	defaultTokenExpirationSeconds := int64(12 * 60 * 60)
+
+	simpleClientset := coreops.New(clientset)
+	mockCoreOps.EXPECT().
+		CreateToken(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&authv1.TokenRequest{
+			Spec: authv1.TokenRequestSpec{
+				ExpirationSeconds: &defaultTokenExpirationSeconds,
+			},
+			Status: authv1.TokenRequestStatus{
+				Token: "xxxx",
+			},
+		}, nil).
+		AnyTimes()
+	mockCoreOps.EXPECT().
+		GetVersion().
+		Return(clientset.Discovery().ServerVersion()).
+		AnyTimes()
+	mockCoreOps.EXPECT().
+		ResourceExists(gomock.Any()).
+		Return(simpleClientset.ResourceExists(schema.GroupVersionKind{
+			Kind:    pxutil.ClusterOperatorKind,
+			Version: pxutil.ClusterOperatorVersion,
+		})).
+		AnyTimes()
+	return mockCoreOps
+}
+
+// test Autopilot install and Uninstall on ocp cluster 4.16
+func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
+
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Resources = []*metav1.APIResourceList{
+		{
+			GroupVersion: component.ClusterOperatorVersion,
+			APIResources: []metav1.APIResource{
+				{
+					Kind: component.ClusterOperatorKind,
+				},
+			},
+		},
+	}
+	mockCtrl := gomock.NewController(t)
+	setUpMockCoreOps(mockCtrl, versionClient)
+
+	reregisterComponents()
+	operator := &ocpconfig.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: component.OpenshiftAPIServer,
+		},
+		Status: ocpconfig.ClusterOperatorStatus{
+			RelatedObjects: []ocpconfig.ObjectReference{
+				{Name: component.OpenshiftAPIServer},
+			},
+			Versions: []ocpconfig.OperandVersion{
+				{
+					Name:    component.OpenshiftAPIServer,
+					Version: "4.16",
+				},
+			},
+		},
+	}
+	k8sClient := testutil.FakeK8sClient()
+	err := k8sClient.Create(context.TODO(), operator)
+	require.NoError(t, err)
+
+	driver := portworx{}
+	err = driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	stcSpec := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+			Annotations: map[string]string{
+				pxutil.AnnotationPVCController: "true",
+			},
+		},
+		Spec: corev1.StorageClusterSpec{
+			Monitoring: &corev1.MonitoringSpec{Telemetry: &corev1.TelemetrySpec{}},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: true,
+				Image:   "portworx/autopilot:1.1.1",
+				Providers: []corev1.DataProviderSpec{
+					{
+						Name: "default",
+						Type: "prometheus",
+						Params: map[string]string{
+							"url": "http://prometheus:9090",
+						},
+					},
+					{
+						Name: "second",
+						Type: "datadog",
+						Params: map[string]string{
+							"url":  "http://datadog:9090",
+							"auth": "foobar",
+						},
+					},
+				},
+				Args: map[string]string{
+					"min_poll_interval": "4",
+					"log-level":         "info",
+				},
+			},
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					SelfSigned: &corev1.SelfSignedSpec{
+						Issuer:        stringPtr(defaultSelfSignedIssuer),
+						TokenLifetime: stringPtr(defaultTokenLifetime),
+						SharedSecret:  stringPtr(pxutil.SecurityPXSharedSecretSecretName),
+					},
+				},
+			},
+		},
+	}
+
+	cluster := stcSpec.DeepCopy()
+
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	err = driver.PreInstall(cluster)
+	require.NoError(t, err)
+
+	// on OCP 4.16+ , autopilot-prometheus service account will be used for authentication
+	clusterRoleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: component.OpenshiftClusterViewRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				Name:     "example-user",
+				APIGroup: "rbac.authorization.k8s.io",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     "view",
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+
+	err = k8sClient.Create(context.TODO(), clusterRoleBinding)
+	require.NoError(t, err)
+
+	// Autopilot ConfigMap
+	expectedConfigMap := testutil.GetExpectedConfigMap(t, "autopilotConfigMap.yaml")
+	autopilotConfigMap := &v1.ConfigMap{}
+	err = testutil.Get(k8sClient, autopilotConfigMap, component.AutopilotConfigMapName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedConfigMap.Name, autopilotConfigMap.Name)
+	require.Equal(t, expectedConfigMap.Namespace, autopilotConfigMap.Namespace)
+	require.Len(t, autopilotConfigMap.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, autopilotConfigMap.OwnerReferences[0].Name)
+	require.Equal(t, expectedConfigMap.Data, autopilotConfigMap.Data)
+
+	// Autopilot ServiceAccount
+	sa := &v1.ServiceAccount{}
+	err = testutil.Get(k8sClient, sa, component.AutopilotServiceAccountName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, component.AutopilotServiceAccountName, sa.Name)
+	require.Equal(t, cluster.Namespace, sa.Namespace)
+	require.Len(t, sa.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, sa.OwnerReferences[0].Name)
+
+	// Autopilot ClusterRoleBinding
+	expectedCRB := testutil.GetExpectedClusterRoleBinding(t, "autopilotClusterRoleBinding.yaml")
+	actualCRB := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, actualCRB, component.AutopilotClusterRoleBindingName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedCRB.Name, actualCRB.Name)
+	require.Empty(t, actualCRB.OwnerReferences)
+	require.ElementsMatch(t, expectedCRB.Subjects, actualCRB.Subjects)
+	require.Equal(t, expectedCRB.RoleRef, actualCRB.RoleRef)
+
+	// Autopilot Prometheus Service Account
+	expectedSA := &v1.ServiceAccount{}
+	err = testutil.Get(k8sClient, expectedSA, component.AutopilotPrometheusServiceAccountName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, component.AutopilotPrometheusServiceAccountName, expectedSA.Name)
+	require.Equal(t, cluster.Namespace, expectedSA.Namespace)
+	require.Len(t, expectedSA.OwnerReferences, 1)
+	require.Equal(t, cluster.Name, expectedSA.OwnerReferences[0].Name)
+
+	// Autopilot Prometheus Cluster role binding
+	expectedPrometheusCRB := testutil.GetExpectedClusterRoleBinding(t, "autopilotPrometheusClusterRoleBinding.yaml")
+	actualClusterRoleCRB := &rbacv1.ClusterRoleBinding{}
+	err = testutil.Get(k8sClient, actualClusterRoleCRB, component.AutopilotPrometheusClusterRoleBindingName, "")
+	require.NoError(t, err)
+	require.Equal(t, expectedPrometheusCRB.Name, actualClusterRoleCRB.Name)
+	require.Empty(t, actualCRB.OwnerReferences)
+	require.ElementsMatch(t, expectedPrometheusCRB.Subjects, actualClusterRoleCRB.Subjects)
+	require.Equal(t, expectedPrometheusCRB.RoleRef, actualClusterRoleCRB.RoleRef)
+
+	// Autopilot Secret
+	expectedSecret := testutil.GetExpectedSecret(t, "autopilot-auth-token-secret_4_16.yaml")
+	actualSecret := &v1.Secret{}
+	err = testutil.Get(k8sClient, actualSecret, component.AutopilotSecretName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedSecret.Type, actualSecret.Type)
+	require.Equal(t, expectedSecret.Annotations, actualSecret.Annotations)
+
+	// Autopilot Deployment
+	expectedDeployment := testutil.GetExpectedDeployment(t, "autopilotDeployment_Openshift_4_14.yaml")
+	autopilotDeployment := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, expectedDeployment.Spec.Template.Spec.Volumes, autopilotDeployment.Spec.Template.Spec.Volumes)
+	require.Equal(t, expectedDeployment.Spec.Template.Spec.Containers[0].VolumeMounts, autopilotDeployment.Spec.Template.Spec.Containers[0].VolumeMounts)
+
+	autopilotComponent, _ := component.Get(component.AutopilotComponentName)
+	err = autopilotComponent.Delete(cluster)
+	autopilotComponent.MarkDeleted()
+	require.NoError(t, err)
+
+}
+
 func TestSecurityInstall(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	setUpMockCoreOps(mockCtrl, fakek8sclient.NewSimpleClientset())

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -5080,39 +5080,6 @@ func TestAutopilotInstallAndUninstallOnOpenshift415(t *testing.T) {
 
 }
 
-// For some reason simpleClientset doesn't work with createToken, erroring out with serviceaccounts "" not found.
-// Thus wrap the simpleClientset with MockCoreOps.
-func setUpMockCoreOps(mockCtrl *gomock.Controller, clientset *fakek8sclient.Clientset) *mockcore.MockOps {
-	mockCoreOps := mockcore.NewMockOps(mockCtrl)
-	coreops.SetInstance(mockCoreOps)
-	defaultTokenExpirationSeconds := int64(12 * 60 * 60)
-
-	simpleClientset := coreops.New(clientset)
-	mockCoreOps.EXPECT().
-		CreateToken(gomock.Any(), gomock.Any(), gomock.Any()).
-		Return(&authv1.TokenRequest{
-			Spec: authv1.TokenRequestSpec{
-				ExpirationSeconds: &defaultTokenExpirationSeconds,
-			},
-			Status: authv1.TokenRequestStatus{
-				Token: "dG9rZW4tdmFsdWU=",
-			},
-		}, nil).
-		AnyTimes()
-	mockCoreOps.EXPECT().
-		GetVersion().
-		Return(clientset.Discovery().ServerVersion()).
-		AnyTimes()
-	mockCoreOps.EXPECT().
-		ResourceExists(gomock.Any()).
-		Return(simpleClientset.ResourceExists(schema.GroupVersionKind{
-			Kind:    pxutil.ClusterOperatorKind,
-			Version: pxutil.ClusterOperatorVersion,
-		})).
-		AnyTimes()
-	return mockCoreOps
-}
-
 // test Autopilot install and Uninstall on ocp cluster 4.16
 func TestAutopilotInstallAndUninstallOnOpenshift416(t *testing.T) {
 

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -289,7 +289,7 @@ func TestBasicComponentsInstall(t *testing.T) {
 	require.Equal(t, cluster.Name, saTokenSecret.OwnerReferences[0].Name)
 	require.Equal(t, len(expectedPXSaTokenSecret.Data), len(saTokenSecret.Data))
 	require.Equal(t, []byte(cluster.Namespace), saTokenSecret.Data["namespace"])
-	require.Equal(t, []byte("xxxx"), saTokenSecret.Data["token"])
+	require.Equal(t, []byte("dG9rZW4tdmFsdWU="), saTokenSecret.Data["token"])
 
 	// Portworx KVDB Service
 	expectedPXKVDBService := testutil.GetExpectedService(t, "portworxKVDBService.yaml")

--- a/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
+++ b/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
@@ -6,4 +6,3 @@ kind: Secret
 metadata:
   name: autopilot-prometheus-auth
   namespace: kube-test
-type: Opaque

--- a/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
+++ b/drivers/storage/portworx/testspec/autopilot-auth-token-secret_4_16.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 data:
   ca.crt: WTJWeWRHbG1hV05oZEdVdGRtRnNkV1U9
   token: ZEc5clpXNHRkbUZzZFdVPQ==
+  autopilotSaTokenRefreshTime: MjAyMC0wNy0xNlQxNzoxNzoxN1o=
 kind: Secret
 metadata:
   name: autopilot-prometheus-auth

--- a/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_14.yaml
+++ b/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_14.yaml
@@ -125,7 +125,7 @@ spec:
           secret:
             defaultMode: 420
             items:
-              - key: cacert
+              - key: ca.crt
                 path: ca-certificates.crt
             secretName: autopilot-prometheus-auth
         - name: config-volume

--- a/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_16.yaml
+++ b/drivers/storage/portworx/testspec/autopilotDeployment_Openshift_4_16.yaml
@@ -1,0 +1,138 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    tier: control-plane
+  name: autopilot
+  namespace: kube-test
+  ownerReferences:
+    - apiVersion: core.libopenstorage.org/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: StorageCluster
+      name: px-cluster
+spec:
+  selector:
+    matchLabels:
+      name: autopilot
+      tier: control-plane
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: autopilot
+        tier: control-plane
+        operator.libopenstorage.org/managed-by: portworx
+    spec:
+      containers:
+        - command:
+            - /autopilot
+            - --config=/etc/config/config.yaml
+            - --log-level=info
+          imagePullPolicy: Always
+          image: docker.io/portworx/autopilot:1.1.1
+          resources:
+            requests:
+              cpu: 100m
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+          name: autopilot
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config
+            - name: token-volume
+              mountPath: /var/local/secrets
+              readOnly: true
+            - name: varcores
+              mountPath: /var/cores
+          env:
+            - name: PX_NAMESPACE
+              value: kube-test
+            - name: PX_SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: apps-secret
+                  name: px-system-secrets
+      hostPID: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: px/enabled
+                    operator: NotIn
+                    values:
+                      - "false"
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+              - matchExpressions:
+                  - key: px/enabled
+                    operator: NotIn
+                    values:
+                      - "false"
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+                  - key: node-role.kubernetes.io/master
+                    operator: Exists
+                  - key: node-role.kubernetes.io/worker
+                    operator: Exists
+              - matchExpressions:
+                  - key: px/enabled
+                    operator: NotIn
+                    values:
+                      - "false"
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - "linux"
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+                  - key: node-role.kubernetes.io/worker
+                    operator: Exists
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                      - autopilot
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: autopilot
+      volumes:
+        - name: config-volume
+          configMap:
+            name: autopilot-config
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+        - name: token-volume
+          secret:
+            defaultMode: 420
+            items:
+              - key: token
+                path: token
+            secretName: autopilot-prometheus-auth
+        - hostPath:
+            path: /var/cores
+            type: ""
+          name: varcores

--- a/drivers/storage/portworx/testspec/autopilotPrometheusClusterRoleBinding.yaml
+++ b/drivers/storage/portworx/testspec/autopilotPrometheusClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: autopilot-promethues-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+  - kind: ServiceAccount
+    name: autopilot-prometheus
+    namespace: kube-test

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -895,6 +895,8 @@ func GenerateToken(
 	token, err := auth.Token(claims, signature, &auth.Options{
 		Expiration: time.Now().
 			Add(duration).Unix(),
+		// set IAT to 10 minutes in the past to avoid clock skew issues
+		IATSubtract: 10 * time.Minute,
 	})
 	if err != nil {
 		return "", err

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -269,6 +269,7 @@ const (
 	OpenshiftAPIServer                  = "openshift-apiserver"
 	OpenshiftPrometheusSupportedVersion = "4.12"
 	Openshift_4_15_Version              = "4.15"
+	Openshift_4_16_version              = "4.16"
 	// OpenshiftMonitoringRouteName name of OCP user-workload route
 	OpenshiftMonitoringRouteName = "thanos-querier"
 	// OpenshiftMonitoringRouteName namespace of OCP user-workload route
@@ -1532,4 +1533,18 @@ func ShouldUseClusterDomain(node *api.StorageNode) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+func IsTokenRefreshRequired(secret *v1.Secret, tokenRefreshTimeKey string) (bool, error) {
+	if len(secret.Data) == 0 || len(secret.Data[v1.ServiceAccountTokenKey]) == 0 {
+		return true, nil
+	}
+	expirationTime, err := time.Parse(time.RFC3339, string(secret.Data[tokenRefreshTimeKey]))
+	if err != nil {
+		return false, fmt.Errorf("error parsing expiration time: %w", err)
+	}
+	if time.Now().UTC().After(expirationTime) {
+		return true, nil
+	}
+	return false, nil
 }

--- a/drivers/storage/portworx/util/util_test.go
+++ b/drivers/storage/portworx/util/util_test.go
@@ -2,8 +2,11 @@ package util
 
 import (
 	"testing"
+	"time"
 
+	"github.com/golang-jwt/jwt/v4"
 	version "github.com/hashicorp/go-version"
+	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -463,4 +466,55 @@ func TestIsVersionSupported(t *testing.T) {
 
 	supported = isVersionSupported("4.16.0", "4.15.0")
 	require.True(t, supported)
+}
+
+func TestGenerateToken(t *testing.T) {
+	// setup
+	cluster := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcluster",
+			Namespace: "ns",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+			},
+		},
+	}
+
+	inputClaims := &auth.Claims{
+		Issuer:  "testissuer",
+		Subject: "test-subject",
+		Name:    "test-name",
+		Email:   "test-email",
+		Roles:   nil,
+		Groups:  []string{"*"},
+	}
+
+	secretKey := "dummy-secret"
+	currentTime := time.Now()
+
+	tokenStr, err := GenerateToken(cluster, secretKey, inputClaims, 24*time.Hour)
+	require.NoError(t, err)
+
+	// define the Keyfunc
+	keyFunc := func(token *jwt.Token) (interface{}, error) {
+		return []byte(secretKey), nil
+	}
+
+	// parse the jwt token to get the issued time
+	token, err := jwt.Parse(tokenStr, keyFunc)
+	require.NoError(t, err)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+	// get issued time from token
+	iat, ok := claims["iat"].(float64)
+	require.True(t, ok)
+	iatTime := time.Unix(int64(iat), 0)
+
+	// check time difference between issued time and current time
+	// get time difference in minutes truncating milliseconds
+	timeDifferenceInMinutes := currentTime.Sub(iatTime).Truncate(time.Minute).Minutes()
+	require.Equal(t, float64(10), timeDifferenceInMinutes)
 }

--- a/pkg/mock/mockcore/core.ops.mock.go
+++ b/pkg/mock/mockcore/core.ops.mock.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	core "github.com/portworx/sched-ops/k8s/core"
-	v1 "k8s.io/api/authentication/v1"
+	authv1 "k8s.io/api/authentication/v1"
 	v10 "k8s.io/api/certificates/v1"
 	v11 "k8s.io/api/core/v1"
 	v12 "k8s.io/api/networking/v1"
@@ -300,10 +300,10 @@ func (mr *MockOpsMockRecorder) CreateServiceAccount(arg0 interface{}) *gomock.Ca
 }
 
 // CreateToken mocks base method.
-func (m *MockOps) CreateToken(arg0, arg1 string, arg2 *v1.TokenRequest) (*v1.TokenRequest, error) {
+func (m *MockOps) CreateToken(arg0, arg1 string, arg2 *authv1.TokenRequest) (*authv1.TokenRequest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateToken", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*v1.TokenRequest)
+	ret0, _ := ret[0].(*authv1.TokenRequest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
Cherrypicking following tickets into 24.2.0
- @nikita-bhatia
[PWX-37681](https://github.com/libopenstorage/operator/pull/1628/commits/e8abbd5d754e29dc5abca7eaa1df5efb50318eff)
- @nikita-bhatia
[PWX-38004](https://github.com/libopenstorage/operator/pull/1628/commits/1cc450d821991512e52d70064cb988c9f2ffebf4)
- @nikita-bhatia
PWX-38035 
- @nikita-bhatia
[[cherrypick] [24.1.1] PWX-38202](https://github.com/libopenstorage/operator/pull/1628/commits/d80609c77956a0b3f39b63913f861c5022509eb8)
