### PR TITLE
PWX-38512 Skip token refresh verification if host-pid not enabled

### DIFF
--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -1847,6 +1847,13 @@ func validatePortworxTokenRefresh(cluster *corev1.StorageCluster, timeout, inter
 	}
 	pidEnabled, err := strconv.ParseBool(cluster.Annotations["portworx.io/host-pid"])
 	if err != nil || !pidEnabled {
+		pxSaSecret, err := coreops.Instance().GetSecret(pxSaTokenSecretName, cluster.Namespace)
+		if err != nil {
+			return fmt.Errorf("px serviceaccount token validation failed. Unable to get px serviceaccount secret. Err: %w", err)
+		}
+		if len(pxSaSecret.Data[core.ServiceAccountTokenKey]) == 0 {
+			return fmt.Errorf("px serviceaccount token validation failed. Token doesn't exist or length is 0")
+		}
 		logrus.Infof("Annotation `host-pid: true` is required for verifying token refresh because we need to run command inside px runc container. Thus Skipping verification.")
 		return nil
 	}

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -1849,7 +1849,7 @@ func validatePortworxTokenRefresh(cluster *corev1.StorageCluster, timeout, inter
 	if err != nil || !pidEnabled {
 		pxSaSecret, err := coreops.Instance().GetSecret(pxSaTokenSecretName, cluster.Namespace)
 		if err != nil {
-			return fmt.Errorf("px serviceaccount token validation failed. Unable to get px serviceaccount secret. Err: %w", err)
+			return fmt.Errorf("failed to get px serviceaccount secret [%s] in namespace [%s]. Err: %w", pxSaTokenSecretName, cluster.Namespace, err)
 		}
 		if len(pxSaSecret.Data[core.ServiceAccountTokenKey]) == 0 {
 			return fmt.Errorf("px serviceaccount token validation failed. Token doesn't exist or length is 0")

--- a/pkg/util/test/util.go
+++ b/pkg/util/test/util.go
@@ -1845,6 +1845,11 @@ func validatePortworxTokenRefresh(cluster *corev1.StorageCluster, timeout, inter
 		logrus.Infof("pxVersion: %v, opVersion: %v. Skip verification because px token refresh is not supported with these versions.", pxVersion, opVersion)
 		return nil
 	}
+	pidEnabled, err := strconv.ParseBool(cluster.Annotations["portworx.io/host-pid"])
+	if err != nil || !pidEnabled {
+		logrus.Infof("Annotation `host-pid: true` is required for verifying token refresh because we need to run command inside px runc container. Thus Skipping verification.")
+		return nil
+	}
 	logrus.Infof("Verifying px runc container token...")
 	// Get one Portworx pod to run commands inside the px runc container on the same node
 	pxPods, err := coreops.Instance().GetPods(cluster.Namespace, map[string]string{"name": "portworx"})


### PR DESCRIPTION
**What this PR does / why we need it**:
host-pid is required to run nsenter with runc. nsenter without runc is fine is the reason why other verifications are fine.


**Which issue(s) this PR fixes** (optional)
Closes PWX-38512

A full set of integration test is being run at https://jenkins.pwx.dev.purestorage.com/job/Operator/view/Operator%20Release%20Dashboard/job/op-basic-hotfix/