### PR TITLE
PWX-38545 :  Failed to create AlertManager object with prometheus-operator v0.75.0

### DIFF
--- a/drivers/storage/portworx/component/prometheus.go
+++ b/drivers/storage/portworx/component/prometheus.go
@@ -269,6 +269,7 @@ func (c *prometheus) createOperatorClusterRole() error {
 						"alertmanagers",
 						"alertmanagers/finalizers",
 						"alertmanagerconfigs",
+						"alertmanagers/status",
 						"prometheuses",
 						"prometheuses/status",
 						"prometheuses/finalizers",

--- a/drivers/storage/portworx/testspec/prometheusOperatorClusterRole.yaml
+++ b/drivers/storage/portworx/testspec/prometheusOperatorClusterRole.yaml
@@ -20,6 +20,7 @@ rules:
       - alertmanagers
       - alertmanagers/finalizers
       - alertmanagerconfigs
+      - alertmanagers/status
       - prometheuses
       - prometheuses/status
       - prometheuses/finalizers


### PR DESCRIPTION
**What this PR does / why we need it**:
The AlertManager object creation started failing as soon as PrometheusOperator version is upgraded to 0.75.0.
Turns out Prometheus-operator team has updated the RBAC permissions required by the operator to manage CRDs. Because of this, the operator starts requiring permission "update" on resource "alertmanagers/status" and if users don't update the prometheus-operator SA RBAC, the controller starts but it wouldn't work fully.
https://github.com/prometheus-operator/prometheus-operator/pull/6351

Error in px-prometheus-operator pod 
`"missing permission on resource \"alertmanagers\" (group: \"monitoring.coreos.com/v1\")" reason="missing \"update\" permission on resource \"alertmanagers/status\" (group: \"monitoring.coreos.com\") for namespace \"kube-system\""`

What is changed in this PR?
- alertmanagers/status Resource is provided permission in px-prometheus-operator clusterrole

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-38545

**Special notes for your reviewer**:
- Verified on Vanilla k8s cluster, the alert-manager pods started coming up as soon as the permission was added in cluster role.
