### PR TITLE
PWX-38583 : fix nil pointer derefernce in operator pod

### DIFF
--- a/pkg/apis/core/v1/storagecluster.go
+++ b/pkg/apis/core/v1/storagecluster.go
@@ -285,7 +285,7 @@ type RollingUpdateStorageCluster struct {
 // Disruption contains configuration for disruption
 type Disruption struct {
 	// Flag indicates whether updates are non-disruptive or disruptive.
-	Allow *bool `json:"allow,omitempty"`
+	Allow bool `json:"allow,omitempty"`
 }
 
 // StorageClusterDeleteStrategyType is enum for storage cluster delete strategies

--- a/pkg/controller/storagecluster/update.go
+++ b/pkg/controller/storagecluster/update.go
@@ -129,7 +129,7 @@ func (c *Controller) rollingUpdate(cluster *corev1.StorageCluster, hash string, 
 		}
 	}
 	// Non disruptive upgrade of nodes only if update strategy is rolling and if allow disruption is false
-	if cluster.Spec.UpdateStrategy.RollingUpdate == nil || cluster.Spec.UpdateStrategy.RollingUpdate.Disruption == nil || !*cluster.Spec.UpdateStrategy.RollingUpdate.Disruption.Allow {
+	if cluster.Spec.UpdateStrategy.RollingUpdate == nil || cluster.Spec.UpdateStrategy.RollingUpdate.Disruption == nil || !cluster.Spec.UpdateStrategy.RollingUpdate.Disruption.Allow {
 		oldAvailablePods, err = c.parallelUpgradeNodesList(cluster, oldAvailablePods, unavailableNodes, storageNodeList)
 		if err != nil {
 			return err


### PR DESCRIPTION
**What this PR does / why we need it**: Operator pod crashes with nil pointer dereference error while upgrading PX from 3.1.1 to 3.1.2 
because, cluster.Spec.UpdateStrategy.RollingUpdate.Disruption.Allow, becuase when Allow is *bool and the value was not set, it was nil and trying to dereference a nil pointer resulted in a nil pointer dereference error.

As a fix, changed  Allow  bool instead of *bool, since the value can be either true/false.

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-38583

**Special notes for your reviewer**:
Verified on vanilla k8s 
