### PR TITLE
PWX-38596 : Skip token validation before node is synced during rollin…

### DIFF
--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -815,7 +815,7 @@ func (p *portworx) GetNodesSelectedForUpgrade(cluster *corev1.StorageCluster, no
 		return nil, fmt.Errorf("failed to get Portworx connection: %v", err)
 	}
 	nodeClient := storageapi.NewOpenStorageNodeClient(p.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, false)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup context with token: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
After disabling PX Security STC goes into DEGRADED state due to rolling update failed.
When security was disabled from previously enabled value, the update on storagenodes is still not done at the point when this API call made, so even thought security is disabled from STC, storagenode is still not in sync and expects token to be passed by the operator during GRPC call.

Fix
As a fix, we are bypassing security enabled check in case of this particular GRPC call

- When security is disabled on STC, security check will be disabled for this GRPC call, so dummy secret value will be used to generate token, GRPC call will not require the token so it will not have issue.
- When security is enabled on STC, valid token will be created and used.
- When security is disabled again, for this specific GRPC call, we are skipping the security, so it will still generate valid token using px-system-secrets secret and proceed. Once it proceeds, it will fetch nodes for upgrade and also complete rolling update, and the nodes will be in sync, disabling the security as point 1.

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-38596

**Special notes for your reviewer**:

