### PR TITLE
PWX-38596 : After disabling PX Security STC goes into DEGRADED state due to rolling update failed

### DIFF
--- a/drivers/storage/portworx/component/disruption_budget.go
+++ b/drivers/storage/portworx/component/disruption_budget.go
@@ -90,7 +90,7 @@ func (c *disruptionBudget) Reconcile(cluster *corev1.StorageCluster) error {
 
 	// Get list of portworx storage nodes
 	nodeClient := api.NewOpenStorageNodeClient(c.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, c.k8sClient, false)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, c.k8sClient)
 	if err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/component/security.go
+++ b/drivers/storage/portworx/component/security.go
@@ -534,7 +534,7 @@ func (c *security) updateSystemGuestRole(cluster *corev1.StorageCluster) error {
 	}
 
 	roleClient := api.NewOpenStorageRoleClient(c.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, c.k8sClient, false)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, c.k8sClient)
 	if err != nil {
 		c.closeSdkConn()
 		return err

--- a/drivers/storage/portworx/portworx.go
+++ b/drivers/storage/portworx/portworx.go
@@ -762,7 +762,7 @@ func (p *portworx) GetStorageNodes(
 	}
 
 	nodeClient := storageapi.NewOpenStorageNodeClient(p.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, false)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient)
 	if err != nil {
 		return nil, err
 	}
@@ -787,10 +787,7 @@ func (p *portworx) GetKVDBMembers(cluster *corev1.StorageCluster) (map[string]bo
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()
 
-	// if security was previously enabled and changed to disabled now
-	// the storagenodes might not be in sync since rolling update has not completed
-	// so always pass the token while rolling update
-	ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient, true)
+	ctx, err = pxutil.SetupContextWithToken(ctx, cluster, p.k8sClient)
 	if err != nil {
 		return nil, err
 	}
@@ -815,7 +812,7 @@ func (p *portworx) GetNodesSelectedForUpgrade(cluster *corev1.StorageCluster, no
 		return nil, fmt.Errorf("failed to get Portworx connection: %v", err)
 	}
 	nodeClient := storageapi.NewOpenStorageNodeClient(p.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, false)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup context with token: %v", err)
 	}

--- a/drivers/storage/portworx/status.go
+++ b/drivers/storage/portworx/status.go
@@ -154,7 +154,7 @@ func (p *portworx) updatePortworxRuntimeStatus(
 	}
 
 	clusterClient := api.NewOpenStorageClusterClient(p.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, false)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient)
 	if err != nil {
 		return err
 	}
@@ -419,7 +419,7 @@ func (p *portworx) updateStorageNodes(
 	cluster *corev1.StorageCluster,
 ) error {
 	nodeClient := api.NewOpenStorageNodeClient(p.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, false)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient)
 	if err != nil {
 		return err
 	}

--- a/drivers/storage/portworx/status_test.go
+++ b/drivers/storage/portworx/status_test.go
@@ -62,7 +62,6 @@ func TestSetupContextWithToken(t *testing.T) {
 		initialSecrets    []v1.Secret
 		initialConfigMaps []v1.ConfigMap
 		securityEnabled   bool
-		skipSecurityCheck bool
 
 		expectError      bool
 		expectTokenAdded bool
@@ -73,7 +72,6 @@ func TestSetupContextWithToken(t *testing.T) {
 			pxSecretName:      "",
 			pxSharedSecretKey: "mysecret",
 			securityEnabled:   true,
-			skipSecurityCheck: false,
 
 			expectTokenAdded: true,
 			expectError:      false,
@@ -83,39 +81,17 @@ func TestSetupContextWithToken(t *testing.T) {
 			pxConfigMapName:   defaultConfigMap[0].Name,
 			initialConfigMaps: defaultConfigMap,
 			securityEnabled:   true,
-			skipSecurityCheck: false,
 
 			expectTokenAdded: true,
 			expectError:      false,
 		},
 		{
-			name:              "Default secret should generate and add token to context",
-			pxSecretName:      defaultSecret[0].Name,
-			initialSecrets:    defaultSecret,
-			securityEnabled:   true,
-			skipSecurityCheck: false,
+			name:            "Default secret should generate and add token to context",
+			pxSecretName:    defaultSecret[0].Name,
+			initialSecrets:  defaultSecret,
+			securityEnabled: true,
 
 			expectTokenAdded: true,
-			expectError:      false,
-		},
-		{
-			name:              "Default secret should generate and add token to context when security is disabled but security check is skipped",
-			pxSecretName:      defaultSecret[0].Name,
-			initialSecrets:    defaultSecret,
-			securityEnabled:   false,
-			skipSecurityCheck: true,
-
-			expectTokenAdded: true,
-			expectError:      false,
-		},
-		{
-			name:              "Default secret should not be generated when security is disabled and security check is not skipped",
-			pxSecretName:      defaultSecret[0].Name,
-			initialSecrets:    defaultSecret,
-			securityEnabled:   false,
-			skipSecurityCheck: false,
-
-			expectTokenAdded: false,
 			expectError:      false,
 		},
 	}
@@ -198,7 +174,7 @@ func TestSetupContextWithToken(t *testing.T) {
 			p := portworx{
 				k8sClient: k8sClient,
 			}
-			ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient, tc.skipSecurityCheck)
+			ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, p.k8sClient)
 			if tc.expectError {
 				assert.Error(t, err)
 				assert.EqualError(t, err, tc.expectedError)

--- a/drivers/storage/portworx/util/util.go
+++ b/drivers/storage/portworx/util/util.go
@@ -966,7 +966,7 @@ func SetupContextWithToken(ctx context.Context, cluster *corev1.StorageCluster, 
 	if errors.IsNotFound(err) {
 		if SecurityEnabled(cluster) {
 			// when security is enabled in STC, and secret is not found, return error
-			return nil, fmt.Errorf("failed to get portworx system secret: %v", err.Error())
+			return nil, fmt.Errorf("failed to get portworx apps secret: %v", err.Error())
 		}
 		// if security is not enabled in STC, it is okay to proceed without the secret
 		return ctx, nil

--- a/pkg/controller/storagenode/storagenode.go
+++ b/pkg/controller/storagenode/storagenode.go
@@ -510,7 +510,7 @@ func (c *Controller) isStorageNode(storageNode *corev1.StorageNode, cluster *cor
 	}
 
 	nodeClient := api.NewOpenStorageNodeClient(c.sdkConn)
-	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, c.client, false)
+	ctx, err := pxutil.SetupContextWithToken(context.Background(), cluster, c.client)
 	if err != nil {
 		logrus.Errorf("failed to setup context with token: %v", err)
 		return false, err


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
After disabling PX Security STC goes into DEGRADED state due to rolling update failed: cannot upgrade nodes in parallel: failed to get non overlapping nodes: rpc error: code = PermissionDenied desc = Access denied without authentication token

Reason : When security was disabled from previously enabled value, the update on storagenodes is still not done at the point when API call is made to PX to get storage nodes, so even thought security is disabled from STC, storagenode is still not in sync and expects token to be passed by the operator during GRPC call.

Note that `skipSecurityCheck' variable is removed which was previously added in https://github.com/libopenstorage/operator/pull/1539 for improvement of logic as discussed in PR.

**Fix**
The code change does following to decide if token is required or not to for API calls.
- fetches the secret
- if secret is not found and security is disabled on STC, proceeds without token.
- if secret is not found and security is enabled on STC, returns error because secret is expected in this case


**Which issue(s) this PR fixes** (optional)
Closes # 
https://purestorage.atlassian.net/browse/PWX-38596
https://purestorage.atlassian.net/browse/PWX-37232

**Special notes for your reviewer**:
- verified on vanilla k8s cluster, by updating the operator image with this fix, the STC comes out of Degraded state and all nodes were upgraded
