### PR TITLE
PWX-38098 Implement the entrypoint for collecting pod logs

### DIFF
--- a/deploy/crds/portworx.io_portworxdiags.yaml
+++ b/deploy/crds/portworx.io_portworxdiags.yaml
@@ -89,6 +89,9 @@ spec:
                         description: Labels of the volumes to be selected.
                         type: object
                     type: object
+                  collectPodLogs:
+                    description: Flag indicating whether we want to collect pod logs too or not.
+                    type: boolean  
                 type: object
             type: object
           status:
@@ -120,6 +123,16 @@ spec:
                       type: string
                   type: object
                 type: array
+              collectPodLogs:
+                description: Status of the diags collection from all the pods with label 'portworx'.
+                properties:
+                  message:
+                    description: Optional message used to give the reason for any failure.
+                    type: string
+                  status:
+                    description: One word status of the diags collection on the pod.
+                    type: string
+                type: object  
               phase:
                 description: One word status of the entire diags collection job.
                 type: string

--- a/pkg/apis/portworx/v1/portworxdiag.go
+++ b/pkg/apis/portworx/v1/portworxdiag.go
@@ -11,6 +11,14 @@ const (
 	NodeStatusFailed     = "Failed"
 	NodeStatusCompleted  = "Completed"
 
+	//Pod Logs Statuses
+	PodLogStatusPending        = "Pending"
+	PodLogStatusInProgress     = "InProgress"
+	PodLogStatusFailed         = "Failed"
+	PodLogStatusCompleted      = "Completed"
+	PodLogStatusPartialFailure = "PartiallyFailed"
+	PodLogStatusUnknown        = "Unknown"
+
 	// Diag Statuses
 	DiagStatusPending        = "Pending"
 	DiagStatusInProgress     = "InProgress"
@@ -37,6 +45,9 @@ type PortworxComponent struct {
 	NodeSelector NodeSelector `json:"nodes,omitempty"`
 	// Volumes for which the diags need to be collected.
 	VolumeSelector VolumeSelector `json:"volumes,omitempty"`
+	// Collects all the pod logs. Used to specify whether Pod logs need to be
+	// collected or not.
+	CollectPodLogs bool `json:"collectPodLogs,omitempty"`
 	// Generates the core dump as well when collecting the diags. Could be useful
 	// to analyze the current state of the system.
 	GenerateCore bool `json:"generateCore,omitempty"`
@@ -76,6 +87,8 @@ type PortworxDiagStatus struct {
 	ClusterUUID string `json:"clusterUuid,omitempty"`
 	// Status of the diags collection from all the selected nodes.
 	NodeStatuses []NodeStatus `json:"nodes,omitempty"`
+	// Status of the diags collection from all the pods.
+	PodLogStatus string `json:"podLogsStatus,omitempty"`
 }
 
 // Status of the diags collection from a single node.


### PR DESCRIPTION
This PR has changes in PortworxDiag CRD to collect pod logs.

PWX-38098

Testing Done

<img width="1728" alt="Screenshot 2024-08-19 at 1 51 46 PM" src="https://github.com/user-attachments/assets/5c21993d-229e-4a17-bbf4-f60f4ae03088">
