### PR TITLE
PWX-38589: Fix the CPU spike and excessive logging in telemetry pods

### DIFF
--- a/deploy/ccm/ccm.properties
+++ b/deploy/ccm/ccm.properties
@@ -28,7 +28,7 @@
       "/var/cores/px_info.log",
       "/var/cores/px_patch_fs.log"
     ],
-    "phonehome_hour_range": 8760,
+    "phonehome_hour_range": 744,
     "phonehome_sent": "/var/logs/phonehome.sent",
     "always_scan_range_days": 7,
     "max_retry_per_hour": 5,

--- a/drivers/storage/portworx/component/telemetry.go
+++ b/drivers/storage/portworx/component/telemetry.go
@@ -88,6 +88,7 @@ const (
 	daemonsetFileNameTelemetryPhonehome              = "phonehome-cluster.yaml"
 
 	configParameterApplianceID                           = "APPLIANCE_ID"
+	configParameterApplianceName                         = "APPLIANCE_NAME"
 	configParameterComponentSN                           = "COMPONENT_SN"
 	configParameterProductVersion                        = "PRODUCT_VERSION"
 	configParameterRegisterProxyURL                      = "REGISTER_PROXY_URL"
@@ -588,6 +589,7 @@ func (t *telemetry) createCCMGoConfigMapRegisterProxy(
 	cloudSupportPort, tcpProxyPort, envoyRedirectPort := getCCMCloudSupportPorts(cluster, defaultRegisterPort)
 	replaceMap := map[string]string{
 		configParameterApplianceID:              cluster.Status.ClusterUID,
+		configParameterApplianceName:            cluster.Status.ClusterName,
 		configParameterComponentSN:              cluster.Name,
 		configParameterProductVersion:           pxutil.GetPortworxVersion(cluster).String(),
 		configParameterRegisterProxyURL:         getArcusRegisterProxyURL(cluster),
@@ -644,6 +646,7 @@ func (t *telemetry) createCCMGoConfigMapTelemetryPhonehomeProxy(
 	cloudSupportPort, tcpProxyPort, envoyRedirectPort := getCCMCloudSupportPorts(cluster, defaultPhonehomePort)
 	replaceMap := map[string]string{
 		configParameterApplianceID:          cluster.Status.ClusterUID,
+		configParameterApplianceName:        cluster.Status.ClusterName,
 		configParameterProductVersion:       pxutil.GetPortworxVersion(cluster).String(),
 		configParameterRestProxyURL:         getArcusRestProxyURL(cluster),
 		configParameterRestCloudSupportPort: fmt.Sprint(cloudSupportPort),
@@ -701,6 +704,7 @@ func (t *telemetry) createCCMGoConfigMapCollectorProxyV2(
 	cloudSupportPort, tcpProxyPort, envoyRedirectPort := getCCMCloudSupportPorts(cluster, defaultCollectorPort)
 	replaceMap := map[string]string{
 		configParameterApplianceID:          cluster.Status.ClusterUID,
+		configParameterApplianceName:        cluster.Status.ClusterName,
 		configParameterProductVersion:       pxutil.GetPortworxVersion(cluster).String(),
 		configParameterRestProxyURL:         getArcusRestProxyURL(cluster),
 		configParameterRestCloudSupportPort: fmt.Sprint(cloudSupportPort),
@@ -830,6 +834,10 @@ func (t *telemetry) createDeploymentTelemetryRegistration(
 				Name:  configParameterApplianceID,
 				Value: cluster.Status.ClusterUID,
 			})
+			container.Env = append(container.Env, v1.EnvVar{
+				Name:  configParameterApplianceName,
+				Value: cluster.Status.ClusterName,
+			})
 		} else if container.Name == containerNameTelemetryProxy {
 			container.Image = proxyImage
 		}
@@ -893,6 +901,15 @@ func (t *telemetry) createDaemonSetTelemetryPhonehome(
 		container := &daemonset.Spec.Template.Spec.Containers[i]
 		if container.Name == containerNameLogUploader {
 			container.Image = logUploaderImage
+			// add APPLIANCE_ID env var
+			container.Env = append(container.Env, v1.EnvVar{
+				Name:  configParameterApplianceID,
+				Value: cluster.Status.ClusterUID,
+			})
+			container.Env = append(container.Env, v1.EnvVar{
+				Name:  configParameterApplianceName,
+				Value: cluster.Status.ClusterName,
+			})
 			for j := 0; j < len(container.Ports); j++ {
 				port := &container.Ports[j]
 				if port.Name == portNameLogUploaderContainer {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -15189,7 +15189,8 @@ func TestTelemetryCCMGoEnableAndDisable(t *testing.T) {
 			},
 		},
 		Status: corev1.StorageClusterStatus{
-			ClusterUID: "test-clusteruid",
+			ClusterUID:  "test-clusteruid",
+			ClusterName: "test-clustername",
 		},
 	}
 
@@ -15447,7 +15448,8 @@ func TestTelemetryContainerOrchestratorEnable(t *testing.T) {
 			},
 		},
 		Status: corev1.StorageClusterStatus{
-			ClusterUID: "test-clusteruid",
+			ClusterName: "test-clustername",
+			ClusterUID:  "test-clusteruid",
 		},
 	}
 
@@ -15466,7 +15468,7 @@ func TestTelemetryContainerOrchestratorEnable(t *testing.T) {
 	deployment := &appsv1.Deployment{}
 	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
+	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 3)
 
 	// Compatible PX & Incompatible Telemetry Images
 	cluster.Spec.Image = "portworx/image:3.2.0"
@@ -15483,7 +15485,7 @@ func TestTelemetryContainerOrchestratorEnable(t *testing.T) {
 	// Validate deployments
 	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
+	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 3)
 
 	// Incompatible PX & compatible Telemetry Images
 	cluster.Spec.Image = "portworx/image:3.0.0"
@@ -15500,7 +15502,7 @@ func TestTelemetryContainerOrchestratorEnable(t *testing.T) {
 	// Validate deployments
 	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 2)
+	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 3)
 
 	// Compatible PX & Telemetry Images
 	cluster.Spec.Image = "portworx/image:3.2.0"
@@ -15518,13 +15520,15 @@ func TestTelemetryContainerOrchestratorEnable(t *testing.T) {
 	// Validate deployments
 	err = testutil.Get(k8sClient, deployment, component.DeploymentNameTelemetryRegistration, cluster.Namespace)
 	require.NoError(t, err)
-	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 3)
+	require.Len(t, deployment.Spec.Template.Spec.Containers[0].Env, 4)
 	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[0].Name, "CONFIG")
 	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[0].Value, "config/config_properties_px.yaml")
 	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[1].Name, "APPLIANCE_ID")
 	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[1].Value, "test-clusteruid")
-	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[2].Name, "REFRESH_TOKEN")
-	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[2].Value, "")
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[2].Name, "APPLIANCE_NAME")
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[2].Value, "test-clustername")
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[3].Name, "REFRESH_TOKEN")
+	require.Equal(t, deployment.Spec.Template.Spec.Containers[0].Env[3].Value, "")
 
 	// Port shift on OCP
 	cluster.Annotations[pxutil.AnnotationIsOpenshift] = "true"

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -16640,7 +16640,8 @@ func TestTelemetryCCMGoRestartPhonehome(t *testing.T) {
 			StartPort: &startPort,
 		},
 		Status: corev1.StorageClusterStatus{
-			ClusterUID: "test-clusteruid",
+			ClusterUID:  "test-clusteruid",
+			ClusterName: "test-clustername",
 		},
 	}
 

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeConfigMap.yaml
@@ -40,7 +40,7 @@ data:
           "/var/cores/px_info.log",
           "/var/cores/px_patch_fs.log"
         ],
-        "phonehome_hour_range": 8760,
+        "phonehome_hour_range": 744,
         "phonehome_sent": "/var/logs/phonehome.sent",
         "always_scan_range_days": 7,
         "max_retry_per_hour": 5,

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSet.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSet.yaml
@@ -49,6 +49,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: APPLIANCE_ID
+          value: test-clusteruid
+        - name: APPLIANCE_NAME
+          value: test-clustername
         image: docker.io/purestorage/log-upload:1.2.3
         imagePullPolicy: Always
         name: log-upload-service

--- a/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSetDefaultPort.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoPhonehomeDaemonSetDefaultPort.yaml
@@ -49,6 +49,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: APPLIANCE_ID
+          value: test-clusteruid
+        - name: APPLIANCE_NAME
+          value: test-clustername
         image: docker.io/purestorage/log-upload:1.2.3
         imagePullPolicy: Always
         name: log-upload-service

--- a/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
+++ b/drivers/storage/portworx/testspec/ccmGoRegisterDeployment.yaml
@@ -50,6 +50,8 @@ spec:
           value: config/config_properties_px.yaml
         - name: APPLIANCE_ID
           value: test-clusteruid
+        - name: APPLIANCE_NAME
+          value: test-clustername
         image: docker.io/portworx/px-telemetry:4.3.2
         imagePullPolicy: Always
         name: registration


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR contains 2 changes which combine to greatly reduce the log spam in the `px-telemetry-phonehome` pod and 1 change to slightly reduce the `px-telemetry-registration` pod's log spam:

1. In `createDaemonSetTelemetryPhonehome`, we are now seeding `APPLIANCE_ID` and `APPLIANCE_NAME`.
2. In the various `reconcile` functions, we now seed `APPLIANCE_NAME`
3. We reduce the `uploadAll` timerange from the last 8760 hours (1 year of hours) to 744 (31 days).

With the old config, we were logging 8760 hours * 11 logs-per-run = ~96k log lines

With the new config, we log 744 * 6 = ~3.8k log lines.

**Which issue(s) this PR fixes** (optional)
Closes PWX-38589

**Special notes for your reviewer**:

I ran this changeset on my local cluster, the (truncated) output for the log now looks like:
```
{"level":"info","ts":1724096621.8442233,"caller":"components/log_processor.go:129","msg":" >>>>> Starting Hour 2024071922"}
{"level":"info","ts":1724096621.845684,"caller":"components/log_scanner.go:49","msg":"Starting scan time extension 2024071922"}
{"level":"info","ts":1724096621.8470185,"caller":"components/log_scanner.go:65","msg":"Finished scan time extension 2024071922"}
{"level":"info","ts":1724096621.8470461,"caller":"components/log_scanner.go:44","msg":"Scanned 0 logs with timeExtension 2024071922"}
{"level":"info","ts":1724096621.8523428,"caller":"components/log_processor.go:187","msg":"Hour 2024071922 completed. 0 records deleted from table."}
{"level":"info","ts":1724096621.8523734,"caller":"components/log_processor.go:129","msg":" >>>>> Starting Hour 2024071921"}
{"level":"info","ts":1724096621.8533957,"caller":"components/log_scanner.go:49","msg":"Starting scan time extension 2024071921"}
{"level":"info","ts":1724096621.8543782,"caller":"components/log_scanner.go:65","msg":"Finished scan time extension 2024071921"}
{"level":"info","ts":1724096621.854402,"caller":"components/log_scanner.go:44","msg":"Scanned 0 logs with timeExtension 2024071921"}
{"level":"info","ts":1724096621.8610723,"caller":"components/log_processor.go:187","msg":"Hour 2024071921 completed. 0 records deleted from table."}
{"level":"info","ts":1724096621.861129,"caller":"components/log_processor.go:129","msg":" >>>>> Starting Hour 2024071920"}
{"level":"info","ts":1724096621.8622558,"caller":"components/log_scanner.go:49","msg":"Starting scan time extension 2024071920"}
{"level":"info","ts":1724096621.8632746,"caller":"components/log_scanner.go:65","msg":"Finished scan time extension 2024071920"}
{"level":"info","ts":1724096621.8633,"caller":"components/log_scanner.go:44","msg":"Scanned 0 logs with timeExtension 2024071920"}
{"level":"info","ts":1724096621.8681047,"caller":"components/log_processor.go:187","msg":"Hour 2024071920 completed. 0 records deleted from table."}
root@ip-10-13-161-24:~/go/pkg/mod/github.com/fullstorydev/grpcurl@v1.9.1# kubectl logs -n $NS px-telemetry-phonehome-8mvsr | wc -l
Defaulted container "log-upload-service" out of: log-upload-service, envoy, init-cont (init)
3806

```