### PR TITLE
[PWX-38584][PWX-38575] Updated Autopilot deployment to include readiness probes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ operator:
 
 container:
 	@echo "Building operator image $(OPERATOR_IMG)"
-	docker build --pull --tag $(OPERATOR_IMG) -f build/Dockerfile .
+	docker build --no-cache --pull --tag $(OPERATOR_IMG) -f build/Dockerfile .
 
 DOCK_BUILD_CNT	:= golang:1.21
 

--- a/drivers/storage/portworx/component/autopilot.go
+++ b/drivers/storage/portworx/component/autopilot.go
@@ -3,13 +3,14 @@ package component
 import (
 	"context"
 	"fmt"
-	coreops "github.com/portworx/sched-ops/k8s/core"
-	authv1 "k8s.io/api/authentication/v1"
-	"k8s.io/kubernetes/pkg/apis/core"
 	"reflect"
 	"sort"
 	"strings"
 	"time"
+
+	coreops "github.com/portworx/sched-ops/k8s/core"
+	authv1 "k8s.io/api/authentication/v1"
+	"k8s.io/kubernetes/pkg/apis/core"
 
 	"github.com/sirupsen/logrus"
 
@@ -650,6 +651,26 @@ func (c *autopilot) createDeployment(
 	return nil
 }
 
+// Function to check if ReadinessProbe should be added to the autopilot container
+// Readiness probe is added to the autopilot container if the image version is greater than 1.3.15
+// as autopilot container has a /ready endpoint from 1.3.15 onwards
+func shouldAddReadinessProbe(image string) bool {
+	// Get the image tag using the existing function
+	imageVersion := pxutil.GetImageTag(image)
+
+	// Parse the image version and the threshold version using go-version
+	currentVersion, err := version.NewSemver(imageVersion)
+	if err != nil {
+		logrus.Errorf("Invalid version format: %s", imageVersion)
+		return false
+	}
+
+	thresholdVersion, _ := version.NewSemver("1.3.15")
+
+	// Compare the current version with the threshold version
+	return currentVersion.GreaterThan(thresholdVersion)
+}
+
 func (c *autopilot) getAutopilotDeploymentSpec(
 	cluster *corev1.StorageCluster,
 	ownerRef *metav1.OwnerReference,
@@ -677,6 +698,23 @@ func (c *autopilot) getAutopilotDeploymentSpec(
 	maxUnavailable := intstr.FromInt(1)
 	maxSurge := intstr.FromInt(1)
 	imagePullPolicy := pxutil.ImagePullPolicy(cluster)
+
+	var readinessProbe *v1.Probe
+	if shouldAddReadinessProbe(imageName) {
+		readinessProbe = &v1.Probe{
+			ProbeHandler: v1.ProbeHandler{
+				HTTPGet: &v1.HTTPGetAction{
+					Path: "/ready",
+					Port: intstr.FromInt(9628),
+				},
+			},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+			TimeoutSeconds:      5,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+		}
+	}
 
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -754,6 +792,12 @@ func (c *autopilot) getAutopilotDeploymentSpec(
 				},
 			},
 		},
+	}
+
+	// Only assign the readiness probe if it's not nil
+	// and the container is the autopilot container
+	if readinessProbe != nil && deployment.Spec.Template.Spec.Containers[0].Name == AutopilotContainerName {
+		deployment.Spec.Template.Spec.Containers[0].ReadinessProbe = readinessProbe
 	}
 
 	if cluster.Spec.ImagePullSecret != nil && *cluster.Spec.ImagePullSecret != "" {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -3498,6 +3498,166 @@ func TestAutopilotInstall(t *testing.T) {
 
 }
 
+func TestPresenceOfReadinessProbeForAutopilotValidImageTagGreaterThan1_3_15(t *testing.T) {
+	// Arrange
+	mockCtrl := gomock.NewController(t)
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.25.0",
+	}
+	setUpMockCoreOps(mockCtrl, versionClient)
+	fakeExtClient := fakeextclient.NewSimpleClientset()
+	apiextensionsops.SetInstance(apiextensionsops.New(fakeExtClient))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+
+	stcSpec := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Monitoring: &corev1.MonitoringSpec{Telemetry: &corev1.TelemetrySpec{}},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: true,
+				Image:   "portworx/autopilot:1.3.16",
+			},
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					SelfSigned: &corev1.SelfSignedSpec{
+						Issuer:        stringPtr(defaultSelfSignedIssuer),
+						TokenLifetime: stringPtr(defaultTokenLifetime),
+						SharedSecret:  stringPtr(pxutil.SecurityPXSharedSecretSecretName),
+					},
+				},
+			},
+		},
+	}
+	cluster := stcSpec.DeepCopy()
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	// Act
+	err = driver.PreInstall(cluster)
+
+	// Assert
+	require.NoError(t, err)
+	autopilotDeployment := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Equal(t, autopilotDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe.HTTPGet.Path, "/ready")
+}
+
+func TestAbsenceOfReadinessProbeForAutopilotValidImageTagLesserThanOrEqual1_3_15(t *testing.T) {
+	// Arrange
+	mockCtrl := gomock.NewController(t)
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.25.0",
+	}
+	setUpMockCoreOps(mockCtrl, versionClient)
+	fakeExtClient := fakeextclient.NewSimpleClientset()
+	apiextensionsops.SetInstance(apiextensionsops.New(fakeExtClient))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	stcSpec := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Monitoring: &corev1.MonitoringSpec{Telemetry: &corev1.TelemetrySpec{}},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: true,
+				Image:   "portworx/autopilot:1.3.15",
+			},
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					SelfSigned: &corev1.SelfSignedSpec{
+						Issuer:        stringPtr(defaultSelfSignedIssuer),
+						TokenLifetime: stringPtr(defaultTokenLifetime),
+						SharedSecret:  stringPtr(pxutil.SecurityPXSharedSecretSecretName),
+					},
+				},
+			},
+		},
+	}
+	cluster := stcSpec.DeepCopy()
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	// Act
+	err = driver.PreInstall(cluster)
+
+	// Assert
+	require.NoError(t, err)
+	autopilotDeployment := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Nil(t, autopilotDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+}
+
+func TestAbsenceOfReadinessProbeForAutopilotInValidImageTag(t *testing.T) {
+	// Arrange
+	mockCtrl := gomock.NewController(t)
+	versionClient := fakek8sclient.NewSimpleClientset()
+	versionClient.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{
+		GitVersion: "v1.25.0",
+	}
+	setUpMockCoreOps(mockCtrl, versionClient)
+	fakeExtClient := fakeextclient.NewSimpleClientset()
+	apiextensionsops.SetInstance(apiextensionsops.New(fakeExtClient))
+	reregisterComponents()
+	k8sClient := testutil.FakeK8sClient()
+	driver := portworx{}
+	err := driver.Init(k8sClient, runtime.NewScheme(), record.NewFakeRecorder(0))
+	require.NoError(t, err)
+	stcSpec := &corev1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "px-cluster",
+			Namespace: "kube-test",
+		},
+		Spec: corev1.StorageClusterSpec{
+			Monitoring: &corev1.MonitoringSpec{Telemetry: &corev1.TelemetrySpec{}},
+			Autopilot: &corev1.AutopilotSpec{
+				Enabled: true,
+				Image:   "portworx/autopilot:77u",
+			},
+			Security: &corev1.SecuritySpec{
+				Enabled: true,
+				Auth: &corev1.AuthSpec{
+					SelfSigned: &corev1.SelfSignedSpec{
+						Issuer:        stringPtr(defaultSelfSignedIssuer),
+						TokenLifetime: stringPtr(defaultTokenLifetime),
+						SharedSecret:  stringPtr(pxutil.SecurityPXSharedSecretSecretName),
+					},
+				},
+			},
+		},
+	}
+	cluster := stcSpec.DeepCopy()
+	err = driver.SetDefaultsOnStorageCluster(cluster)
+	require.NoError(t, err)
+
+	// Act
+	err = driver.PreInstall(cluster)
+
+	// Assert
+	require.NoError(t, err)
+	autopilotDeployment := &appsv1.Deployment{}
+	err = testutil.Get(k8sClient, autopilotDeployment, component.AutopilotDeploymentName, cluster.Namespace)
+	require.NoError(t, err)
+	require.Nil(t, autopilotDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe)
+}
+
 func TestAutopilotWithoutImage(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	setUpMockCoreOps(mockCtrl, fakek8sclient.NewSimpleClientset())


### PR DESCRIPTION
### What this PR does :

This PR adds Readiness Probes to Autopilot deployments from autopilot versions greater than 1.3.15.

### Why we need it

Autopilot relies heavily on Prometheus signals to execute its operations. If Prometheus becomes unreachable, Autopilot's expansion operations will fail.

Users typically become aware of this issue only after an expansion operation fails, which is too late.

To address this, we will add readiness probes to continuously monitor the connectivity between Autopilot and Prometheus. This will allow us to update the pod's readiness status (0/1) in real time, providing better visibility into potential issues and enabling proactive responses rather than waiting for an expansion failure

To address this, we are adding Readiness Probes instead of Liveness Probes. Liveness Probes would restart the pod if they fail, but in this case, a restart won't resolve the issue. Readiness Probes, on the other hand, will update the pod's readiness status (0/1) without triggering unnecessary restarts. This ensures continuous monitoring of the Autopilot-Prometheus connectivity and provides better visibility into potential issues, allowing for proactive responses.

A separate PR will be raised for Autopilot where  /ready endpoint would serve the readiness prone hits made by k8s.

### Which issue(s) this PR fixes (optional)

https://purestorage.atlassian.net/browse/PWX-38584 

https://purestorage.atlassian.net/browse/PWX-38575 

### Testing

- Executed existing unit tests. No failures observed.

- Added unit tests for the code added.

- Deployed operator image with above change and autopilot:1.3.15. Verified that autopilot deployment does not has Readiness Probe.

```
## Autopilot container

Containers:
  autopilot:
    Container ID:  cri-o://218c6b7e430eeccff2337f7643b811de1b552f430cb08c9f4928a2deab5a23c3
    Image:         docker.io/portworx/autopilot:1.3.15
    Image ID:      docker.io/portworx/autopilot@sha256:50581ec6c42e30a5cfed7099bac05242bf943f044ee45e000d1b56333f570fb3
    Port:          <none>
    Host Port:     <none>
    Command:
      /autopilot
      --config=/etc/config/config.yaml
      --log-level=debug
    State:          Running
      Started:      Tue, 20 Aug 2024 16:30:55 +0000
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:  250m
    Requests:
      cpu:  100m
    Environment:
      PX_NAMESPACE:  kube-system
    Mounts:
      /etc/config from config-volume (rw)
      /etc/ssl/px-custom/1 from ca-cert-volume (ro)
      /var/cores from varcores (rw)
      /var/local/secrets from token-volume (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-25m2k (ro)
```

 - Deployed operator image with above change and autopilot:1.3.16. Verified that autopilot deployment  has Readiness Probe.

```
## Autopilot container

Containers:
  autopilot:
    Container ID:  cri-o://69122b8854be06976d094509c16e2f53bb798ffc86ab70c065f2bee66ab045db
    Image:         pure-artifactory.dev.purestorage.com/px-docker-dev-local/autopilot:1.3.16
    Image ID:      pure-artifactory.dev.purestorage.com/px-docker-dev-local/autopilot@sha256:eb312be27f80771abc3468bdafbadd00afc072860c5e01445dc7f208ce9d34c5
    Port:          <none>
    Host Port:     <none>
    Command:
      /autopilot
      --config=/etc/config/config.yaml
      --log-level=debug
    State:          Running
      Started:      Tue, 20 Aug 2024 16:53:21 +0000
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:  250m
    Requests:
      cpu:      100m
    Readiness:  http-get http://:9628/ready delay=10s timeout=5s period=10s #success=1 #failure=3
    Environment:
      PX_NAMESPACE:  kube-system
    Mounts:
      /etc/config from config-volume (rw)
      /etc/ssl/px-custom/1 from ca-cert-volume (ro)
      /var/cores from varcores (rw)
      /var/local/secrets from token-volume (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-4cxd9 (ro)
```
