### PR TITLE
PWX-38400 : Do not attempt to delete plugin on non-openshift clusters

### DIFF
--- a/drivers/storage/portworx/component/plugin.go
+++ b/drivers/storage/portworx/component/plugin.go
@@ -171,37 +171,41 @@ func (p *plugin) Reconcile(cluster *corev1.StorageCluster) error {
 }
 
 func (p *plugin) Delete(cluster *corev1.StorageCluster) error {
-	var errList []string
-	ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
 
-	// delete plugin configs
-	if err := k8s.DeleteDeployment(p.client, PluginDeploymentName, cluster.Namespace, *ownerRef); err != nil {
-		errList = append(errList, err.Error())
-	}
-	if err := k8s.DeleteConfigMap(p.client, PluginConfigMapName, cluster.Namespace, *ownerRef); err != nil {
-		errList = append(errList, err.Error())
-	}
-	if err := k8s.DeleteService(p.client, PluginServiceName, cluster.Namespace, *ownerRef); err != nil {
-		errList = append(errList, err.Error())
-	}
+	if p.isPluginSupported != nil && *p.isPluginSupported {
+		var errList []string
+		ownerRef := metav1.NewControllerRef(cluster, pxutil.StorageClusterKind())
 
-	// delete nginx configs
-	if err := k8s.DeleteDeployment(p.client, NginxDeploymentName, cluster.Namespace, *ownerRef); err != nil {
-		errList = append(errList, err.Error())
-	}
-	if err := k8s.DeleteConfigMap(p.client, NginxConfigMapName, cluster.Namespace, *ownerRef); err != nil {
-		errList = append(errList, err.Error())
-	}
-	if err := k8s.DeleteService(p.client, NginxServiceName, cluster.Namespace, *ownerRef); err != nil {
-		errList = append(errList, err.Error())
-	}
+		// delete plugin configs
+		if err := k8s.DeleteDeployment(p.client, PluginDeploymentName, cluster.Namespace, *ownerRef); err != nil {
+			errList = append(errList, err.Error())
+		}
+		if err := k8s.DeleteConfigMap(p.client, PluginConfigMapName, cluster.Namespace, *ownerRef); err != nil {
+			errList = append(errList, err.Error())
+		}
+		if err := k8s.DeleteService(p.client, PluginServiceName, cluster.Namespace, *ownerRef); err != nil {
+			errList = append(errList, err.Error())
+		}
 
-	// delete console plugin
-	if err := k8s.DeleteConsolePlugin(p.client, PluginName, cluster.Namespace, *ownerRef); err != nil {
-		errList = append(errList, err.Error())
-	}
-	if len(errList) > 0 {
-		return commonerrors.New(strings.Join(errList, " , "))
+		// delete nginx configs
+		if err := k8s.DeleteDeployment(p.client, NginxDeploymentName, cluster.Namespace, *ownerRef); err != nil {
+			errList = append(errList, err.Error())
+		}
+		if err := k8s.DeleteConfigMap(p.client, NginxConfigMapName, cluster.Namespace, *ownerRef); err != nil {
+			errList = append(errList, err.Error())
+		}
+		if err := k8s.DeleteService(p.client, NginxServiceName, cluster.Namespace, *ownerRef); err != nil {
+			errList = append(errList, err.Error())
+		}
+
+		// delete console plugin
+		if err := k8s.DeleteConsolePlugin(p.client, PluginName, cluster.Namespace, *ownerRef); err != nil {
+			errList = append(errList, err.Error())
+		}
+		if len(errList) > 0 {
+			return commonerrors.New(strings.Join(errList, " , "))
+		}
+		p.MarkDeleted()
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
While doing Portworx uninstall, all the components are deleted and for Plugin, even though plugin is not created on non-openshift clusters, operator tries to delete it. 
- As a fix, added additional check to check if plugin is supported on the platform or not.

**Which issue(s) this PR fixes** (optional)
Closes # https://purestorage.atlassian.net/browse/PWX-38400

**Special notes for your reviewer**:
- Existing UT TestPluginInstallAndUninstall verifies the test of uninstall on OCP platform
- Manually verified on vanilla k8s and OCP platform install and uninstall of PX. 
