### PR TITLE
PWX-38082 (op24.2.0): Fixing CSI on SELinux=enabled systems

### DIFF
--- a/drivers/storage/portworx/cloud_storage_test.go
+++ b/drivers/storage/portworx/cloud_storage_test.go
@@ -582,9 +582,15 @@ func TestCreateStorageDistributionMatrixAlreadyExists(t *testing.T) {
 
 func matrixSetup(t *testing.T) {
 	linkPath := path.Join(os.Getenv("GOPATH"), "src/github.com/libopenstorage/operator/vendor/github.com/libopenstorage/cloudops/specs")
-	matrixCleanup(t)
-	err := os.Symlink(linkPath, "specs")
-	require.NoError(t, err, "failed to create symlink")
+	cwd, err := os.Getwd()
+	require.NoError(t, err, "failed to get current working directory")
+
+	specsPath := path.Join(cwd, "specs")
+	os.Remove(specsPath) // don't care about the error
+	err = os.Symlink(linkPath, specsPath)
+	require.NoError(t, err, "failed to create symlink at %s", specsPath)
+	_, err = os.ReadFile(path.Join(specsPath, "decisionmatrix/azure.yaml"))
+	require.NoError(t, err, "failed to read azure.yaml")
 }
 
 func matrixCleanup(t *testing.T) {

--- a/drivers/storage/portworx/cloud_storage_test.go
+++ b/drivers/storage/portworx/cloud_storage_test.go
@@ -582,6 +582,7 @@ func TestCreateStorageDistributionMatrixAlreadyExists(t *testing.T) {
 
 func matrixSetup(t *testing.T) {
 	linkPath := path.Join(os.Getenv("GOPATH"), "src/github.com/libopenstorage/operator/vendor/github.com/libopenstorage/cloudops/specs")
+	matrixCleanup(t)
 	err := os.Symlink(linkPath, "specs")
 	require.NoError(t, err, "failed to create symlink")
 }

--- a/drivers/storage/portworx/component/portworx_api.go
+++ b/drivers/storage/portworx/component/portworx_api.go
@@ -396,6 +396,9 @@ func csiRegistrarContainer(cluster *corev1.StorageCluster) *v1.Container {
 				MountPath: "/registration",
 			},
 		},
+		SecurityContext: &v1.SecurityContext{
+			Privileged: boolPtr(true),
+		},
 	}
 
 	if cluster.Status.DesiredImages.CSINodeDriverRegistrar != "" {

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -168,6 +168,7 @@ func TestBasicComponentsInstall(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	setUpMockCoreOps(mockCtrl, fakek8sclient.NewSimpleClientset())
 	setUpFakeRootCert(t)
+	defer os.Remove(fakeRootCertPath)
 	logrus.SetLevel(logrus.TraceLevel)
 	reregisterComponents()
 	k8sClient := testutil.FakeK8sClient()
@@ -1118,6 +1119,7 @@ func TestUpdateServiceAccountTokenSecretCaCrt(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	setUpMockCoreOps(mockCtrl, fakek8sclient.NewSimpleClientset())
 	setUpFakeRootCert(t)
+	defer os.Remove(fakeRootCertPath)
 	reregisterComponents()
 	k8sClient := testutil.FakeK8sClient()
 	driver := portworx{}

--- a/drivers/storage/portworx/components_test.go
+++ b/drivers/storage/portworx/components_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/libopenstorage/operator/pkg/mock/mockcore"
 	"github.com/libopenstorage/operator/pkg/util"
 	k8sutil "github.com/libopenstorage/operator/pkg/util/k8s"
+	"github.com/libopenstorage/operator/pkg/util/maps"
 	testutil "github.com/libopenstorage/operator/pkg/util/test"
 )
 
@@ -287,7 +288,7 @@ func TestBasicComponentsInstall(t *testing.T) {
 	require.Equal(t, expectedPXSaTokenSecret.Namespace, saTokenSecret.Namespace)
 	require.Len(t, saTokenSecret.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, saTokenSecret.OwnerReferences[0].Name)
-	require.Equal(t, len(expectedPXSaTokenSecret.Data), len(saTokenSecret.Data))
+	require.Equal(t, maps.KeysSorted(expectedPXSaTokenSecret.Data), maps.KeysSorted(saTokenSecret.Data))
 	require.Equal(t, []byte(cluster.Namespace), saTokenSecret.Data["namespace"])
 	require.Equal(t, []byte("dG9rZW4tdmFsdWU="), saTokenSecret.Data["token"])
 
@@ -556,7 +557,7 @@ func TestPortworxWithCustomSecretsNamespace(t *testing.T) {
 	require.Equal(t, expectedSecret.Namespace, actualSecret.Namespace)
 	require.Len(t, actualSecret.OwnerReferences, 1)
 	require.Equal(t, cluster.Name, actualSecret.OwnerReferences[0].Name)
-	require.Equal(t, len(expectedSecret.Data), len(actualSecret.Data))
+	require.Equal(t, maps.KeysSorted(expectedSecret.Data), maps.KeysSorted(actualSecret.Data))
 	require.Equal(t, []byte(cluster.Namespace), actualSecret.Data["namespace"])
 
 	// Disable storage should result in deleting objects even from secrets namespace

--- a/drivers/storage/portworx/deployment.go
+++ b/drivers/storage/portworx/deployment.go
@@ -597,6 +597,9 @@ func (t *template) csiRegistrarContainer() *v1.Container {
 				MountPath: "/registration",
 			},
 		},
+		SecurityContext: &v1.SecurityContext{
+			Privileged: boolPtr(true),
+		},
 	}
 
 	if t.cluster.Status.DesiredImages.CSINodeDriverRegistrar != "" {

--- a/drivers/storage/portworx/testspec/portworxAPIDaemonset_2_13.yaml
+++ b/drivers/storage/portworx/testspec/portworxAPIDaemonset_2_13.yaml
@@ -56,6 +56,8 @@ spec:
           imagePullPolicy: Always
           name: csi-node-driver-registrar
           resources: {}
+          securityContext:
+            privileged: true
           terminationMessagePath: ""
           terminationMessagePolicy: ""
           volumeMounts:

--- a/drivers/storage/portworx/testspec/portworxServiceAccountTokenSecret.yaml
+++ b/drivers/storage/portworx/testspec/portworxServiceAccountTokenSecret.yaml
@@ -7,5 +7,5 @@ data:
   ca.crt: eHh4eA==
   namespace: eHh4eA==
   token: eHh4eA==
-  tokenRefreshTime: eHh4eA==
+  pxSaTokenRefreshTime: eHh4eA==
 type: Opaque

--- a/drivers/storage/portworx/testspec/px_csi_0.3.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_0.3.yaml
@@ -104,6 +104,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
           volumeMounts:
             - name: csi-driver-path
               mountPath: /csi

--- a/drivers/storage/portworx/testspec/px_csi_1.0.yaml
+++ b/drivers/storage/portworx/testspec/px_csi_1.0.yaml
@@ -101,6 +101,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
           volumeMounts:
             - name: csi-driver-path
               mountPath: /csi

--- a/drivers/storage/portworx/testspec/px_k3s.yaml
+++ b/drivers/storage/portworx/testspec/px_k3s.yaml
@@ -117,6 +117,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
           volumeMounts:
             - name: csi-driver-path
               mountPath: /csi

--- a/drivers/storage/portworx/testspec/px_master.yaml
+++ b/drivers/storage/portworx/testspec/px_master.yaml
@@ -115,6 +115,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
           volumeMounts:
             - name: csi-driver-path
               mountPath: /csi

--- a/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
+++ b/drivers/storage/portworx/testspec/px_pks_with_csi.yaml
@@ -105,6 +105,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+          securityContext:
+            privileged: true
           volumeMounts:
             - name: csi-driver-path
               mountPath: /csi

--- a/pkg/util/maps/general.go
+++ b/pkg/util/maps/general.go
@@ -1,0 +1,26 @@
+package maps
+
+import (
+	"cmp"
+	"sort"
+)
+
+// Keys returns all keys in the map, in unsorted order.
+func Keys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// KeysSorted returns all keys in the map, in sorted order.
+// - note, may not work on all types of maps/keys
+// - note2, needs Golang 1.21 to compile due to cmp.Ordered
+func KeysSorted[K cmp.Ordered, V any](m map[K]V) []K {
+	keys := Keys(m)
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+	return keys
+}

--- a/pkg/util/maps/general_test.go
+++ b/pkg/util/maps/general_test.go
@@ -1,0 +1,19 @@
+package maps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeys(t *testing.T) {
+	m := map[int]string{1: "one", 2: "two", 3: "three", 0: "zero"}
+	expectedKeys := []int{0, 1, 2, 3}
+	assert.Equal(t, expectedKeys, KeysSorted(m))
+
+	// regular Keys() will return _unsorted_ keys
+	keys := Keys(m)
+	for _, expkey := range expectedKeys {
+		assert.Contains(t, keys, expkey)
+	}
+}


### PR DESCRIPTION
* adding `privileged=true` for csi-node-driver-registrar container

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

The old `PWX-31551: CSI privileged fix (#1062)`  (https://github.com/libopenstorage/operator/pull/1062) has reconfigured the CSI PODs to `securityContext.privileged: true`
* this was done so that the `SELinux` would not block the access to the `csi.sock` file

ISSUE:
* however, looks like the `csi-node-driver-registrar` container got moved to the `portworx-api` POD, but they did not update the `securityContext.privileged: true`
* as a consequence, the CSI no longer works on the `SELinux: enforcing` platforms  (see PWX-38082)

FIX:
* the fix is similar to the old (https://github.com/libopenstorage/operator/pull/1062) -- which was unconditionally adding the `privileged: true` to the CSI containers

**Which issue(s) this PR fixes** (optional)
PWX-38082 (op24.2.0)

**Special notes for your reviewer**:

Manual testing:

* environment:
  - the RKE2 cluster installed on top of RHEL 9.x with `SELinux: enforcing` fails with the following error on the application (PVC-consumer) POD:

Expectations:

* BEFORE the fix:
```
# kubectl describe pod demo-pvc-comsumer-55dcd76c7d-l87x8
...
Events:
  Type     Reason            Age                From               Message
  ----     ------            ----               ----               -------
  Warning  FailedScheduling  51s                default-scheduler  0/4 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/4 nodes are available: 4 Preemption is not helpful for scheduling.
  Normal   Scheduled         49s                default-scheduler  Successfully assigned portworx/demo-pvc-comsumer-55dcd76c7d-l87x8 to foo2
  Warning  FailedMount       17s (x7 over 49s)  kubelet            MountVolume.MountDevice failed for volume "pvc-7ee79280-537d-4f1a-a82c-e3f46c14d63b" : kubernetes.io/csi: attacher.MountDevice failed to create newCsiDriverClient: driver name pxd.portworx.com not found in the list of registered CSI drivers

# kubectl get csidriver
NAME               ATTACHREQUIRED   PODINFOONMOUNT   STORAGECAPACITY   TOKENREQUESTS   REQUIRESREPUBLISH   MODES                  AGE
pxd.portworx.com   false            true             false             <unset>         false               Persistent,Ephemeral   4h9m
```
  - note, the `kubectl get csidriver` reports `pxd.portworx.com` -driver is installed and available, and yet the application PODs cannot use the PVCs

* AFTER the fix, the application PODs can start normally  (i.e. can use CSI-volumes without issues)